### PR TITLE
fix: increase range of supported versions of python

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     # moved from v1 to v2 20230301

--- a/.github/workflows/conventional-pr.yml
+++ b/.github/workflows/conventional-pr.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Install dependencies
       run: npm install @commitlint/cli @commitlint/config-conventional

--- a/.github/workflows/python-push.yml
+++ b/.github/workflows/python-push.yml
@@ -12,7 +12,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # Note: mac-os latest has transitioned to arm64. Only macos-13 and lower are x86_64 and support python 3.7.
+        os: [ubuntu-latest, macos-latest, windows-latest, macos-13.0]
         include:
         - os: ubuntu-latest
           path: ~/.cache/pip
@@ -25,14 +26,14 @@ jobs:
           path: ~/.cache/pip
           python-version: 3.7
         # optional 3.7 test
-        - os: macos-latest
+        - os: macos-13.0
           path: ~/Library/Caches/pip
           python-version: 3.7.16
         # optional 3.7 test
         - os: windows-latest
           path: ~\AppData\Local\pip\Cache
           python-version: 3.7
-        python-version: [3.8, 3.9]
+        python-version: [3.8, 3.12]
 
     steps:
     - name: Don't mess with  line endings

--- a/.github/workflows/python-push.yml
+++ b/.github/workflows/python-push.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         # Note: mac-os latest has transitioned to arm64. Only macos-13 and lower are x86_64 and support python 3.7.
-        os: [ubuntu-latest, macos-latest, windows-latest, macos-13.0]
+        os: [ubuntu-latest, macos-latest, windows-latest, macos-13]
         include:
         - os: ubuntu-latest
           path: ~/.cache/pip
@@ -26,7 +26,7 @@ jobs:
           path: ~/.cache/pip
           python-version: 3.7
         # optional 3.7 test
-        - os: macos-13.0
+        - os: macos-13
           path: ~/Library/Caches/pip
           python-version: 3.7.16
         # optional 3.7 test

--- a/.github/workflows/python-push.yml
+++ b/.github/workflows/python-push.yml
@@ -13,7 +13,8 @@ jobs:
     strategy:
       matrix:
         # Note: mac-os latest has transitioned to arm64. Only macos-13 and lower are x86_64 and support python 3.7.
-        os: [ubuntu-latest, macos-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.8, 3.12]
         include:
         - os: ubuntu-latest
           path: ~/.cache/pip
@@ -33,13 +34,13 @@ jobs:
         - os: windows-latest
           path: ~\AppData\Local\pip\Cache
           python-version: 3.7
-        python-version: [3.8, 3.12]
+
 
     steps:
     - name: Don't mess with  line endings
       run: |
         git config --global core.autocrlf false
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-push.yml
+++ b/.github/workflows/python-push.yml
@@ -42,7 +42,7 @@ jobs:
       with:
         submodules: true
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - uses: actions/cache@v2
@@ -103,7 +103,7 @@ jobs:
         fetch-depth: 0
         token: ${{ secrets.ADMIN_PAT }} 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8
     - name: Install build tools
@@ -126,13 +126,13 @@ jobs:
     # Temporary hack: allow develop as well as master to deploy docs.
     if: github.ref == 'refs/heads/main'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: true
         fetch-depth: 0
         token: ${{ secrets.ADMIN_PAT }} 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       # This is deliberately not using a custom credential as it relies on native github actions token to have push rights.
       with:
         python-version: 3.8
@@ -153,7 +153,7 @@ jobs:
       cancel-in-progress: true
     if: github.ref == 'refs/heads/main'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: true
         ref: main

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -112,7 +112,7 @@ jobs:
         - os: windows-latest
           path: ~\AppData\Local\pip\Cache
           python-version: 3.7
-          
+        python-version: [3.8, 3.12]
     steps:
     - name: Don't mess with line endings
       run: |

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -13,11 +13,11 @@ jobs:
     - name: Don't mess with line endings
       run: |
         git config --global core.autocrlf false
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
     - uses: actions/cache@v2
@@ -66,11 +66,11 @@ jobs:
     - name: Don't mess with line endings
       run: |
         git config --global core.autocrlf false
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
     - uses: actions/cache@v2
@@ -117,12 +117,12 @@ jobs:
     - name: Don't mess with line endings
       run: |
         git config --global core.autocrlf false
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         submodules: true
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - uses: actions/cache@v2
@@ -161,11 +161,11 @@ jobs:
     - name: Don't mess with line endings
       run: |
         git config --global core.autocrlf false
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8
     - uses: actions/cache@v2

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -92,7 +92,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9]
+        python-version: [3.8, 3.12]
         include:
         - os: ubuntu-latest
           path: ~/.cache/pip

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -91,8 +91,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.12]
+        # Note: mac-os latest has transitioned to arm64. Only macos-13 and lower are x86_64 and support python 3.7.
+        os: [ubuntu-latest, macos-latest, windows-latest, macos-13]
         include:
         - os: ubuntu-latest
           path: ~/.cache/pip
@@ -105,7 +105,7 @@ jobs:
           path: ~/.cache/pip
           python-version: 3.7
         # optional 3.7 test
-        - os: macos-latest
+        - os: macos-13
           path: ~/Library/Caches/pip
           python-version: 3.7.16
         # optional 3.7 test

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -171,9 +171,9 @@ jobs:
     - uses: actions/cache@v2
       with:
         path: ~/.cache/pip
-        key: ubuntu-latest-3.9-pip-${{ hashFiles('setup.cfg') }}
+        key: ubuntu-latest-3.8-pip-${{ hashFiles('setup.cfg') }}
         restore-keys: |
-          ubuntu-latest-3.9-pip-
+          ubuntu-latest-3.8-pip-
     - name: Install build tools
       run: |
         make develop

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -92,7 +92,8 @@ jobs:
     strategy:
       matrix:
         # Note: mac-os latest has transitioned to arm64. Only macos-13 and lower are x86_64 and support python 3.7.
-        os: [ubuntu-latest, macos-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.8, 3.12]
         include:
         - os: ubuntu-latest
           path: ~/.cache/pip
@@ -112,7 +113,6 @@ jobs:
         - os: windows-latest
           path: ~\AppData\Local\pip\Cache
           python-version: 3.7
-        python-version: [3.8, 3.12]
     steps:
     - name: Don't mess with line endings
       run: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,9 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
 long_description_content_type = text/markdown
 long_description = file: README.md
 python_require= '>=3.7'
@@ -43,6 +46,7 @@ install_requires =
     cmarkgfm==0.6.* #Update regularly
     orjson
     requests
+    setuptools
 
 [options.packages.find]
 include = trestle*
@@ -64,7 +68,6 @@ dev =
     pytest-cov>=2.10.0
     pytest-xdist
     pre-commit>=2.4.0
-    setuptools
     urllib3==1.26.17
     wheel
     yapf


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary

GitHub actions is now defaulting to python 3.12 when the python version is not specified. There was a breaking change for `compliance-trestle` in a fresh environment as `setuptools` is no longer included by default in a python environment / venv.

To merge this PR, required versions of the pipelines will need to be updated in the branch protection configuration

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit'
- Ensure CI is currently passing
- Is this a merge to `develop` from any branch except `main` and `ghpages`


Signed-off-by: Chris Butler <chris.butler@redhat.com>
