### PR TITLE
fix: add check for empty label to fix failure for statement with no label property

### DIFF
--- a/tests/data/json/full_profile_rev5.json
+++ b/tests/data/json/full_profile_rev5.json
@@ -99,6 +99,8 @@
         "include-controls": [
           {
             "with-ids": [
+              "ac-1",
+              "ac-2.3",
               "sc-21"
             ]
           }

--- a/tests/data/json/test_compdef_rev5.json
+++ b/tests/data/json/test_compdef_rev5.json
@@ -1,0 +1,127 @@
+{
+  "component-definition": {
+    "uuid": "2652b814-2a6b-4b6d-a0ae-8bc7a007209f",
+    "metadata": {
+      "title": "example FedRAMP component definition",
+      "last-modified": "2021-07-19T14:03:03+00:00",
+      "version": "0.21.0",
+      "oscal-version": "1.0.2",
+      "roles": [
+        {
+          "id": "prepared-by",
+          "title": "Indicates the organization that created this content."
+        },
+        {
+          "id": "prepared-for",
+          "title": "Indicates the organization for which this content was created.."
+        },
+        {
+          "id": "content-approver",
+          "title": "Indicates the organization responsible for all content represented in the \"document\"."
+        }
+      ],
+      "parties": [
+        {
+          "uuid": "ce1f379a-fcdd-485a-a7b7-6f02c0763dd2",
+          "type": "organization",
+          "name": "ACME",
+          "remarks": "ACME company"
+        },
+        {
+          "uuid": "481856b6-16e4-4993-a3ed-2fb242ce235b",
+          "type": "organization",
+          "name": "Customer",
+          "remarks": "Customer for the Component Definition"
+        },
+        {
+          "uuid": "2dc8b17f-daca-44a1-8a1d-c290120ea5e2",
+          "type": "organization",
+          "name": "ISV",
+          "remarks": "ISV for the Component Definition"
+        }
+      ],
+      "responsible-parties": [
+        {
+          "role-id": "prepared-by",
+          "party-uuids": [
+            "ce1f379a-fcdd-485a-a7b7-6f02c0763dd2"
+          ]
+        },
+        {
+          "role-id": "prepared-for",
+          "party-uuids": [
+            "481856b6-16e4-4993-a3ed-2fb242ce235b",
+            "2dc8b17f-daca-44a1-8a1d-c290120ea5e2"
+          ]
+        },
+        {
+          "role-id": "content-approver",
+          "party-uuids": [
+            "ce1f379a-fcdd-485a-a7b7-6f02c0763dd2"
+          ]
+        }
+      ]
+    },
+    "components": [
+      {
+        "uuid": "8220b305-0271-45f9-8a21-40ab6f197f75",
+        "type": "Service",
+        "title": "test_component",
+        "description": "This is a test component",
+        "control-implementations": [
+          {
+            "uuid": "76e89b67-3d6b-463d-90df-ec56a46c6069",
+            "source": "trestle://profiles/full_profile_rev5/profile.json",
+            "description": "trestle comp rev5",
+            "implemented-requirements": [
+              {
+                "uuid": "ca5ea4c5-ba51-4b1d-932a-5606891b7600",
+                "control-id": "sc-21",
+                "description": "imp req prose for sc-21 from test component",
+                "props": [
+                  {
+                    "name": "Rule_Id",
+                    "value": "top_shared_rule_1"
+                  },
+                  {
+                    "name": "implementation-status",
+                    "value": "implemented"
+                  },
+                  {
+                    "name": "control-origination",
+                    "value": "system-specific"
+                  },
+                  {
+                    "name": "control-origination",
+                    "value": "customer-configured"
+                  }
+                ],
+                "responsible-roles": [
+                  {
+                    "role-id": "prepared-by",
+                    "party-uuids": [
+                      "ce1f379a-fcdd-485a-a7b7-6f02c0763dd2"
+                    ]
+                  },
+                  {
+                    "role-id": "prepared-for",
+                    "party-uuids": [
+                      "481856b6-16e4-4993-a3ed-2fb242ce235b",
+                      "2dc8b17f-daca-44a1-8a1d-c290120ea5e2"
+                    ]
+                  },
+                  {
+                    "role-id": "content-approver",
+                    "party-uuids": [
+                      "ce1f379a-fcdd-485a-a7b7-6f02c0763dd2"
+                    ]
+                  }
+                ]
+              }
+            ]
+         }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -493,6 +493,32 @@ def setup_for_ssp(
     return args, yaml_path
 
 
+def setup_for_ssp_fedramp(
+    tmp_trestle_dir: pathlib.Path,
+    output_name: str,
+) -> argparse.Namespace:
+    """Load profile and component needed for ssp-generate with FedRAMP profile."""
+    prof_name = 'full_profile_rev5'
+    comp_name = 'test_compdef_rev5'
+    load_from_json(tmp_trestle_dir, prof_name, prof_name, prof.Profile)
+    load_from_json(tmp_trestle_dir, comp_name, comp_name, comp.ComponentDefinition)
+
+    args = argparse.Namespace(
+        trestle_root=tmp_trestle_dir,
+        profile=prof_name,
+        compdefs=comp_name,
+        leveraged_ssp=None,
+        output=output_name,
+        verbose=0,
+        overwrite_header_values=False,
+        yaml_header=None,
+        allowed_sections=None,
+        force_overwrite=None
+    )
+
+    return args
+
+
 def make_file_hidden(file_path: pathlib.Path, if_dot=False) -> None:
     """
     Make a file hidden on windows.

--- a/tests/trestle/core/commands/author/ssp_test.py
+++ b/tests/trestle/core/commands/author/ssp_test.py
@@ -19,7 +19,7 @@ import pathlib
 from _pytest.monkeypatch import MonkeyPatch
 
 from tests import test_utils
-from tests.test_utils import FileChecker, setup_for_ssp
+from tests.test_utils import FileChecker, setup_for_ssp, setup_for_ssp_fedramp
 
 import trestle.core.generators as gens
 import trestle.core.generic_oscal as generic
@@ -483,6 +483,17 @@ def test_ssp_assemble(tmp_trestle_dir: pathlib.Path) -> None:
     assert orig_uuid != test_utils.get_model_uuid(tmp_trestle_dir, ssp_name, ossp.SystemSecurityPlan)
     # confirm the file was not written out since no change
     assert orig_ssp_path.stat().st_mtime > orig_file_creation
+
+
+def test_ssp_assemble_fedramp_profile(tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
+    """Tests ssp assemble with a fedramp profile."""
+    gen_args = setup_for_ssp_fedramp(tmp_trestle_dir, ssp_name)
+    ssp_gen = SSPGenerate()
+    assert ssp_gen._run(gen_args) == 0
+
+    # first assemble
+    ssp_assemble = f'trestle author ssp-assemble -m {ssp_name} -o {ssp_name} -cd {gen_args.compdefs}'
+    test_utils.execute_command_and_assert(ssp_assemble, 0, monkeypatch)
 
 
 def test_ssp_assemble_remove_comp_defs(tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPatch) -> None:

--- a/trestle/core/catalog/catalog_interface.py
+++ b/trestle/core/catalog/catalog_interface.py
@@ -302,10 +302,12 @@ class CatalogInterface():
                 id_dict: Dict[str, str] = {}
                 for sub_part in as_list(statement_part.parts):
                     label = ControlInterface.get_label(sub_part)
-                    if label_as_key:
-                        id_dict[label] = sub_part.id
-                    else:
-                        id_dict[sub_part.id] = label
+                    # skip add to map for empty label
+                    if label:
+                        if label_as_key:
+                            id_dict[label] = sub_part.id
+                        else:
+                            id_dict[sub_part.id] = label
                 if id_dict:
                     id_map[control.id] = id_dict
         return id_map

--- a/trestle/core/catalog/catalog_interface.py
+++ b/trestle/core/catalog/catalog_interface.py
@@ -298,18 +298,20 @@ class CatalogInterface():
         id_map = {}
         for control in self.get_all_controls_from_catalog(True):
             statement_part = get_item_from_list(control.parts, const.STATEMENT, lambda p: p.name)
-            if statement_part:
-                id_dict: Dict[str, str] = {}
-                for sub_part in as_list(statement_part.parts):
-                    label = ControlInterface.get_label(sub_part)
-                    # skip add to map for empty label
-                    if label:
-                        if label_as_key:
-                            id_dict[label] = sub_part.id
-                        else:
-                            id_dict[sub_part.id] = label
-                if id_dict:
-                    id_map[control.id] = id_dict
+            if not statement_part:
+                continue
+            id_dict: Dict[str, str] = {}
+            for sub_part in as_list(statement_part.parts):
+                label = ControlInterface.get_label(sub_part)
+                # skip add to map for empty label
+                if not label:
+                    continue
+                if label_as_key:
+                    id_dict[label] = sub_part.id
+                else:
+                    id_dict[sub_part.id] = label
+            if id_dict:
+                id_map[control.id] = id_dict
         return id_map
 
     @staticmethod

--- a/trestle/core/catalog/catalog_reader.py
+++ b/trestle/core/catalog/catalog_reader.py
@@ -259,7 +259,10 @@ class CatalogReader():
         # if control has no parts it will not have part id map and bycomps will go at control level
         control_part_id_map = part_id_map_by_label.get(control_id, {})
         for label, comp_info in comp_info_dict.items():
-            part_id = control_part_id_map.get(label, '')
+            if label:
+                part_id = control_part_id_map.get(label, '')
+            else:
+                part_id = ''
             by_comp = CatalogReader._get_by_comp_from_imp_req(imp_req, part_id, gen_comp.uuid)
             by_comp.description = comp_info.prose
             by_comp.implementation_status = comp_info.status

--- a/trestle/core/catalog/catalog_reader.py
+++ b/trestle/core/catalog/catalog_reader.py
@@ -259,10 +259,7 @@ class CatalogReader():
         # if control has no parts it will not have part id map and bycomps will go at control level
         control_part_id_map = part_id_map_by_label.get(control_id, {})
         for label, comp_info in comp_info_dict.items():
-            if label:
-                part_id = control_part_id_map.get(label, '')
-            else:
-                part_id = ''
+            part_id = control_part_id_map.get(label, '')
             by_comp = CatalogReader._get_by_comp_from_imp_req(imp_req, part_id, gen_comp.uuid)
             by_comp.description = comp_info.prose
             by_comp.implementation_status = comp_info.status


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [X] My code follows the code style of this project.
- [ ] Documentation for my change is up to date?
- [X] My PR meets testing requirements.
- [X] All new and existing tests passed.
- [X] All commits are signed-off.

## Summary

Updates Catalog Interface `get_statement_part_id_map ` to check if the label is empty. If the label is empty and `label_as_key` is True, the statement is not added to the map.

This may be only a partial fix because any statement that does not have a label property would be skipped over here.

Test added to verify the fix

### Alternatives

Some alternatives fixes I tried.

- If a label does not existing for a statement part, set it to the part id. This broke several unit tests.
- Changing the the convention that an empty label means adding it to the implemented requirement, but this also broke several unit tests.

Fixes #1502 

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
