### PR TITLE
fix: skips sonar scans for dependabot updates

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -157,7 +157,7 @@ jobs:
         path: coverage.xml
 
   sonar:
-    if: ${{ github.event.pull_request.base.repo.url == github.event.pull_request.head.repo.url }}
+    if: ${{github.event.pull_request.base.repo.url == github.event.pull_request.head.repo.url && github.triggering_actor != 'dependabot[bot]'}}
     runs-on: ubuntu-latest
     needs: [ test, set-versions]
     steps:

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -157,7 +157,7 @@ jobs:
         path: coverage.xml
 
   sonar:
-    if: ${{github.event.pull_request.base.repo.url == github.event.pull_request.head.repo.url && github.triggering_actor != 'dependabot[bot]'}}
+    if: ${{ (github.event.pull_request.base.repo.url == github.event.pull_request.head.repo.url && github.triggering_actor != 'dependabot[bot]' ) }}
     runs-on: ubuntu-latest
     needs: [ test, set-versions]
     steps:


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [X] My code follows the code style of this project.
- [ ] Documentation for my change is up to date?
- [ ] My PR meets testing requirements.
- [X] All new and existing tests passed.
- [X] All commits are signed-off.

## Summary

Dependabot does not have access to secrets and the updates only include third party dependency updates and should not need sonar scans.
Closes #1655 

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
