### PR TITLE
feat: add parameter aggregation support for SSP

### DIFF
--- a/tests/data/json/profile_aggregation.json
+++ b/tests/data/json/profile_aggregation.json
@@ -1,0 +1,106 @@
+{
+  "profile": {
+    "uuid": "83be30e4-6c88-40e0-9927-286ff0e43d59",
+    "metadata": {
+      "title": "SI-7 profile",
+      "last-modified": "2024-06-24T19:35:43.973109+00:00",
+      "version": "0.0.1",
+      "oscal-version": "1.1.2"
+    },
+    "imports": [
+      {
+        "href": "https://raw.githubusercontent.com/usnistgov/oscal-content/main/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_catalog.json",
+        "include-controls": [
+          {
+            "with-ids": [
+              "si-7"
+            ]
+          }
+        ]
+      }
+    ],
+    "modify": {
+      "set-parameters": [
+        {
+          "param-id": "si-07_odp.01",
+          "props": [
+            {
+              "name": "param-value-origin",
+              "value": "OCISO"
+            }
+          ],
+          "values": [
+            "software"
+          ]
+        },
+        {
+          "param-id": "si-07_odp.02",
+          "props": [
+            {
+              "name": "param-value-origin",
+              "value": "OCISO"
+            }
+          ],
+          "values": [
+            "firmware"
+          ]
+        },
+        {
+          "param-id": "si-07_odp.03",
+          "props": [
+            {
+              "name": "param-value-origin",
+              "value": "OCISO"
+            }
+          ],
+          "values": [
+            "information"
+          ]
+        },
+        {
+          "param-id": "si-07_odp.04",
+          "props": [
+            {
+              "name": "param-value-origin",
+              "value": "OCISO"
+            }
+          ],
+          "values": [
+            "notify the System Owner, ISSO, ISSM, and the Incident Response team"
+          ]
+        },
+        {
+          "param-id": "si-07_odp.05",
+          "props": [
+            {
+              "name": "param-value-origin",
+              "value": "OCISO"
+            }
+          ],
+          "values": [
+            "notify the System Owner, ISSO, ISSM, and the Incident Response team"
+          ]
+        },
+        {
+          "param-id": "si-07_odp.06",
+          "props": [
+            {
+              "name": "param-value-origin",
+              "value": "OCISO"
+            }
+          ],
+          "values": [
+            "notify the System Owner, ISSO, ISSM, and the Incident Response team"
+          ]
+        },
+        {
+          "param-id": "si-7_prm_1"
+        },
+        {
+          "param-id": "si-7_prm_2"
+        }
+      ],
+      "alters": []
+    }
+  }
+}

--- a/trestle/core/catalog/catalog_writer.py
+++ b/trestle/core/catalog/catalog_writer.py
@@ -165,9 +165,11 @@ class CatalogWriter():
                 # adds it to prof-param-value-origin
                 if prof_param_value_origin != '' and prof_param_value_origin is not None:
                     if context.purpose == ContextPurpose.PROFILE:
-                        new_dict[const.PROFILE_PARAM_VALUE_ORIGIN] = prof_param_value_origin
+                        if const.AGGREGATES not in [prop.name for prop in as_list(param.props)]:
+                            new_dict[const.PROFILE_PARAM_VALUE_ORIGIN] = prof_param_value_origin
                 else:
-                    new_dict[const.PROFILE_PARAM_VALUE_ORIGIN] = const.REPLACE_ME_PLACEHOLDER
+                    if const.AGGREGATES not in [prop.name for prop in as_list(param.props)]:
+                        new_dict[const.PROFILE_PARAM_VALUE_ORIGIN] = const.REPLACE_ME_PLACEHOLDER
                 # then insert the original, incoming values as values
                 if param_id in control_param_dict:
                     orig_param = control_param_dict[param_id]
@@ -180,6 +182,8 @@ class CatalogWriter():
                         new_dict.pop(const.VALUES)
                     if new_dict[const.GUIDELINES] is None:
                         new_dict.pop(const.GUIDELINES)
+                    if const.AGGREGATES in [prop.name for prop in as_list(orig_param.props)]:
+                        new_dict.pop(const.PROFILE_PARAM_VALUE_ORIGIN)
             else:
                 # if the profile doesnt change this param at all, show it in the header with values
                 tmp_dict = ModelUtils.parameter_to_dict(param_dict, True)


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary

Closes #1596 

I'm making this as a feature addition as we didn't initially considered this to be supported in SSP, just in profile.

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
