### PR TITLE
fix: Fix trestle version in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Trestle provides tooling to help orchestrate the compliance process across a num
 ## Important Note:
 
 The current version of trestle supports NIST OSCAL 1.0.2.  There was a breaking change in OSCAL moving from
-version 1.0.0 to 1.0.2 mainly due to `prop` becoming `props` in AssessmentResults.  As a result, the current development path of trestle requires OSCAL 1.0.2, but for those who require OSCAL 1.0.0 please use trestle version 0.37.x.  That version is stable but will not have any features added, and we encourage users to move to OSCAL 1.0.2 and trestle ≥ 1.0.1.
+version 1.0.0 to 1.0.2 mainly due to `prop` becoming `props` in AssessmentResults.  As a result, the current development path of trestle requires OSCAL 1.0.2, but for those who require OSCAL 1.0.0 please use trestle version 0.37.x.  That version is stable but will not have any features added, and we encourage users to move to OSCAL 1.0.2 and Trestle ≥ 1.0.1.
 
 OSCAL version 1.0.0 files are still handled on import but any AssessmentResults must conform to the OSCAL 1.0.2 schema, with
 props instead of prop.  And all files created by trestle will be output as OSCAL version 1.0.2.

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ Trestle provides tooling to help orchestrate the compliance process across a num
 ## Important Note:
 
 The current version of trestle supports NIST OSCAL 1.0.2.  There was a breaking change in OSCAL moving from
-version 1.0.0 to 1.0.2 mainly due to `prop` becoming `props` in AssessmentResults.  As a result, the current development path of trestle requires OSCAL 1.0.2, but for those who require OSCAL 1.0.0 please use trestle version 0.37.x.  That version is stable but will not have any features added, and we encourage users to move to OSCAL 1.0.2 and trestle ≥ 1.0.1.
+version 1.0.0 to 1.0.2 mainly due to `prop` becoming `props` in AssessmentResults.  As a result, the current development path of trestle requires OSCAL 1.0.2, but for those who require OSCAL 1.0.0 please use trestle version 0.37.x.  That version is stable but will not have any features added, and we encourage users to move to OSCAL 1.0.2 and Trestle ≥ 1.0.1.
 
 OSCAL version 1.0.0 files are still handled on import but any AssessmentResults must conform to the OSCAL 1.0.2 schema, with
 props instead of prop.  And all files created by trestle will be output as OSCAL version 1.0.2.


### PR DESCRIPTION
Signed-off-by: Ekaterina Nikonova <enikonovad@gmail.com>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
Updated docs to use Trestle >= 1.0.1 instead
## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.


Closes #1130 
