### PR TITLE
docs: update maintainers list to reflect active maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,8 +6,6 @@ Christopher Butler [butler54](https://github.com/butler54)
 
 Lou Degenaro [degenaro](https://github.com/degenaro)
 
-Frank Suits [fsuits](https://github.com/fsuits)
-
 Jennifer Power [jpower432](https://github.com/jpower432)
 
 Manjiree Gadgil [mrgadgil](https://github.com/mrgadgil)


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [X] My code follows the code style of this project.
- [X] Documentation for my change is up to date?
- [ ] My PR meets testing requirements.
- [ ] All new and existing tests passed.
- [X] All commits are signed-off.

## Summary

Removes inactive maintainers from `MAINTAINERS.md`

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
