### PR TITLE
fix: default value for optional string params should be None

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -65,7 +65,7 @@ dev =
     pytest-cov>=2.10.0
     pytest-xdist
     pre-commit>=2.4.0
-    setuptools
+    setuptools>=61
     urllib3==1.26.19
     wheel
     yapf

--- a/trestle/core/repository.py
+++ b/trestle/core/repository.py
@@ -622,6 +622,7 @@ class AgileAuthoring(Repository):
         compdefs: str,
         leveraged_ssp: Optional[str] = None,
         force_overwrite: bool = False,
+        include_all_parts: bool = False,
         yaml_header: Optional[str] = None,
         overwrite_header_values: bool = False
     ) -> bool:

--- a/trestle/core/repository.py
+++ b/trestle/core/repository.py
@@ -388,7 +388,7 @@ class AgileAuthoring(Repository):
         markdown_dir: str,
         set_parameters: bool = False,
         regenerate: bool = False,
-        version: str = ''
+        version: Optional[str] = None
     ) -> bool:
         """Assemble catalog markdown into OSCAL Catalog in JSON."""
         logger.debug(f'Assembling model {name} of type catalog.')
@@ -423,10 +423,10 @@ class AgileAuthoring(Repository):
         markdown_dir: str,
         set_parameters: bool = False,
         regenerate: bool = False,
-        version: str = '',
-        sections: str = '',
-        required_sections: str = '',
-        allowed_sections: str = ''
+        version: Optional[str] = None,
+        sections: Optional[str] = None,
+        required_sections: Optional[str] = None,
+        allowed_sections: Optional[str] = None
     ) -> bool:
         """Assemble profile markdown into OSCAL Profile in JSON."""
         logger.debug(f'Assembling model {name} of type profile.')
@@ -492,7 +492,7 @@ class AgileAuthoring(Repository):
         markdown_dir: str,
         compdefs: str,
         regenerate: bool = False,
-        version: str = ''
+        version: Optional[str] = None
     ) -> bool:
         """Assemble ssp markdown into OSCAL SSP in JSON."""
         logger.debug(f'Assembling model {name} of type ssp.')
@@ -525,7 +525,7 @@ class AgileAuthoring(Repository):
         name: str,
         output: str,
         force_overwrite: bool = False,
-        yaml_header: str = '',
+        yaml_header: Optional[str] = None,
         overwrite_header_values: bool = False
     ) -> bool:
         """Generate catalog markdown from OSCAL Catalog in JSON."""
@@ -558,10 +558,10 @@ class AgileAuthoring(Repository):
         name: str,
         output: str,
         force_overwrite: bool = False,
-        yaml_header: str = '',
+        yaml_header: Optional[str] = None,
         overwrite_header_values: bool = False,
-        sections: str = '',
-        required_sections: str = ''
+        sections: Optional[str] = None,
+        required_sections: Optional[str] = None
     ) -> bool:
         """Generate profile markdown from OSCAL Profile in JSON."""
         logger.debug(f'Generating markdown for {name} of type profile.')
@@ -620,9 +620,9 @@ class AgileAuthoring(Repository):
         profile: str,
         output: str,
         compdefs: str,
-        leveraged_ssp: str = '',
+        leveraged_ssp: Optional[str] = None,
         force_overwrite: bool = False,
-        yaml_header: str = '',
+        yaml_header: Optional[str] = None,
         overwrite_header_values: bool = False
     ) -> bool:
         """Generate ssp markdown from OSCAL Profile and Component Definitions."""


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [X] My code follows the code style of this project.
- [X] Documentation for my change is up to date?
- [X] My PR meets testing requirements.
- [X] All new and existing tests passed.
- [X] All commits are signed-off.

## Summary
Fixes [Issue #1562](https://github.com/oscal-compass/compliance-trestle/issues/1562)

Optional string parameters should have a default value of `None` instead of empty string.

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
