### PR TITLE
fix: Handle hard line breaks

### DIFF
--- a/tests/data/markdown/valid_complex_md.md
+++ b/tests/data/markdown/valid_complex_md.md
@@ -11,6 +11,10 @@ header4: header content 4
 
 <!-- sample link (https://www.somelink.com) -->
 
+new line <br/>
+new line <br />
+<br>
+
 | Col1        | Col2        | Col3        | Col4 | Col5 |
 | ----------- | ----------- | ----------- | ---- | ---- |
 | content 2.1 | content 2.2 | content 2.3 |      |      |
@@ -194,3 +198,7 @@ some text here
 ## 5.3 A section 3
 
 # 6. Next section empty
+
+| Col1        | Col2        | Col3        |
+| ----------- | ----------- | ----------- |
+| content 6.1 | content 6.2 | content 6.3 |

--- a/tests/trestle/core/markdown/markdown_node_test.py
+++ b/tests/trestle/core/markdown/markdown_node_test.py
@@ -76,7 +76,7 @@ def test_md_content_is_correct(md_path: pathlib.Path) -> None:
     assert tree.content.raw_text == markdown_wo_header
     assert tree.key == 'root'
     assert len(tree.content.blockquotes) == 5
-    assert len(tree.content.tables) == 4
+    assert len(tree.content.tables) == 7
     assert len(tree.content.code_lines) == 12
     deep_node = tree.get_node_for_key('5.1.1.1.1', strict_matching=False)
     assert deep_node.content.text[1] == 'some very deep text'

--- a/trestle/core/markdown/markdown_node.py
+++ b/trestle/core/markdown/markdown_node.py
@@ -127,7 +127,7 @@ class MarkdownNode:
         while True:
             if i >= len(lines):
                 break
-            line = lines[i]
+            line = lines[i].strip(' ')
             header_lvl = self._get_header_level_if_valid(line)
 
             if header_lvl is not None:
@@ -150,7 +150,7 @@ class MarkdownNode:
             elif self._does_start_with(line, TABLE_SYMBOL):
                 table_block, i = self._read_table_block(lines, line, i + 1)
                 content.tables.extend(table_block)
-            elif self._does_start_with(line.strip(' '), BLOCKQUOTE_CHAR):
+            elif self._does_start_with(line, BLOCKQUOTE_CHAR):
                 content.blockquotes.append(line)
                 i += 1
             elif governed_header is not None and self._does_contain(
@@ -211,6 +211,8 @@ class MarkdownNode:
     def _read_html_block(self, lines: List[str], line: str, i: int, ending_regex: str) -> Tuple[str, int]:
         """Read html block."""
         html_block = [line]
+        if self._does_contain(line, r'<br[ /]*>'):
+            return html_block, i
         if self._does_contain(line, ending_regex):
             return html_block, i
         while True:
@@ -229,7 +231,7 @@ class MarkdownNode:
         table_block = [line]
         while True:
             if i >= len(lines):
-                raise TrestleError(f'Table block is not closed: {table_block}.')
+                return table_block, i
 
             line = lines[i]
             if not self._does_contain(line, TABLE_REGEX):


### PR DESCRIPTION
Signed-off-by: Ekaterina Nikonova <enikonovad@gmail.com>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary

A markdown [hard line break](https://github.github.com/gfm/#hard-line-break) tag `<br />` was not handled properly as opening tag was expected. This small change fixes the issue.

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

Closes #803 
