### PR TITLE
fix: Ensure a minimal code base is delivered via pypi

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ long_description_content_type = text/markdown
 long_description = file: README.md
 
 [options]
-packages = find:
+packages = trestle
 install_requires =
     attrs~=19.3
     ilcli


### PR DESCRIPTION
Signed-off-by: Chris Butler <chris@thebutlers.me>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

I noticed when running an install of trestle that the tests were getting packaged up with trestle in the wheel distribution.

This should remove the (bulky) tests folder from the wheel distribution downloaded by default when using pip.

## Testing (manual validation).
- Clone and run: `python setup.py bdist_wheel`
- Within ./dist/ a compliance-trestle-0.24.0*.whl file will be created
- Unzip the file 
- Within the unzipped folder only two entries should exist: `trestle` and `compliance_trestle-0.24.0.dist-info`


