### PR TITLE
fix(build): installs required build dependencies during semantic release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,10 @@ line-length = 500
 line_length = 500
 
 [tool.semantic_release]
-build_command = "python setup.py sdist bdist_wheel"
+build_command = """
+    python -m pip install -e .[dev] --upgrade --upgrade-strategy eager --
+    python setup.py sdist bdist_wheel
+"""
 version_variables = ["trestle/__init__.py:__version__"]
 commit_author = "semantic-release <semantic-release>"
 


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [ ] My code follows the code style of this project.
- [ ] Documentation for my change is up to date?
- [X] My PR meets testing requirements.
- [ ] All new and existing tests passed.
- [X] All commits are signed-off.

## Summary

Semantic release is running in a container that does not have access to the dependencies installed in `make develop` step. This just adds the command run with the `make develop` target as part of the build.

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
