### PR TITLE
fix: unit test execution in PyCharm (#1755)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -259,7 +259,9 @@ def tmp_empty_cwd(tmp_path: pathlib.Path) -> Iterator[pathlib.Path]:
 @pytest.fixture(scope='function')
 def testdata_dir() -> pathlib.Path:
     """Return absolute path to test data directory."""
-    test_data_source = pathlib.Path('tests/data')
+    test_dir = pathlib.Path(__file__).parent.resolve()
+    data_path = test_dir / 'data'
+    test_data_source = pathlib.Path(data_path)
     return test_data_source.resolve()
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,6 +17,7 @@
 
 import argparse
 import difflib
+import functools
 import logging
 import os
 import pathlib
@@ -53,29 +54,52 @@ if file_utils.is_windows():  # pragma: no cover
 
 logger = logging.getLogger(__name__)
 
-BASE_TMP_DIR = pathlib.Path('tests/__tmp_path').resolve()
-YAML_TEST_DATA_PATH = pathlib.Path('tests/data/yaml/').resolve()
-JSON_TEST_DATA_PATH = pathlib.Path('tests/data/json/').resolve()
-ENV_TEST_DATA_PATH = pathlib.Path('tests/data/env/').resolve()
-JSON_NIST_DATA_PATH = pathlib.Path('nist-content/nist.gov/SP800-53/rev5/json/').resolve()
+TEST_DIR = pathlib.Path(__file__).parent.resolve()
+BASE_TMP_DIR = pathlib.Path(TEST_DIR / '__tmp_path').resolve()
+YAML_TEST_DATA_PATH = pathlib.Path(TEST_DIR / 'data/yaml/').resolve()
+JSON_TEST_DATA_PATH = pathlib.Path(TEST_DIR / 'data/json/').resolve()
+ENV_TEST_DATA_PATH = pathlib.Path(TEST_DIR / 'data/env/').resolve()
+JSON_NIST_DATA_PATH = pathlib.Path(TEST_DIR / '../nist-content/nist.gov/SP800-53/rev5/json/').resolve()
 JSON_NIST_CATALOG_NAME = 'NIST_SP-800-53_rev5_catalog.json'
 JSON_NIST_PROFILE_NAME = 'NIST_SP-800-53_rev5_MODERATE-baseline_profile.json'
-JSON_NIST_REV_4_DATA_PATH = pathlib.Path('nist-content/nist.gov/SP800-53/rev4/json/').resolve()
+JSON_NIST_REV_4_DATA_PATH = pathlib.Path(TEST_DIR / '../nist-content/nist.gov/SP800-53/rev4/json/').resolve()
 JSON_NIST_REV_4_CATALOG_NAME = 'NIST_SP-800-53_rev4_catalog.json'
 JSON_NIST_REV_5_CATALOG_NAME = 'nist-rev5-catalog-full.json'
 JSON_NIST_REV_4_PROFILE_NAME = 'NIST_SP-800-53_rev4_MODERATE-baseline_profile.json'
 SIMPLIFIED_NIST_CATALOG_NAME = 'simplified_nist_catalog.json'
 SIMPLIFIED_NIST_PROFILE_NAME = 'simplified_nist_profile.json'
-TASK_XLSX_OUTPUT_PATH = pathlib.Path('tests/data/tasks/xlsx/output').resolve()
+TASK_XLSX_OUTPUT_PATH = pathlib.Path(TEST_DIR / 'data/tasks/xlsx/output').resolve()
 
 CATALOGS_DIR = 'catalogs'
 PROFILES_DIR = 'profiles'
 COMPONENT_DEF_DIR = 'component-definitions'
 
-NIST_EXAMPLES = pathlib.Path('nist-content/examples')
+NIST_EXAMPLES = pathlib.Path(TEST_DIR / '../nist-content/examples')
 NIST_SAMPLE_CD_JSON = NIST_EXAMPLES / 'component-definition' / 'json' / 'example-component.json'
 
 NEW_MODEL_AGE_SECONDS = 100
+
+
+def set_cwd_unsafe(cwd: pathlib.Path = TEST_DIR):
+    """Set the current working directory to the test directory.
+
+    Not safe for concurrent tests which may change directory.
+    """
+
+    def decorator(f):
+
+        @functools.wraps(f)
+        def wrapper(*args, **kwargs):
+            original_cwd = os.getcwd()
+            os.chdir(cwd)
+            try:
+                f(*args, **kwargs)
+            finally:
+                os.chdir(original_cwd)
+
+        return wrapper
+
+    return decorator
 
 
 def clean_tmp_path(tmp_path: pathlib.Path):

--- a/tests/trestle/core/commands/validate_test.py
+++ b/tests/trestle/core/commands/validate_test.py
@@ -46,8 +46,6 @@ from trestle.oscal.catalog import Catalog
 from trestle.oscal.common import ResponsibleParty, Role
 from trestle.oscal.component import ComponentDefinition, ControlImplementation
 
-test_data_dir = pathlib.Path('tests/data').resolve()
-
 md_path = 'md_comp'
 
 
@@ -58,16 +56,18 @@ md_path = 'md_comp'
         ('my_test_model', '-t', False), ('my_test_model', '-a', False), ('my_test_model', '-x', False)
     ]
 )
-def test_validation_happy(name, mode, parent, tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
+def test_validation_happy(
+    name, mode, parent, tmp_trestle_dir: pathlib.Path, testdata_dir: pathlib.Path, monkeypatch: MonkeyPatch
+) -> None:
     """Test successful validation runs."""
     (tmp_trestle_dir / test_utils.CATALOGS_DIR / 'my_test_model').mkdir(exist_ok=True, parents=True)
     (tmp_trestle_dir / test_utils.CATALOGS_DIR / 'my_test_model2').mkdir(exist_ok=True, parents=True)
     shutil.copyfile(
-        test_data_dir / 'json/minimal_catalog.json',
+        testdata_dir / 'json/minimal_catalog.json',
         tmp_trestle_dir / test_utils.CATALOGS_DIR / 'my_test_model/catalog.json'
     )
     shutil.copyfile(
-        test_data_dir / 'json/minimal_catalog.json',
+        testdata_dir / 'json/minimal_catalog.json',
         tmp_trestle_dir / test_utils.CATALOGS_DIR / 'my_test_model2/catalog.json'
     )
 
@@ -101,17 +101,17 @@ def test_validation_happy(name, mode, parent, tmp_trestle_dir: pathlib.Path, mon
     ]
 )
 def test_validation_unhappy(
-    name, mode, parent, status, tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPatch
+    name, mode, parent, status, tmp_trestle_dir: pathlib.Path, testdata_dir: pathlib.Path, monkeypatch: MonkeyPatch
 ) -> None:
     """Test failure modes of validation."""
     (tmp_trestle_dir / test_utils.CATALOGS_DIR / 'my_test_model').mkdir(exist_ok=True, parents=True)
     (tmp_trestle_dir / test_utils.CATALOGS_DIR / 'my_test_model2').mkdir(exist_ok=True, parents=True)
     shutil.copyfile(
-        test_data_dir / 'json/minimal_catalog_bad_oscal_version.json',
+        testdata_dir / 'json/minimal_catalog_bad_oscal_version.json',
         tmp_trestle_dir / test_utils.CATALOGS_DIR / 'my_test_model/catalog.json'
     )
     shutil.copyfile(
-        test_data_dir / 'json/minimal_catalog.json',
+        testdata_dir / 'json/minimal_catalog.json',
         tmp_trestle_dir / test_utils.CATALOGS_DIR / 'my_test_model2/catalog.json'
     )
 
@@ -421,11 +421,13 @@ def test_period(tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPatch) -> None
         pass
 
 
-def test_validate_component_definition(tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
+def test_validate_component_definition(
+    tmp_trestle_dir: pathlib.Path, testdata_dir: pathlib.Path, monkeypatch: MonkeyPatch
+) -> None:
     """Test validation of Component Definition."""
     jfile = 'component-definition.json'
 
-    sdir = test_data_dir / 'validate' / 'component-definitions' / 'x1'
+    sdir = testdata_dir / 'validate' / 'component-definitions' / 'x1'
     spth = sdir / f'{jfile}'
 
     tdir = tmp_trestle_dir / test_utils.COMPONENT_DEF_DIR / 'my_test_model'
@@ -438,11 +440,13 @@ def test_validate_component_definition(tmp_trestle_dir: pathlib.Path, monkeypatc
     test_utils.execute_command_and_assert(validate_command, 0, monkeypatch)
 
 
-def test_validate_component_definition_ports(tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
+def test_validate_component_definition_ports(
+    tmp_trestle_dir: pathlib.Path, testdata_dir: pathlib.Path, monkeypatch: MonkeyPatch
+) -> None:
     """Test validation of ports in Component Definition."""
     jfile = 'component-definition.json'
 
-    sdir = test_data_dir / 'validate' / 'component-definitions' / 'x2'
+    sdir = testdata_dir / 'validate' / 'component-definitions' / 'x2'
     spth = sdir / f'{jfile}'
 
     tdir = tmp_trestle_dir / test_utils.COMPONENT_DEF_DIR / 'my_test_model'
@@ -455,11 +459,13 @@ def test_validate_component_definition_ports(tmp_trestle_dir: pathlib.Path, monk
     test_utils.execute_command_and_assert(validate_command, 0, monkeypatch)
 
 
-def test_validate_component_definition_ports_invalid(tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
+def test_validate_component_definition_ports_invalid(
+    tmp_trestle_dir: pathlib.Path, testdata_dir: pathlib.Path, monkeypatch: MonkeyPatch
+) -> None:
     """Test validation of ports in Component Definition."""
     jfile = 'component-definition.json'
 
-    sdir = test_data_dir / 'validate' / 'component-definitions' / 'x3'
+    sdir = testdata_dir / 'validate' / 'component-definitions' / 'x3'
     spth = sdir / f'{jfile}'
 
     tdir = tmp_trestle_dir / test_utils.COMPONENT_DEF_DIR / 'my_test_model'

--- a/tests/trestle/core/control_io_test.py
+++ b/tests/trestle/core/control_io_test.py
@@ -338,10 +338,12 @@ def test_get_control_param_dict(tmp_trestle_dir: pathlib.Path) -> None:
 
 
 @pytest.mark.parametrize('overwrite_header_values', [True, False])
-def test_write_control_header_params(overwrite_header_values, tmp_path: pathlib.Path) -> None:
+def test_write_control_header_params(
+    overwrite_header_values, tmp_path: pathlib.Path, testdata_dir: pathlib.Path
+) -> None:
     """Test write/read of control header params."""
     # orig file just has one param ac-1_prm_3
-    src_control_path = pathlib.Path('tests/data/author/controls/control_with_components_and_params.md')
+    src_control_path = pathlib.Path(testdata_dir / 'author/controls/control_with_components_and_params.md')
     # header has two params - 3 and 4
     header = {
         const.SET_PARAMS_TAG: {

--- a/tests/trestle/core/control_io_test.py
+++ b/tests/trestle/core/control_io_test.py
@@ -45,7 +45,7 @@ case_2 = 'indent jump back 2'
 case_3 = 'indent end abrupt'
 case_4 = 'no items'
 
-control_text = """---
+control_text = r"""---
 x-trestle-global:
   sort-id: xy-09
 ---
@@ -131,7 +131,7 @@ def test_read_write_controls(
     part_b3 = common.Part(id='ac-1_smt.b.3', name='item', prose='b.3 prose', props=[prop])
     prop.value = 'c'
     part_c = common.Part(id='ac-1_smt.c', name='item', prose='c prose', props=[prop])
-    sec_1_text = """
+    sec_1_text = r"""
 General comment
 on separate lines
 
@@ -397,7 +397,7 @@ def test_write_control_header_params(
     assert test_utils.controls_equivalent(orig_control_read, new_control_read)
 
 
-statement_text = """
+statement_text = r"""
 
 
 # xy-9 - \[My Group Title\] Fancy Control

--- a/tests/trestle/core/draw_io_test.py
+++ b/tests/trestle/core/draw_io_test.py
@@ -21,6 +21,8 @@ from uuid import uuid4
 
 import pytest
 
+from tests.test_utils import TEST_DIR
+
 from trestle.common.err import TrestleError
 from trestle.core.draw_io import DrawIO, DrawIOMetadataValidator
 from trestle.core.markdown.markdown_validator import MarkdownValidator
@@ -42,20 +44,13 @@ def test_missing_file(tmp_path) -> None:
 @pytest.mark.parametrize(
     'file_path, metadata_exists, metadata_valid',
     [
-        (
-            pathlib.Path('tests/data/author/0.0.1/drawio/single_tab_bad_metadata_extra_fields_compressed.drawio'),
-            True,
-            False
-        ),
-        (
-            pathlib.Path('tests/data/author/0.0.1/drawio/single_tab_bad_metadata_missing_fields_compressed.drawio'),
-            True,
-            False
-        ), (pathlib.Path('tests/data/author/0.0.1/drawio/single_tab_metadata_compressed.drawio'), True, True),
-        (pathlib.Path('tests/data/author/0.0.1/drawio/single_tab_no_metadata_compressed.drawio'), False, False),
-        (pathlib.Path('tests/data/author/0.0.1/drawio/single_tab_no_metadata_uncompressed.drawio'), False, False),
-        (pathlib.Path('tests/data/author/0.0.1/drawio/two_tabs_metadata_compressed.drawio'), True, True),
-        (pathlib.Path('tests/data/author/0.0.1/drawio/two_tabs_metadata_second_tab_compressed.drawio'), True, False)
+        (TEST_DIR / 'data/author/0.0.1/drawio/single_tab_bad_metadata_extra_fields_compressed.drawio', True, False),
+        (TEST_DIR / 'data/author/0.0.1/drawio/single_tab_bad_metadata_missing_fields_compressed.drawio', True, False),
+        (TEST_DIR / 'data/author/0.0.1/drawio/single_tab_metadata_compressed.drawio', True, True),
+        (TEST_DIR / 'data/author/0.0.1/drawio/single_tab_no_metadata_compressed.drawio', False, False),
+        (TEST_DIR / 'data/author/0.0.1/drawio/single_tab_no_metadata_uncompressed.drawio', False, False),
+        (TEST_DIR / 'data/author/0.0.1/drawio/two_tabs_metadata_compressed.drawio', True, True),
+        (TEST_DIR / 'data/author/0.0.1/drawio/two_tabs_metadata_second_tab_compressed.drawio', True, False)
     ]
 )
 def test_valid_drawio(file_path: pathlib.Path, metadata_exists: bool, metadata_valid: bool) -> None:
@@ -78,9 +73,9 @@ def test_valid_drawio(file_path: pathlib.Path, metadata_exists: bool, metadata_v
 @pytest.mark.parametrize(
     'bad_file_name',
     [
-        (pathlib.Path('tests/data/author/0.0.1/drawio/single_tab_no_metadata_uncompressed_mangled.drawio')),
-        (pathlib.Path('tests/data/author/0.0.1/drawio/not_mxfile.drawio')),
-        (pathlib.Path('tests/data/author/0.0.1/drawio/single_tab_no_metadata_bad_internal_structure.drawio'))
+        (TEST_DIR / 'data/author/0.0.1/drawio/single_tab_no_metadata_uncompressed_mangled.drawio'),
+        (TEST_DIR / 'data/author/0.0.1/drawio/not_mxfile.drawio'),
+        (TEST_DIR / 'data/author/0.0.1/drawio/single_tab_no_metadata_bad_internal_structure.drawio')
     ]
 )
 def test_bad_drawio_files(bad_file_name: pathlib.Path) -> None:
@@ -93,32 +88,32 @@ def test_bad_drawio_files(bad_file_name: pathlib.Path) -> None:
     'template_file, sample_file, must_be_first_tab, metadata_valid',
     [
         (
-            pathlib.Path('tests/data/author/0.0.1/drawio/single_tab_metadata_compressed.drawio'),
-            pathlib.Path('tests/data/author/0.0.1/drawio/single_tab_metadata_compressed.drawio'),
+            TEST_DIR / 'data/author/0.0.1/drawio/single_tab_metadata_compressed.drawio',
+            TEST_DIR / 'data/author/0.0.1/drawio/single_tab_metadata_compressed.drawio',
             True,
             True
         ),
         (
-            pathlib.Path('tests/data/author/0.0.1/drawio/single_tab_metadata_compressed.drawio'),
-            pathlib.Path('tests/data/author/0.0.1/drawio/two_tabs_metadata_compressed.drawio'),
+            TEST_DIR / 'data/author/0.0.1/drawio/single_tab_metadata_compressed.drawio',
+            TEST_DIR / 'data/author/0.0.1/drawio/two_tabs_metadata_compressed.drawio',
             True,
             True
         ),
         (
-            pathlib.Path('tests/data/author/0.0.1/drawio/single_tab_metadata_compressed.drawio'),
-            pathlib.Path('tests/data/author/0.0.1/drawio/two_tabs_metadata_second_tab_compressed.drawio'),
+            TEST_DIR / 'data/author/0.0.1/drawio/single_tab_metadata_compressed.drawio',
+            TEST_DIR / 'data/author/0.0.1/drawio/two_tabs_metadata_second_tab_compressed.drawio',
             True,
             False
         ),
         (
-            pathlib.Path('tests/data/author/0.0.1/drawio/single_tab_metadata_compressed.drawio'),
-            pathlib.Path('tests/data/author/0.0.1/drawio/two_tabs_metadata_second_tab_compressed.drawio'),
+            TEST_DIR / 'data/author/0.0.1/drawio/single_tab_metadata_compressed.drawio',
+            TEST_DIR / 'data/author/0.0.1/drawio/two_tabs_metadata_second_tab_compressed.drawio',
             False,
             True
         ),
         (
-            pathlib.Path('tests/data/author/0.0.1/drawio/single_tab_metadata_compressed.drawio'),
-            pathlib.Path('tests/data/author/0.0.1/drawio/two_tabs_metadata_second_tab_bad_md.drawio'),
+            TEST_DIR / 'data/author/0.0.1/drawio/single_tab_metadata_compressed.drawio',
+            TEST_DIR / 'data/author/0.0.1/drawio/two_tabs_metadata_second_tab_bad_md.drawio',
             False,
             False
         )
@@ -135,7 +130,7 @@ def test_valid_drawio_second_tab(
 
 def test_restructure_metadata():
     """Test Restructuring metadata."""
-    drawio_file = pathlib.Path('tests/data/author/0.0.1/drawio/single_tab_metadata_compressed.drawio')
+    drawio_file = TEST_DIR / 'data/author/0.0.1/drawio/single_tab_metadata_compressed.drawio'
     comparison_metadata = {'test': 'value', 'nested': {'test': 'value', 'extra': 'value', 'nested': {'test': 'value'}}}
     draw_io = DrawIO(drawio_file)
     metadata_flat = draw_io.get_metadata()[0]
@@ -146,9 +141,7 @@ def test_restructure_metadata():
 def test_write_metadata_compressed(tmp_path):
     """Test writing modified metadata to drawio file."""
     tmp_drawio_file = tmp_path / 'test.drawio'
-    shutil.copyfile(
-        pathlib.Path('tests/data/author/0.0.1/drawio/single_tab_metadata_compressed.drawio'), tmp_drawio_file
-    )
+    shutil.copyfile(TEST_DIR / 'data/author/0.0.1/drawio/single_tab_metadata_compressed.drawio', tmp_drawio_file)
     draw_io = DrawIO(tmp_drawio_file)
 
     diagram_idx = 0
@@ -171,9 +164,7 @@ def test_write_metadata_compressed(tmp_path):
 def test_write_metadata_uncompressed(tmp_path):
     """Test writing modified metadata to drawio file."""
     tmp_drawio_file = tmp_path / 'test.drawio'
-    shutil.copyfile(
-        pathlib.Path('tests/data/author/0.0.1/drawio/single_tab_metadata_uncompressed.drawio'), tmp_drawio_file
-    )
+    shutil.copyfile(TEST_DIR / 'data/author/0.0.1/drawio/single_tab_metadata_uncompressed.drawio', tmp_drawio_file)
     draw_io = DrawIO(tmp_drawio_file)
 
     diagram_idx = 0

--- a/tests/trestle/core/markdown/markdown_node_test.py
+++ b/tests/trestle/core/markdown/markdown_node_test.py
@@ -20,12 +20,14 @@ import frontmatter
 
 import pytest
 
+from tests.test_utils import TEST_DIR
+
 import trestle.common.const as const
 from trestle.core.markdown.docs_markdown_node import DocsMarkdownNode, DocsSectionContent
 from trestle.core.markdown.markdown_api import MarkdownAPI
 
 
-@pytest.mark.parametrize('md_path', [(pathlib.Path('tests/data/markdown/valid_complex_md.md'))])
+@pytest.mark.parametrize('md_path', [(TEST_DIR / 'data/markdown/valid_complex_md.md')])
 def test_tree_text_equal_to_md(md_path: pathlib.Path) -> None:
     """Test tree construction."""
     contents = frontmatter.loads(md_path.open('r', encoding=const.FILE_ENCODING).read())
@@ -36,7 +38,7 @@ def test_tree_text_equal_to_md(md_path: pathlib.Path) -> None:
     assert markdown_wo_header == tree.content.raw_text
 
 
-@pytest.mark.parametrize('md_path', [(pathlib.Path('tests/data/markdown/valid_complex_md.md'))])
+@pytest.mark.parametrize('md_path', [(TEST_DIR / 'data/markdown/valid_complex_md.md')])
 def test_md_get_node_for_key(md_path: pathlib.Path) -> None:
     """Test node fetching."""
     contents = frontmatter.loads(md_path.open('r', encoding=const.FILE_ENCODING).read())
@@ -64,7 +66,7 @@ def test_md_get_node_for_key(md_path: pathlib.Path) -> None:
     assert node.key == '### 5.1.1 A deeper section 1'
 
 
-@pytest.mark.parametrize('md_path', [(pathlib.Path('tests/data/markdown/valid_complex_md.md'))])
+@pytest.mark.parametrize('md_path', [(TEST_DIR / 'data/markdown/valid_complex_md.md')])
 def test_md_content_is_correct(md_path: pathlib.Path) -> None:
     """Test that read content is correct."""
     contents = frontmatter.loads(md_path.open('r', encoding=const.FILE_ENCODING).read())
@@ -83,7 +85,7 @@ def test_md_content_is_correct(md_path: pathlib.Path) -> None:
     assert deep_node.content.text[1] == 'some very deep text'
 
 
-@pytest.mark.parametrize('md_path', [(pathlib.Path('tests/data/markdown/valid_complex_md.md'))])
+@pytest.mark.parametrize('md_path', [(TEST_DIR / 'data/markdown/valid_complex_md.md')])
 def test_md_headers_in_html_blocks_are_ignored(md_path: pathlib.Path) -> None:
     """Test that headers in the various html blocks are ignored."""
     contents = frontmatter.loads(md_path.open('r', encoding=const.FILE_ENCODING).read())

--- a/tests/trestle/core/markdown/markdown_validator_test.py
+++ b/tests/trestle/core/markdown/markdown_validator_test.py
@@ -19,6 +19,8 @@ from typing import Any, Dict
 
 import pytest
 
+from tests.test_utils import TEST_DIR
+
 import trestle.common.err as err
 from trestle.core.markdown.markdown_api import MarkdownAPI
 from trestle.core.markdown.markdown_validator import MarkdownValidator
@@ -28,127 +30,127 @@ from trestle.core.markdown.markdown_validator import MarkdownValidator
     'template_path, instance_path, status, header_validate, header_only_validate',
     [
         (
-            pathlib.Path('tests/data/author/0.0.1/test_1_md_format/template.md'),
-            pathlib.Path('tests/data/author/0.0.1/test_1_md_format/correct_instance.md'),
+            TEST_DIR / 'data/author/0.0.1/test_1_md_format/template.md',
+            TEST_DIR / 'data/author/0.0.1/test_1_md_format/correct_instance.md',
             True,
             True,
             False
         ),
         (
-            pathlib.Path('tests/data/author/0.0.1/test_1_md_format/template.md'),
-            pathlib.Path('tests/data/author/0.0.1/test_1_md_format/correct_instance_extra_features.md'),
+            TEST_DIR / 'data/author/0.0.1/test_1_md_format/template.md',
+            TEST_DIR / 'data/author/0.0.1/test_1_md_format/correct_instance_extra_features.md',
             True,
             True,
             False
         ),
         (
-            pathlib.Path('tests/data/author/0.0.1/test_1_md_format/template.md'),
-            pathlib.Path('tests/data/author/0.0.1/test_1_md_format/bad_instance_yaml_header_change.md'),
+            TEST_DIR / 'data/author/0.0.1/test_1_md_format/template.md',
+            TEST_DIR / 'data/author/0.0.1/test_1_md_format/bad_instance_yaml_header_change.md',
             False,
             True,
             False
         ),
         (
-            pathlib.Path('tests/data/author/0.0.1/test_1_md_format/template.md'),
-            pathlib.Path('tests/data/author/0.0.1/test_1_md_format/bad_instance_yaml_header_change.md'),
+            TEST_DIR / 'data/author/0.0.1/test_1_md_format/template.md',
+            TEST_DIR / 'data/author/0.0.1/test_1_md_format/bad_instance_yaml_header_change.md',
             True,
             False,
             False
         ),
         (
-            pathlib.Path('tests/data/author/0.0.1/test_1_md_format/template.md'),
-            pathlib.Path('tests/data/author/0.0.1/test_1_md_format/bad_instance_missing_heading.md'),
+            TEST_DIR / 'data/author/0.0.1/test_1_md_format/template.md',
+            TEST_DIR / 'data/author/0.0.1/test_1_md_format/bad_instance_missing_heading.md',
             False,
             False,
             False
         ),
         (
-            pathlib.Path('tests/data/author/0.0.1/test_1_md_format/template.md'),
-            pathlib.Path('tests/data/author/0.0.1/test_1_md_format/bad_instance_missing_heading.md'),
+            TEST_DIR / 'data/author/0.0.1/test_1_md_format/template.md',
+            TEST_DIR / 'data/author/0.0.1/test_1_md_format/bad_instance_missing_heading.md',
             True,
             True,
             True
         ),
         (
-            pathlib.Path('tests/data/author/0.0.1/test_1_md_format/template.md'),
-            pathlib.Path('tests/data/author/0.0.1/test_1_md_format/bad_instance_heading_wrong_type.md'),
+            TEST_DIR / 'data/author/0.0.1/test_1_md_format/template.md',
+            TEST_DIR / 'data/author/0.0.1/test_1_md_format/bad_instance_heading_wrong_type.md',
             False,
             False,
             False
         ),
         (
-            pathlib.Path('tests/data/author/0.0.1/test_1_md_format/template.md'),
-            pathlib.Path('tests/data/author/0.0.1/test_1_md_format/bad_instance_bold_heading.md'),
+            TEST_DIR / 'data/author/0.0.1/test_1_md_format/template.md',
+            TEST_DIR / 'data/author/0.0.1/test_1_md_format/bad_instance_bold_heading.md',
             False,
             False,
             False
         ),
         (
-            pathlib.Path('tests/data/author/0.0.1/test_1_md_format/bad_instance_bold_heading.md'),
-            pathlib.Path('tests/data/author/0.0.1/test_1_md_format/template.md'),
+            TEST_DIR / 'data/author/0.0.1/test_1_md_format/bad_instance_bold_heading.md',
+            TEST_DIR / 'data/author/0.0.1/test_1_md_format/template.md',
             False,
             False,
             False
         ),
         (
-            pathlib.Path('tests/data/author/0.0.1/test_4_md_format_extras/template.md'),
-            pathlib.Path('tests/data/author/0.0.1/test_4_md_format_extras/correct_instance.md'),
+            TEST_DIR / 'data/author/0.0.1/test_4_md_format_extras/template.md',
+            TEST_DIR / 'data/author/0.0.1/test_4_md_format_extras/correct_instance.md',
             True,
             True,
             False
         ),
         (
-            pathlib.Path('tests/data/author/0.0.1/test_4_md_format_extras/template.md'),
-            pathlib.Path('tests/data/author/0.0.1/test_4_md_format_extras/correct_instance_extra_features.md'),
+            TEST_DIR / 'data/author/0.0.1/test_4_md_format_extras/template.md',
+            TEST_DIR / 'data/author/0.0.1/test_4_md_format_extras/correct_instance_extra_features.md',
             True,
             True,
             False
         ),
         (
-            pathlib.Path('tests/data/author/0.0.1/test_4_md_format_extras/template.md'),
-            pathlib.Path('tests/data/author/0.0.1/test_4_md_format_extras/bad_instance_yaml_header_change.md'),
+            TEST_DIR / 'data/author/0.0.1/test_4_md_format_extras/template.md',
+            TEST_DIR / 'data/author/0.0.1/test_4_md_format_extras/bad_instance_yaml_header_change.md',
             False,
             True,
             False
         ),
         (
-            pathlib.Path('tests/data/author/0.0.1/test_4_md_format_extras/template.md'),
-            pathlib.Path('tests/data/author/0.0.1/test_4_md_format_extras/bad_instance_yaml_header_change.md'),
+            TEST_DIR / 'data/author/0.0.1/test_4_md_format_extras/template.md',
+            TEST_DIR / 'data/author/0.0.1/test_4_md_format_extras/bad_instance_yaml_header_change.md',
             True,
             False,
             False
         ),
         (
-            pathlib.Path('tests/data/author/0.0.1/test_4_md_format_extras/template.md'),
-            pathlib.Path('tests/data/author/0.0.1/test_4_md_format_extras/bad_instance_missing_heading.md'),
+            TEST_DIR / 'data/author/0.0.1/test_4_md_format_extras/template.md',
+            TEST_DIR / 'data/author/0.0.1/test_4_md_format_extras/bad_instance_missing_heading.md',
             False,
             False,
             False
         ),
         (
-            pathlib.Path('tests/data/author/0.0.1/test_4_md_format_extras/template.md'),
-            pathlib.Path('tests/data/author/0.0.1/test_4_md_format_extras/bad_instance_missing_heading.md'),
+            TEST_DIR / 'data/author/0.0.1/test_4_md_format_extras/template.md',
+            TEST_DIR / 'data/author/0.0.1/test_4_md_format_extras/bad_instance_missing_heading.md',
             True,
             True,
             True
         ),
         (
-            pathlib.Path('tests/data/author/0.0.1/test_4_md_format_extras/template.md'),
-            pathlib.Path('tests/data/author/0.0.1/test_4_md_format_extras/bad_instance_heading_wrong_type.md'),
+            TEST_DIR / 'data/author/0.0.1/test_4_md_format_extras/template.md',
+            TEST_DIR / 'data/author/0.0.1/test_4_md_format_extras/bad_instance_heading_wrong_type.md',
             False,
             False,
             False
         ),
         (
-            pathlib.Path('tests/data/author/0.0.1/test_4_md_format_extras/template.md'),
-            pathlib.Path('tests/data/author/0.0.1/test_4_md_format_extras/bad_instance_bold_heading.md'),
+            TEST_DIR / 'data/author/0.0.1/test_4_md_format_extras/template.md',
+            TEST_DIR / 'data/author/0.0.1/test_4_md_format_extras/bad_instance_bold_heading.md',
             False,
             False,
             False
         ),
         (
-            pathlib.Path('tests/data/author/0.0.1/test_4_md_format_extras/bad_instance_bold_heading.md'),
-            pathlib.Path('tests/data/author/0.0.1/test_4_md_format_extras/template.md'),
+            TEST_DIR / 'data/author/0.0.1/test_4_md_format_extras/bad_instance_bold_heading.md',
+            TEST_DIR / 'data/author/0.0.1/test_4_md_format_extras/template.md',
             False,
             False,
             False
@@ -171,8 +173,8 @@ def test_md_validator_pass(
 
 def test_md_by_hand() -> None:
     """Simpler test to enable debugging."""
-    template_path = pathlib.Path('tests/data/author/0.0.1/test_3_md_hand_edited/template.md')
-    instance_path = pathlib.Path('tests/data/author/0.0.1/test_3_md_hand_edited/decisions_000.md')
+    template_path = TEST_DIR / 'data/author/0.0.1/test_3_md_hand_edited/template.md'
+    instance_path = TEST_DIR / 'data/author/0.0.1/test_3_md_hand_edited/decisions_000.md'
     header_validate = False
     status = True
     md_api = MarkdownAPI()
@@ -185,26 +187,26 @@ def test_md_by_hand() -> None:
     'template_path, instance_path, status, yaml_header_validate',
     [
         (
-            pathlib.Path('tests/data/author/0.0.1/test_2_md_with_md_header/template.md'),
-            pathlib.Path('tests/data/author/0.0.1/test_2_md_with_md_header/instance.md'),
+            TEST_DIR / 'data/author/0.0.1/test_2_md_with_md_header/template.md',
+            TEST_DIR / 'data/author/0.0.1/test_2_md_with_md_header/instance.md',
             True,
             False
         ),
         (
-            pathlib.Path('tests/data/author/0.0.1/test_3_md_hand_edited/template.md'),
-            pathlib.Path('tests/data/author/0.0.1/test_3_md_hand_edited/decisions_000.md'),
+            TEST_DIR / 'data/author/0.0.1/test_3_md_hand_edited/template.md',
+            TEST_DIR / 'data/author/0.0.1/test_3_md_hand_edited/decisions_000.md',
             True,
             False
         ),
         (
-            pathlib.Path('tests/data/author/0.0.1/test_3_md_hand_edited/template.md'),
-            pathlib.Path('tests/data/author/0.0.1/test_3_md_hand_edited/decisions_001.md'),
+            TEST_DIR / 'data/author/0.0.1/test_3_md_hand_edited/template.md',
+            TEST_DIR / 'data/author/0.0.1/test_3_md_hand_edited/decisions_001.md',
             True,
             False
         ),
         (
-            pathlib.Path('tests/data/author/0.0.1/test_3_md_hand_edited/template.md'),
-            pathlib.Path('tests/data/author/0.0.1/test_3_md_hand_edited/decisions_002.md'),
+            TEST_DIR / 'data/author/0.0.1/test_3_md_hand_edited/template.md',
+            TEST_DIR / 'data/author/0.0.1/test_3_md_hand_edited/decisions_002.md',
             True,
             False
         )
@@ -306,38 +308,38 @@ def test_key_compare(template: Dict[str, Any], candidate: Dict[str, Any], expect
     'template_path, instance_path, status, governed_header',
     [
         (
-            pathlib.Path('tests/data/author/0.0.1/test_2_md_with_md_header/template.md'),
-            pathlib.Path('tests/data/author/0.0.1/test_2_md_with_md_header/instance.md'),
+            TEST_DIR / 'data/author/0.0.1/test_2_md_with_md_header/template.md',
+            TEST_DIR / 'data/author/0.0.1/test_2_md_with_md_header/instance.md',
             True,
             'Governed Document'
         ),
         (
-            pathlib.Path('tests/data/author/0.0.1/test_2_md_with_md_header/template.md'),
-            pathlib.Path('tests/data/author/0.0.1/test_2_md_with_md_header/instance.md'),
+            TEST_DIR / 'data/author/0.0.1/test_2_md_with_md_header/template.md',
+            TEST_DIR / 'data/author/0.0.1/test_2_md_with_md_header/instance.md',
             True,
             'Governed Document      '
         ),
         (
-            pathlib.Path('tests/data/author/0.0.1/test_2_md_with_md_header/template.md'),
-            pathlib.Path('tests/data/author/0.0.1/test_2_md_with_md_header/instance.md'),
+            TEST_DIR / 'data/author/0.0.1/test_2_md_with_md_header/template.md',
+            TEST_DIR / 'data/author/0.0.1/test_2_md_with_md_header/instance.md',
             False,
             'Governed Documeent'
         ),
         (
-            pathlib.Path('tests/data/author/0.0.1/test_2_md_with_md_header/template.md'),
-            pathlib.Path('tests/data/author/0.0.1/test_2_md_with_md_header/bad_heading_content_changed_header.md'),
+            TEST_DIR / 'data/author/0.0.1/test_2_md_with_md_header/template.md',
+            TEST_DIR / 'data/author/0.0.1/test_2_md_with_md_header/bad_heading_content_changed_header.md',
             False,
             'Governed Document'
         ),
         (
-            pathlib.Path('tests/data/author/0.0.1/test_2_md_with_md_header/template.md'),
-            pathlib.Path('tests/data/author/0.0.1/test_2_md_with_md_header/bad_heading_content_extra_lines.md'),
+            TEST_DIR / 'data/author/0.0.1/test_2_md_with_md_header/template.md',
+            TEST_DIR / 'data/author/0.0.1/test_2_md_with_md_header/bad_heading_content_extra_lines.md',
             False,
             'Governed Document'
         ),
         (
-            pathlib.Path('tests/data/author/0.0.1/test_2_md_with_md_header/template.md'),
-            pathlib.Path('tests/data/author/0.0.1/test_2_md_with_md_header/wrong_heading_title.md'),
+            TEST_DIR / 'data/author/0.0.1/test_2_md_with_md_header/template.md',
+            TEST_DIR / 'data/author/0.0.1/test_2_md_with_md_header/wrong_heading_title.md',
             False,
             'Governed Document'
         )
@@ -375,29 +377,29 @@ def test_broken_yaml_header(testdata_dir: pathlib.Path):
     'template_path, instance_path, status, header_validate, validate_md_body',
     [
         (
-            pathlib.Path('tests/data/author/0.0.1/test_4_md_substitutions/template.md'),
-            pathlib.Path('tests/data/author/0.0.1/test_4_md_substitutions/correct_instance.md'),
+            TEST_DIR / 'data/author/0.0.1/test_4_md_substitutions/template.md',
+            TEST_DIR / 'data/author/0.0.1/test_4_md_substitutions/correct_instance.md',
             True,
             True,
             True
         ),
         (
-            pathlib.Path('tests/data/author/0.0.1/test_4_md_substitutions/template.md'),
-            pathlib.Path('tests/data/author/0.0.1/test_4_md_substitutions/correct_instance_empty_subs.md'),
+            TEST_DIR / 'data/author/0.0.1/test_4_md_substitutions/template.md',
+            TEST_DIR / 'data/author/0.0.1/test_4_md_substitutions/correct_instance_empty_subs.md',
             True,
             True,
             True
         ),
         (
-            pathlib.Path('tests/data/author/0.0.1/test_4_md_substitutions/template.md'),
-            pathlib.Path('tests/data/author/0.0.1/test_4_md_substitutions/bad_added_header.md'),
+            TEST_DIR / 'data/author/0.0.1/test_4_md_substitutions/template.md',
+            TEST_DIR / 'data/author/0.0.1/test_4_md_substitutions/bad_added_header.md',
             False,
             True,
             True
         ),
         (
-            pathlib.Path('tests/data/author/0.0.1/test_4_md_substitutions/template.md'),
-            pathlib.Path('tests/data/author/0.0.1/test_4_md_substitutions/bad_modified_header_deep.md'),
+            TEST_DIR / 'data/author/0.0.1/test_4_md_substitutions/template.md',
+            TEST_DIR / 'data/author/0.0.1/test_4_md_substitutions/bad_modified_header_deep.md',
             False,
             True,
             True
@@ -422,10 +424,10 @@ def test_md_validator_substitutions(
     'template_path, status',
     [
         (
-            pathlib.Path('tests/data/author/versions/1.0.0/good_template.md'),
+            TEST_DIR / 'data/author/versions/1.0.0/good_template.md',
             True,
         ), (
-            pathlib.Path('tests/data/author/versions/1.1.0/good_template.md'),
+            TEST_DIR / 'data/author/versions/1.1.0/good_template.md',
             True,
         )
     ]
@@ -442,18 +444,18 @@ def test_template_version(template_path: pathlib.Path, status: bool) -> None:
     'template_path, instance_path, status',
     [
         (
-            pathlib.Path('tests/data/author/versions/1.1.0/good_template.md'),
-            pathlib.Path('tests/data/author/versions/good_instance_with_version_outside_structure.md'),
+            TEST_DIR / 'data/author/versions/1.1.0/good_template.md',
+            TEST_DIR / 'data/author/versions/good_instance_with_version_outside_structure.md',
             True,
         ),
         (
-            pathlib.Path('tests/data/author/versions/1.1.0/good_template.md'),
-            pathlib.Path('tests/data/author/versions/1.1.0/good_instance.md'),
+            TEST_DIR / 'data/author/versions/1.1.0/good_template.md',
+            TEST_DIR / 'data/author/versions/1.1.0/good_instance.md',
             True,
         ),
         (
-            pathlib.Path('tests/data/author/versions/1.1.0/good_template.md'),
-            pathlib.Path('tests/data/author/versions/1.1.0/bad_instance_mismatched_versions.md'),
+            TEST_DIR / 'data/author/versions/1.1.0/good_template.md',
+            TEST_DIR / 'data/author/versions/1.1.0/bad_instance_mismatched_versions.md',
             False,
         )
     ]
@@ -469,8 +471,8 @@ def test_instance_template_version(template_path: pathlib.Path, instance_path: p
 @pytest.mark.parametrize(
     'template_path',
     [
-        (pathlib.Path('tests/data/author/versions/1.0.0/bad_template_wrong_folder.md')),
-        (pathlib.Path('tests/data/author/versions/1.1.0/bad_template_mismatched_versions.md'))
+        (TEST_DIR / 'data/author/versions/1.0.0/bad_template_wrong_folder.md'),
+        (TEST_DIR / 'data/author/versions/1.1.0/bad_template_mismatched_versions.md')
     ]
 )
 def test_template_path_mismatch(template_path: pathlib.Path) -> None:

--- a/tests/trestle/core/parser_test.py
+++ b/tests/trestle/core/parser_test.py
@@ -19,10 +19,12 @@ import pathlib
 
 from ruamel.yaml import YAML
 
+from tests.test_utils import TEST_DIR
+
 from trestle.common import const
 from trestle.core import parser
 
-yaml_path = pathlib.Path('tests/data/yaml/')
+yaml_path = TEST_DIR / 'data/yaml/'
 
 
 def test_parse_dict() -> None:

--- a/tests/trestle/core/utils_test.py
+++ b/tests/trestle/core/utils_test.py
@@ -24,6 +24,7 @@ from pydantic.v1 import ValidationError
 import pytest
 
 from tests import test_utils
+from tests.test_utils import TEST_DIR
 
 import trestle.common.const as const
 import trestle.common.err as err
@@ -45,7 +46,7 @@ from trestle.common.str_utils import AliasMode
 
 def load_good_catalog() -> catalog.Catalog:
     """Load nist 800-53 as a catalog example."""
-    good_sample_path = pathlib.Path('nist-content/nist.gov/SP800-53/rev4/json/NIST_SP-800-53_rev4_catalog.json')
+    good_sample_path = TEST_DIR / '../nist-content/nist.gov/SP800-53/rev4/json/NIST_SP-800-53_rev4_catalog.json'
 
     assert (good_sample_path.exists())
     return catalog.Catalog.oscal_read(good_sample_path)

--- a/tests/trestle/core/validator_helper_test.py
+++ b/tests/trestle/core/validator_helper_test.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 """Tests for validator helper functionality that was moved to model_utils."""
 
-import pathlib
 from uuid import uuid4
 
 import tests.test_utils as test_utils
@@ -24,7 +23,7 @@ import trestle.oscal.catalog as catalog
 import trestle.oscal.ssp as ssp
 from trestle.common.model_utils import ModelUtils
 
-ssp_path = pathlib.Path('nist-content/examples/ssp/json/ssp-example.json')
+ssp_path = test_utils.TEST_DIR / '../nist-content/examples/ssp/json/ssp-example.json'
 catalog_path = test_utils.JSON_TEST_DATA_PATH / test_utils.SIMPLIFIED_NIST_CATALOG_NAME
 
 

--- a/tests/trestle/misc/mypy_test.py
+++ b/tests/trestle/misc/mypy_test.py
@@ -14,10 +14,11 @@
 # limitations under the License.
 """Testing mypy."""
 
-import pathlib
 import subprocess
 
-folder = pathlib.Path('tests') / 'trestle' / 'misc'
+from tests.test_utils import TEST_DIR
+
+folder = TEST_DIR / 'trestle' / 'misc'
 subject = folder / '_inventory.py'
 config = folder / 'mypy.cfg'
 

--- a/tests/trestle/parsing/parsing_test.py
+++ b/tests/trestle/parsing/parsing_test.py
@@ -23,25 +23,25 @@ import pytest
 from ruamel.yaml import YAML
 from ruamel.yaml.parser import ParserError
 
+from tests.test_utils import YAML_TEST_DATA_PATH
+
 import trestle.common.const as const
 import trestle.oscal.component as component
 
-yaml_path = pathlib.Path('tests/data/yaml/')
-json_path = pathlib.Path('tests/data/json/')
 encoding = const.FILE_ENCODING
 
 
 def test_yaml_load() -> None:
     """Test yaml load."""
     # happy path
-    read_file = (yaml_path / 'good_simple.yaml').open('r', encoding=encoding)
+    read_file = (YAML_TEST_DATA_PATH / 'good_simple.yaml').open('r', encoding=encoding)
     yaml = YAML(typ='safe')
     obj = yaml.load(read_file)
     assert obj is not None
 
     # unhappy path
     with pytest.raises(ParserError):
-        read_file = (yaml_path / 'bad_simple.yaml').open('r', encoding=encoding)
+        read_file = (YAML_TEST_DATA_PATH / 'bad_simple.yaml').open('r', encoding=encoding)
         obj = yaml.load(read_file)
 
 
@@ -51,7 +51,7 @@ def test_yaml_dump(tmp_path: pathlib.Path) -> None:
     tmp_path = pathlib.Path(tmp_path)
     yaml = YAML(typ='safe')
     # happy path
-    read_file = (yaml_path / component_name).open('r', encoding=encoding)
+    read_file = (YAML_TEST_DATA_PATH / component_name).open('r', encoding=encoding)
     component_obj = yaml.load(read_file)
     read_file.close()
     assert component_obj is not None
@@ -75,7 +75,7 @@ def test_oscal_model(tmp_path: pathlib.Path) -> None:
     tmp_path = pathlib.Path(tmp_path)
 
     # load good component
-    read_file = yaml_path / good_component_name
+    read_file = YAML_TEST_DATA_PATH / good_component_name
     assert read_file.exists()
     component_obj = component.ComponentDefinition.oscal_read(read_file)
     assert component_obj is not None
@@ -96,7 +96,7 @@ def test_oscal_model(tmp_path: pathlib.Path) -> None:
     assert component_obj != component_reload
 
     # load good target with different timezone
-    read_file = yaml_path / 'good_component_diff_tz.yaml'
+    read_file = YAML_TEST_DATA_PATH / 'good_component_diff_tz.yaml'
     component_diff_tz = component.ComponentDefinition.oscal_read(read_file)
     assert component_diff_tz is not None
 
@@ -104,7 +104,7 @@ def test_oscal_model(tmp_path: pathlib.Path) -> None:
     assert component_obj == component_diff_tz
 
     # try to load file with no timezone specified
-    read_file = yaml_path / 'bad_component_no_tz.yaml'
+    read_file = YAML_TEST_DATA_PATH / 'bad_component_no_tz.yaml'
 
     # confirm the load fails because it is invalid without timezone specified
     try:

--- a/tests/trestle/tasks/cis_xlsx_to_oscal_catalog_test.py
+++ b/tests/trestle/tasks/cis_xlsx_to_oscal_catalog_test.py
@@ -22,12 +22,15 @@ from unittest import mock
 
 from openpyxl import load_workbook
 
+from tests.test_utils import TEST_DIR, set_cwd_unsafe
+
 import trestle.tasks.cis_xlsx_to_oscal_catalog as cis_xlsx_to_oscal_catalog
 from trestle.oscal.catalog import Catalog
 from trestle.tasks.base_task import TaskOutcome
 
-ocp_config = 'tests/data/tasks/cis-xlsx-to-oscal-catalog/test-cis-xlsx-to-oscal-catalog.ocp.config'
-rhel_config = 'tests/data/tasks/cis-xlsx-to-oscal-catalog/test-cis-xlsx-to-oscal-catalog.rhel.config'
+root_dir = TEST_DIR / '../'
+ocp_config = TEST_DIR / 'data/tasks/cis-xlsx-to-oscal-catalog/test-cis-xlsx-to-oscal-catalog.ocp.config'
+rhel_config = TEST_DIR / 'data/tasks/cis-xlsx-to-oscal-catalog/test-cis-xlsx-to-oscal-catalog.rhel.config'
 
 
 def _get_section(tmp_path: pathlib.Path, file_: str) -> Dict:
@@ -40,6 +43,7 @@ def _get_section(tmp_path: pathlib.Path, file_: str) -> Dict:
     return section
 
 
+@set_cwd_unsafe(root_dir)
 def test_cis_xlsx_to_oscal_catalog_print_info(tmp_path: pathlib.Path):
     """Test print_info call."""
     section = _get_section(tmp_path, ocp_config)
@@ -48,6 +52,7 @@ def test_cis_xlsx_to_oscal_catalog_print_info(tmp_path: pathlib.Path):
     assert retval is None
 
 
+@set_cwd_unsafe(root_dir)
 def test_cis_xlsx_to_oscal_catalog_simulate(tmp_path: pathlib.Path):
     """Test simulate call."""
     section = _get_section(tmp_path, ocp_config)
@@ -57,6 +62,7 @@ def test_cis_xlsx_to_oscal_catalog_simulate(tmp_path: pathlib.Path):
     assert len(os.listdir(str(tmp_path))) == 0
 
 
+@set_cwd_unsafe(root_dir)
 def test_cis_xlsx_to_oscal_catalog_execute_ocp(tmp_path: pathlib.Path):
     """Test execute call - ocp."""
     section = _get_section(tmp_path, ocp_config)
@@ -96,6 +102,7 @@ def _validate_ocp(tmp_path: pathlib.Path):
     assert p52.value == 'Manual'
 
 
+@set_cwd_unsafe(root_dir)
 def test_cis_xlsx_to_oscal_catalog_no_overwrite(tmp_path: pathlib.Path):
     """Test execute call."""
     section = _get_section(tmp_path, ocp_config)
@@ -109,6 +116,7 @@ def test_cis_xlsx_to_oscal_catalog_no_overwrite(tmp_path: pathlib.Path):
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_cis_xlsx_to_oscal_catalog_missing_config(tmp_path: pathlib.Path):
     """Test missing config."""
     section = None
@@ -117,6 +125,7 @@ def test_cis_xlsx_to_oscal_catalog_missing_config(tmp_path: pathlib.Path):
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_cis_xlsx_to_oscal_catalog_missing_version(tmp_path: pathlib.Path):
     """Test missing version."""
     section = _get_section(tmp_path, ocp_config)
@@ -126,9 +135,10 @@ def test_cis_xlsx_to_oscal_catalog_missing_version(tmp_path: pathlib.Path):
     assert retval == TaskOutcome.FAILURE
 
 
-def test_cis_xlsx_to_oscal_catalog_missing_sheet(tmp_path: pathlib.Path):
+@set_cwd_unsafe(root_dir)
+def test_cis_xlsx_to_oscal_catalog_missing_sheet(tmp_path: pathlib.Path, testdata_dir: pathlib.Path):
     """Test missing sheet."""
-    folder = 'tests/data/tasks/cis-xlsx-to-oscal-catalog'
+    folder = testdata_dir / 'tasks/cis-xlsx-to-oscal-catalog'
     file_ = f'{folder}/CIS_RedHat_OpenShift_Container_Platform_Benchmark_v1.2.0-2.snippet.xlsx'
     wb_hacked = load_workbook(file_)
     sheet = wb_hacked['Combined Profiles']
@@ -141,9 +151,10 @@ def test_cis_xlsx_to_oscal_catalog_missing_sheet(tmp_path: pathlib.Path):
         assert retval == TaskOutcome.FAILURE
 
 
-def test_cis_xlsx_to_oscal_catalog_one_dot_added_part(tmp_path: pathlib.Path):
+@set_cwd_unsafe(root_dir)
+def test_cis_xlsx_to_oscal_catalog_one_dot_added_part(tmp_path: pathlib.Path, testdata_dir: pathlib.Path):
     """Test group part."""
-    folder = 'tests/data/tasks/cis-xlsx-to-oscal-catalog'
+    folder = testdata_dir / 'tasks/cis-xlsx-to-oscal-catalog'
     file_ = f'{folder}/CIS_RedHat_OpenShift_Container_Platform_Benchmark_v1.2.0-2.snippet.xlsx'
     wb_hacked = load_workbook(file_)
     sheet = wb_hacked['Combined Profiles']
@@ -168,9 +179,10 @@ def test_cis_xlsx_to_oscal_catalog_one_dot_added_part(tmp_path: pathlib.Path):
     assert p000.prose == 'foobar'
 
 
-def test_cis_xlsx_to_oscal_catalog_unexpected_section(tmp_path: pathlib.Path):
+@set_cwd_unsafe(root_dir)
+def test_cis_xlsx_to_oscal_catalog_unexpected_section(tmp_path: pathlib.Path, testdata_dir: pathlib.Path):
     """Test group part."""
-    folder = 'tests/data/tasks/cis-xlsx-to-oscal-catalog'
+    folder = testdata_dir / 'tasks/cis-xlsx-to-oscal-catalog'
     file_ = f'{folder}/CIS_RedHat_OpenShift_Container_Platform_Benchmark_v1.2.0-2.snippet.xlsx'
     wb_hacked = load_workbook(file_)
     sheet = wb_hacked['Combined Profiles']
@@ -185,9 +197,10 @@ def test_cis_xlsx_to_oscal_catalog_unexpected_section(tmp_path: pathlib.Path):
         assert retval == TaskOutcome.FAILURE
 
 
-def test_cis_xlsx_to_oscal_catalog_no_status(tmp_path: pathlib.Path):
+@set_cwd_unsafe(root_dir)
+def test_cis_xlsx_to_oscal_catalog_no_status(tmp_path: pathlib.Path, testdata_dir: pathlib.Path):
     """Test no column with name status."""
-    folder = 'tests/data/tasks/cis-xlsx-to-oscal-catalog'
+    folder = testdata_dir / 'tasks/cis-xlsx-to-oscal-catalog'
     file_ = f'{folder}/CIS_RedHat_OpenShift_Container_Platform_Benchmark_v1.2.0-2.snippet.xlsx'
     wb_hacked = load_workbook(file_)
     sheet = wb_hacked['Combined Profiles']
@@ -202,9 +215,10 @@ def test_cis_xlsx_to_oscal_catalog_no_status(tmp_path: pathlib.Path):
         assert retval == TaskOutcome.SUCCESS
 
 
-def test_cis_xlsx_to_oscal_catalog_no_mitre(tmp_path: pathlib.Path):
+@set_cwd_unsafe(root_dir)
+def test_cis_xlsx_to_oscal_catalog_no_mitre(tmp_path: pathlib.Path, testdata_dir: pathlib.Path):
     """Test no column with name mitre."""
-    folder = 'tests/data/tasks/cis-xlsx-to-oscal-catalog'
+    folder = testdata_dir / 'tasks/cis-xlsx-to-oscal-catalog'
     file_ = f'{folder}/CIS_RedHat_OpenShift_Container_Platform_Benchmark_v1.2.0-2.snippet.xlsx'
     wb_hacked = load_workbook(file_)
     sheet = wb_hacked['Combined Profiles']
@@ -219,9 +233,10 @@ def test_cis_xlsx_to_oscal_catalog_no_mitre(tmp_path: pathlib.Path):
         assert retval == TaskOutcome.SUCCESS
 
 
-def test_cis_xlsx_to_oscal_catalog_no_v7_ig1(tmp_path: pathlib.Path):
+@set_cwd_unsafe(root_dir)
+def test_cis_xlsx_to_oscal_catalog_no_v7_ig1(tmp_path: pathlib.Path, testdata_dir: pathlib.Path):
     """Test no column with name v7 IG1."""
-    folder = 'tests/data/tasks/cis-xlsx-to-oscal-catalog'
+    folder = testdata_dir / 'tasks/cis-xlsx-to-oscal-catalog'
     file_ = f'{folder}/CIS_RedHat_OpenShift_Container_Platform_Benchmark_v1.2.0-2.snippet.xlsx'
     wb_hacked = load_workbook(file_)
     sheet = wb_hacked['Combined Profiles']
@@ -236,7 +251,8 @@ def test_cis_xlsx_to_oscal_catalog_no_v7_ig1(tmp_path: pathlib.Path):
         assert retval == TaskOutcome.SUCCESS
 
 
-def test_cis_xlsx_to_oscal_catalog_execute_rhel(tmp_path: pathlib.Path):
+@set_cwd_unsafe(root_dir)
+def test_cis_xlsx_to_oscal_catalog_execute_rhel(tmp_path: pathlib.Path, testdata_dir: pathlib.Path):
     """Test execute call - rhel."""
     section = _get_section(tmp_path, rhel_config)
     tgt = cis_xlsx_to_oscal_catalog.CisXlsxToOscalCatalog(section)

--- a/tests/trestle/tasks/csv_to_oscal_cd_test.py
+++ b/tests/trestle/tasks/csv_to_oscal_cd_test.py
@@ -26,10 +26,13 @@ from _pytest.monkeypatch import MonkeyPatch
 import pytest
 
 from tests import test_utils
+from tests.test_utils import set_cwd_unsafe
 
 import trestle.tasks.csv_to_oscal_cd as csv_to_oscal_cd
 from trestle.oscal.component import ComponentDefinition
 from trestle.tasks.base_task import TaskOutcome
+
+root_dir = test_utils.TEST_DIR / '../'
 
 
 def monkey_exception() -> None:
@@ -139,6 +142,7 @@ def _get_config_section_init(tmp_path: pathlib.Path, fname: str) -> tuple:
     return _get_config_section(tmp_path, fname)
 
 
+@set_cwd_unsafe(root_dir)
 def test_print_info(tmp_path: pathlib.Path) -> None:
     """Test print_info."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd.config')
@@ -147,6 +151,7 @@ def test_print_info(tmp_path: pathlib.Path) -> None:
     assert retval is None
 
 
+@set_cwd_unsafe(root_dir)
 def test_simulate(tmp_path: pathlib.Path) -> None:
     """Test simulate."""
     _, section = _get_config_section(tmp_path, 'test-csv-to-oscal-cd.config')
@@ -156,6 +161,7 @@ def test_simulate(tmp_path: pathlib.Path) -> None:
     assert len(os.listdir(str(tmp_path))) == 0
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute(tmp_path: pathlib.Path) -> None:
     """Test execute."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd.config')
@@ -165,6 +171,7 @@ def test_execute(tmp_path: pathlib.Path) -> None:
     _validate_ocp(tmp_path)
 
 
+@set_cwd_unsafe(root_dir)
 def test_config_missing(tmp_path: pathlib.Path) -> None:
     """Test config missing."""
     section = None
@@ -173,6 +180,7 @@ def test_config_missing(tmp_path: pathlib.Path) -> None:
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_config_missing_title(tmp_path: pathlib.Path) -> None:
     """Test config missing title."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd.config')
@@ -182,6 +190,7 @@ def test_config_missing_title(tmp_path: pathlib.Path) -> None:
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_config_missing_version(tmp_path: pathlib.Path) -> None:
     """Test config missing version."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd.config')
@@ -191,6 +200,7 @@ def test_config_missing_version(tmp_path: pathlib.Path) -> None:
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_config_missing_csv_file_spec(tmp_path: pathlib.Path) -> None:
     """Test config missing csv file spec."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd.config')
@@ -201,6 +211,7 @@ def test_config_missing_csv_file_spec(tmp_path: pathlib.Path) -> None:
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_config_missing_csv_file(tmp_path: pathlib.Path) -> None:
     """Test config missing csv file."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd.config')
@@ -210,6 +221,7 @@ def test_config_missing_csv_file(tmp_path: pathlib.Path) -> None:
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_exception(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
     """Test exception."""
     monkeypatch.setattr(csv_to_oscal_cd._RuleSetIdMgr, 'get_next_rule_set_id', monkey_exception)
@@ -219,6 +231,7 @@ def test_exception(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_mock(tmp_path: pathlib.Path) -> None:
     """Test execute mock."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd.config')
@@ -255,6 +268,7 @@ def _setup_workspace(workspace: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
         os.chdir(cwd)
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_validate_controls(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
     """Test execute validate_controls."""
     workspace = tmp_path / 'trestle.workspace'
@@ -271,6 +285,7 @@ def test_execute_validate_controls(tmp_path: pathlib.Path, monkeypatch: MonkeyPa
     assert retval == TaskOutcome.SUCCESS
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_validate_controls_nist(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
     """Test execute validate_controls nist."""
     workspace = tmp_path / 'trestle.workspace'
@@ -300,6 +315,7 @@ def test_execute_validate_controls_nist(tmp_path: pathlib.Path, monkeypatch: Mon
     assert retval == TaskOutcome.SUCCESS
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_control_invalid(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
     """Test execute control invalid (not in catalog)."""
     workspace = tmp_path / 'trestle.workspace'
@@ -324,6 +340,7 @@ def test_execute_control_invalid(tmp_path: pathlib.Path, monkeypatch: MonkeyPatc
     assert retval == TaskOutcome.SUCCESS
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_control_invalid_fail(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
     """Test execute control invalid (not in catalog)."""
     workspace = tmp_path / 'trestle.workspace'
@@ -348,6 +365,7 @@ def test_execute_control_invalid_fail(tmp_path: pathlib.Path, monkeypatch: Monke
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_no_overwrite(tmp_path: pathlib.Path) -> None:
     """Test execute no overwrite."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd.config')
@@ -359,6 +377,7 @@ def test_execute_no_overwrite(tmp_path: pathlib.Path) -> None:
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_verbose(tmp_path: pathlib.Path) -> None:
     """Test execute verbose."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd.config')
@@ -369,6 +388,7 @@ def test_execute_verbose(tmp_path: pathlib.Path) -> None:
     _validate_ocp(tmp_path)
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_missing_heading(tmp_path: pathlib.Path) -> None:
     """Test execute missing heading."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd.config')
@@ -384,6 +404,7 @@ def test_execute_missing_heading(tmp_path: pathlib.Path) -> None:
         assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_case_insensitive_heading(tmp_path: pathlib.Path) -> None:
     """Test execute case insensitive heading."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd.config')
@@ -402,6 +423,7 @@ def test_execute_case_insensitive_heading(tmp_path: pathlib.Path) -> None:
         _validate_ocp(tmp_path)
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_missing_value(tmp_path: pathlib.Path) -> None:
     """Test execute missing value."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd.config')
@@ -417,6 +439,7 @@ def test_execute_missing_value(tmp_path: pathlib.Path) -> None:
         assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_missing_rule_id(tmp_path: pathlib.Path) -> None:
     """Test execute missing rule id."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd.config')
@@ -432,6 +455,7 @@ def test_execute_missing_rule_id(tmp_path: pathlib.Path) -> None:
         assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_missing_control_id_list(tmp_path: pathlib.Path) -> None:
     """Test execute missing control id list."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd.config')
@@ -453,6 +477,7 @@ def test_execute_missing_control_id_list(tmp_path: pathlib.Path) -> None:
     assert len(component.props) == 423
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_bp_sample(tmp_path: pathlib.Path) -> None:
     """Test execute bp sample."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd-bp.config')
@@ -462,6 +487,7 @@ def test_execute_bp_sample(tmp_path: pathlib.Path) -> None:
     _validate_bp(tmp_path)
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_bp3_sample(tmp_path: pathlib.Path) -> None:
     """Test execute bp3 sample."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd-bp.config')
@@ -490,6 +516,7 @@ def test_execute_bp3_sample(tmp_path: pathlib.Path) -> None:
     assert ci.set_parameters[3].values[2] == '5'
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_bp4_sample(tmp_path: pathlib.Path) -> None:
     """Test execute bp4 sample."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd-bp.config')
@@ -563,6 +590,7 @@ def test_execute_bp4_sample(tmp_path: pathlib.Path) -> None:
     assert ci.set_parameters[index].values[2] == 't'
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_bp4_modify_additional_param_set(tmp_path: pathlib.Path) -> None:
     """Test execute bp4 modify additional param set."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd-bp.config')
@@ -610,6 +638,7 @@ def test_execute_bp4_modify_additional_param_set(tmp_path: pathlib.Path) -> None
     assert ci.set_parameters[index].values[0] == '50'
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_bp4_delete_additional_param_set(tmp_path: pathlib.Path) -> None:
     """Test execute bp4 delete additional param set."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd-bp.config')
@@ -642,6 +671,7 @@ def test_execute_bp4_delete_additional_param_set(tmp_path: pathlib.Path) -> None
     assert len(ci.set_parameters) == 7
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_bp_cd(tmp_path: pathlib.Path) -> None:
     """Test execute bp cd."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd-bp.config')
@@ -652,6 +682,7 @@ def test_execute_bp_cd(tmp_path: pathlib.Path) -> None:
     _validate_bp(tmp_path)
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_bp_cd_missing(tmp_path: pathlib.Path) -> None:
     """Test execute bp cd missing."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd-bp.config')
@@ -661,6 +692,7 @@ def test_execute_bp_cd_missing(tmp_path: pathlib.Path) -> None:
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_duplicate_rule(tmp_path: pathlib.Path) -> None:
     """Test execute duplicate rule."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd-bp.config')
@@ -675,6 +707,7 @@ def test_execute_duplicate_rule(tmp_path: pathlib.Path) -> None:
         assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_delete_rule(tmp_path: pathlib.Path) -> None:
     """Test execute delete rule."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd-bp.config')
@@ -700,6 +733,7 @@ def test_execute_delete_rule(tmp_path: pathlib.Path) -> None:
     assert component.props[0].remarks == 'rule_set_01'
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_delete_all_rules_with_params(tmp_path: pathlib.Path) -> None:
     """Test execute delete all rules with params."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd-bp.config')
@@ -726,6 +760,7 @@ def test_execute_delete_all_rules_with_params(tmp_path: pathlib.Path) -> None:
             assert prop.value != 'allowed_admins_per_account'
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_delete_rule_with_params(tmp_path: pathlib.Path) -> None:
     """Test execute delete rule with params."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd-bp.config')
@@ -749,6 +784,7 @@ def test_execute_delete_rule_with_params(tmp_path: pathlib.Path) -> None:
             assert prop.value != 'allowed_admins_per_account'
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_column_bad_data(tmp_path: pathlib.Path) -> None:
     """Test execute column bad data."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd-bp.config')
@@ -763,6 +799,7 @@ def test_execute_column_bad_data(tmp_path: pathlib.Path) -> None:
         assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_column_ignore(tmp_path: pathlib.Path) -> None:
     """Test execute column ignore."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd-bp.config')
@@ -777,6 +814,7 @@ def test_execute_column_ignore(tmp_path: pathlib.Path) -> None:
         assert retval == TaskOutcome.SUCCESS
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_add_rule(tmp_path: pathlib.Path) -> None:
     """Test execute add rule."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd-bp.config')
@@ -861,6 +899,7 @@ def test_execute_add_rule(tmp_path: pathlib.Path) -> None:
     assert len(component.control_implementations[1].set_parameters) == 1
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_param_duplicate_value(tmp_path: pathlib.Path) -> None:
     """Test execute param duplicate default value."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd-bp.config')
@@ -887,6 +926,7 @@ def test_execute_param_duplicate_value(tmp_path: pathlib.Path) -> None:
         assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_correct_rule_key(tmp_path: pathlib.Path) -> None:
     """Test execute missing value."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd.config')
@@ -915,6 +955,7 @@ def test_execute_correct_rule_key(tmp_path: pathlib.Path) -> None:
         assert unexpected_key not in tgt._csv_mgr.get_rule_keys()
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_missing_param_default_value(tmp_path: pathlib.Path) -> None:
     """Test execute missing param default_value."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd-bp.config')
@@ -931,6 +972,7 @@ def test_execute_missing_param_default_value(tmp_path: pathlib.Path) -> None:
         assert retval == TaskOutcome.SUCCESS
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_change_param_default_value(tmp_path: pathlib.Path) -> None:
     """Test execute change param default_value."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd-bp.config')
@@ -961,6 +1003,7 @@ def test_execute_change_param_default_value(tmp_path: pathlib.Path) -> None:
     assert set_parameters[0].values[0] == '20'
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_delete_param(tmp_path: pathlib.Path) -> None:
     """Test execute delete param."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd-bp.config')
@@ -991,6 +1034,7 @@ def test_execute_delete_param(tmp_path: pathlib.Path) -> None:
     assert component.props[22].remarks == 'rule_set_04'
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_delete_params(tmp_path: pathlib.Path) -> None:
     """Test execute delete params."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd-bp.config')
@@ -1015,6 +1059,7 @@ def test_execute_delete_params(tmp_path: pathlib.Path) -> None:
         assert prop.name != 'Parameter_Id'
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_add_param(tmp_path: pathlib.Path) -> None:
     """Test execute add param."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd-bp.config')
@@ -1054,6 +1099,7 @@ def test_execute_add_param(tmp_path: pathlib.Path) -> None:
     assert set_parameters[4].values[0] == 'add-parameter-default-value'
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_delete_all_control_id_list(tmp_path: pathlib.Path) -> None:
     """Test execute delete all control id list."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd-bp.config')
@@ -1075,6 +1121,7 @@ def test_execute_delete_all_control_id_list(tmp_path: pathlib.Path) -> None:
         assert len(cd.components) == 0
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_delete_control_id(tmp_path: pathlib.Path) -> None:
     """Test execute delete control id."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd-bp.config')
@@ -1100,6 +1147,7 @@ def test_execute_delete_control_id(tmp_path: pathlib.Path) -> None:
     assert implemented_requirements[4].control_id == 'ac-6'
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_delete_control_id_multi(tmp_path: pathlib.Path) -> None:
     """Test execute delete control id multi."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd-bp.config')
@@ -1125,6 +1173,7 @@ def test_execute_delete_control_id_multi(tmp_path: pathlib.Path) -> None:
         assert implemented_requirement.control_id != 'ac-6'
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_delete_control_id_smt(tmp_path: pathlib.Path) -> None:
     """Test execute delete control id smt."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd-bp.config')
@@ -1152,6 +1201,7 @@ def test_execute_delete_control_id_smt(tmp_path: pathlib.Path) -> None:
     assert statements[0].statement_id == 'cm-7_smt.a'
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_add_control_id(tmp_path: pathlib.Path) -> None:
     """Test execute add control id."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd-bp.config')
@@ -1176,6 +1226,7 @@ def test_execute_add_control_id(tmp_path: pathlib.Path) -> None:
     assert implemented_requirements[21].control_id == 'ld-0'
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_add_control_id_smt(tmp_path: pathlib.Path) -> None:
     """Test execute add control mapping smt."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd-bp.config')
@@ -1206,6 +1257,7 @@ def test_execute_add_control_id_smt(tmp_path: pathlib.Path) -> None:
     assert statement.props[0].value == 'account_owner_authorized_ip_range_configured'
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_delete_property(tmp_path: pathlib.Path) -> None:
     """Test execute delete property."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd-bp.config')
@@ -1232,6 +1284,7 @@ def test_execute_delete_property(tmp_path: pathlib.Path) -> None:
     assert component.props[2].name == 'Reference_Id'
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_add_property(tmp_path: pathlib.Path) -> None:
     """Test execute add property."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd-bp.config')
@@ -1264,6 +1317,7 @@ def test_execute_add_property(tmp_path: pathlib.Path) -> None:
     assert component.props[6].value == 'add-fetcher-description'
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_with_risk_properties(tmp_path: pathlib.Path) -> None:
     """Test execute with risk properties."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd-bp.config')
@@ -1305,6 +1359,7 @@ def test_execute_with_risk_properties(tmp_path: pathlib.Path) -> None:
     assert component.props[6].value == 'add-risk-adjustment'
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_with_ignored_risk_properties(tmp_path: pathlib.Path) -> None:
     """Test execute with ignored risk properties when component type is validation."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd-bp.config')
@@ -1345,6 +1400,7 @@ def test_execute_with_ignored_risk_properties(tmp_path: pathlib.Path) -> None:
         assert prop.name != 'Risk_Adjustment'
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_rule_name_overlap(tmp_path: pathlib.Path) -> None:
     """Test execute rule name overlap."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd-rule-name-overlap.config')
@@ -1371,6 +1427,7 @@ def test_execute_rule_name_overlap(tmp_path: pathlib.Path) -> None:
     assert component.props[15].value == 'Target-B'
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_add_user_property(tmp_path: pathlib.Path) -> None:
     """Test execute add user property."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd-bp.config')
@@ -1396,6 +1453,7 @@ def test_execute_add_user_property(tmp_path: pathlib.Path) -> None:
     assert component.props[5].value == 'new-column-value-2'
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_validation(tmp_path: pathlib.Path) -> None:
     """Test execute validation."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd-bp.config')
@@ -1447,6 +1505,7 @@ def test_execute_validation(tmp_path: pathlib.Path) -> None:
     assert len(component.control_implementations) == 0
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute_invalid_set_parameter_values(tmp_path: pathlib.Path) -> None:
     """Test execute invalid set parameter (PARAMETER_ID, Parameter_Value_Default) values."""
     _, section = _get_config_section_init(tmp_path, 'test-csv-to-oscal-cd-bp.config')
@@ -1469,6 +1528,7 @@ def test_execute_invalid_set_parameter_values(tmp_path: pathlib.Path) -> None:
         )
 
 
+@set_cwd_unsafe(root_dir)
 def test_row_property_builder(tmp_path):
     """Test row property builder."""
     # valid

--- a/tests/trestle/tasks/ocp4_cis_profile_to_oscal_catalog_test.py
+++ b/tests/trestle/tasks/ocp4_cis_profile_to_oscal_catalog_test.py
@@ -20,9 +20,13 @@ import pathlib
 
 from _pytest.monkeypatch import MonkeyPatch
 
+from tests.test_utils import TEST_DIR, set_cwd_unsafe
+
 import trestle.tasks.ocp4_cis_profile_to_oscal_catalog as ocp4_cis_profile_to_oscal_catalog
 from trestle.oscal.catalog import Catalog
 from trestle.tasks.base_task import TaskOutcome
+
+root_dir = TEST_DIR / '../'
 
 
 def monkey_exception():
@@ -36,6 +40,7 @@ def monkey_get_filelist(self, idir):
     return filelist
 
 
+@set_cwd_unsafe(root_dir)
 def test_ocp4_cis_profile_to_oscal_catalog_print_info(tmp_path: pathlib.Path):
     """Test print_info call."""
     config = configparser.ConfigParser()
@@ -50,6 +55,7 @@ def test_ocp4_cis_profile_to_oscal_catalog_print_info(tmp_path: pathlib.Path):
     assert retval is None
 
 
+@set_cwd_unsafe(root_dir)
 def test_ocp4_cis_profile_to_oscal_catalog_simulate(tmp_path: pathlib.Path):
     """Test simulate call."""
     config = configparser.ConfigParser()
@@ -65,6 +71,7 @@ def test_ocp4_cis_profile_to_oscal_catalog_simulate(tmp_path: pathlib.Path):
     assert len(os.listdir(str(tmp_path))) == 0
 
 
+@set_cwd_unsafe(root_dir)
 def test_ocp4_cis_profile_to_oscal_catalog_execute(tmp_path: pathlib.Path):
     """Test execute call."""
     config = configparser.ConfigParser()
@@ -107,6 +114,7 @@ def _validate(tmp_path: pathlib.Path):
     assert group.controls[1].title == '2.2 Ensure that the --client-cert-auth argument is set to true'
 
 
+@set_cwd_unsafe(root_dir)
 def test_ocp4_cis_profile_to_oscal_catalog_config_missing(tmp_path: pathlib.Path):
     """Test config missing."""
     section = None
@@ -115,6 +123,7 @@ def test_ocp4_cis_profile_to_oscal_catalog_config_missing(tmp_path: pathlib.Path
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_ocp4_cis_profile_to_oscal_catalog_config_missing_key(tmp_path: pathlib.Path):
     """Test config missing key."""
     config = configparser.ConfigParser()
@@ -129,6 +138,7 @@ def test_ocp4_cis_profile_to_oscal_catalog_config_missing_key(tmp_path: pathlib.
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_ocp4_cis_profile_to_oscal_catalog_exception(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch):
     """Test _parse exception."""
     monkeypatch.setattr(ocp4_cis_profile_to_oscal_catalog.Ocp4CisProfileToOscalCatalog, '_parse', monkey_exception)
@@ -144,6 +154,7 @@ def test_ocp4_cis_profile_to_oscal_catalog_exception(tmp_path: pathlib.Path, mon
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_ocp4_cis_profile_to_oscal_catalog_no_overwrite(tmp_path: pathlib.Path):
     """Test no overwrite."""
     config = configparser.ConfigParser()
@@ -161,6 +172,7 @@ def test_ocp4_cis_profile_to_oscal_catalog_no_overwrite(tmp_path: pathlib.Path):
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_ocp4_cis_profile_to_oscal_catalog_no_input(tmp_path: pathlib.Path):
     """Test no input."""
     config = configparser.ConfigParser()
@@ -178,6 +190,7 @@ def test_ocp4_cis_profile_to_oscal_catalog_no_input(tmp_path: pathlib.Path):
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_ocp4_cis_profile_to_oscal_catalog_no_file(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch):
     """Test no file."""
     monkeypatch.setattr(
@@ -194,6 +207,7 @@ def test_ocp4_cis_profile_to_oscal_catalog_no_file(tmp_path: pathlib.Path, monke
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_ocp4_cis_profile_to_oscal_catalog_input_bogus(tmp_path: pathlib.Path):
     """Test no input."""
     config = configparser.ConfigParser()

--- a/tests/trestle/tasks/ocp4_cis_profile_to_oscal_cd_test.py
+++ b/tests/trestle/tasks/ocp4_cis_profile_to_oscal_cd_test.py
@@ -21,11 +21,13 @@ import uuid
 
 from _pytest.monkeypatch import MonkeyPatch
 
-from tests.test_utils import text_files_equal
+from tests.test_utils import TEST_DIR, set_cwd_unsafe, text_files_equal
 
 import trestle
 import trestle.tasks.ocp4_cis_profile_to_oscal_cd as ocp4_cis_profile_to_oscal_cd
 from trestle.tasks.base_task import TaskOutcome
+
+root_dir = TEST_DIR / '../'
 
 
 def monkey_uuid_1():
@@ -43,6 +45,7 @@ def monkey_trestle_version():
     return '0.21.0'
 
 
+@set_cwd_unsafe(root_dir)
 def test_ocp4_cis_profile_to_oscal_cd_print_info(tmp_path: pathlib.Path):
     """Test print_info call."""
     config = configparser.ConfigParser()
@@ -55,6 +58,7 @@ def test_ocp4_cis_profile_to_oscal_cd_print_info(tmp_path: pathlib.Path):
     assert retval is None
 
 
+@set_cwd_unsafe(root_dir)
 def test_ocp4_cis_profile_to_oscal_cd_simulate(tmp_path: pathlib.Path):
     """Test simulate call."""
     config = configparser.ConfigParser()
@@ -68,6 +72,7 @@ def test_ocp4_cis_profile_to_oscal_cd_simulate(tmp_path: pathlib.Path):
     assert len(os.listdir(str(tmp_path))) == 0
 
 
+@set_cwd_unsafe(root_dir)
 def test_ocp4_cis_profile_to_oscal_cd_execute(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch):
     """Test execute call."""
     monkeypatch.setattr(uuid, 'uuid4', monkey_uuid_1)
@@ -93,6 +98,7 @@ def test_ocp4_cis_profile_to_oscal_cd_execute(tmp_path: pathlib.Path, monkeypatc
         assert result
 
 
+@set_cwd_unsafe(root_dir)
 def test_ocp4_cis_profile_to_oscal_cd_execute_selected_rules2(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch):
     """Test execute selected rules call."""
     monkeypatch.setattr(uuid, 'uuid4', monkey_uuid_1)
@@ -119,6 +125,7 @@ def test_ocp4_cis_profile_to_oscal_cd_execute_selected_rules2(tmp_path: pathlib.
         assert result
 
 
+@set_cwd_unsafe(root_dir)
 def test_ocp4_cis_profile_to_oscal_cd_execute_enabled_rules2(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch):
     """Test execute enabled rules call."""
     monkeypatch.setattr(uuid, 'uuid4', monkey_uuid_1)
@@ -145,6 +152,7 @@ def test_ocp4_cis_profile_to_oscal_cd_execute_enabled_rules2(tmp_path: pathlib.P
         assert result
 
 
+@set_cwd_unsafe(root_dir)
 def test_ocp4_cis_profile_to_oscal_cd_execute_enabled_rules3(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch):
     """Test execute enabled rules call."""
     monkeypatch.setattr(uuid, 'uuid4', monkey_uuid_1)
@@ -166,6 +174,7 @@ def test_ocp4_cis_profile_to_oscal_cd_execute_enabled_rules3(tmp_path: pathlib.P
     assert d_expected != d_produced
 
 
+@set_cwd_unsafe(root_dir)
 def test_ocp4_cis_profile_to_oscal_cd_bogus_config(tmp_path: pathlib.Path):
     """Test execute call bogus config."""
     section = None
@@ -174,6 +183,7 @@ def test_ocp4_cis_profile_to_oscal_cd_bogus_config(tmp_path: pathlib.Path):
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_ocp4_cis_profile_to_oscal_cd_missing_profile_list(tmp_path: pathlib.Path):
     """Test execute call missing profile-list."""
     config = configparser.ConfigParser()
@@ -187,6 +197,7 @@ def test_ocp4_cis_profile_to_oscal_cd_missing_profile_list(tmp_path: pathlib.Pat
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_ocp4_cis_profile_to_oscal_cd_missing_component_name(tmp_path: pathlib.Path):
     """Test execute call missing component-name."""
     config = configparser.ConfigParser()
@@ -200,6 +211,7 @@ def test_ocp4_cis_profile_to_oscal_cd_missing_component_name(tmp_path: pathlib.P
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_ocp4_cis_profile_to_oscal_cd_missing_profile_type(tmp_path: pathlib.Path):
     """Test execute call missing profile-type."""
     config = configparser.ConfigParser()
@@ -213,6 +225,7 @@ def test_ocp4_cis_profile_to_oscal_cd_missing_profile_type(tmp_path: pathlib.Pat
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_ocp4_cis_profile_to_oscal_cd_missing_profile_ns(tmp_path: pathlib.Path):
     """Test execute call missing profile-ns."""
     config = configparser.ConfigParser()
@@ -226,6 +239,7 @@ def test_ocp4_cis_profile_to_oscal_cd_missing_profile_ns(tmp_path: pathlib.Path)
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_ocp4_cis_profile_to_oscal_cd_missing_profile_key(tmp_path: pathlib.Path):
     """Test execute missing profile-file."""
     config = configparser.ConfigParser()
@@ -241,6 +255,7 @@ def test_ocp4_cis_profile_to_oscal_cd_missing_profile_key(tmp_path: pathlib.Path
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_ocp4_cis_profile_to_oscal_cd_missing_profile_file(tmp_path: pathlib.Path):
     """Test execute missing profile-file."""
     config = configparser.ConfigParser()
@@ -256,6 +271,7 @@ def test_ocp4_cis_profile_to_oscal_cd_missing_profile_file(tmp_path: pathlib.Pat
     assert retval == TaskOutcome.SUCCESS
 
 
+@set_cwd_unsafe(root_dir)
 def test_ocp4_cis_profile_to_oscal_cd_missing_profile_url(tmp_path: pathlib.Path):
     """Test execute missinf profile-url."""
     config = configparser.ConfigParser()
@@ -271,6 +287,7 @@ def test_ocp4_cis_profile_to_oscal_cd_missing_profile_url(tmp_path: pathlib.Path
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_ocp4_cis_profile_to_oscal_cd_missing_profile_title(tmp_path: pathlib.Path):
     """Test execute call missing profile-title."""
     config = configparser.ConfigParser()
@@ -286,6 +303,7 @@ def test_ocp4_cis_profile_to_oscal_cd_missing_profile_title(tmp_path: pathlib.Pa
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_ocp4_cis_profile_to_oscal_cd_missing_output_dir(tmp_path: pathlib.Path):
     """Test execute call missing output-dir."""
     config = configparser.ConfigParser()
@@ -298,6 +316,7 @@ def test_ocp4_cis_profile_to_oscal_cd_missing_output_dir(tmp_path: pathlib.Path)
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_ocp4_cis_profile_to_oscal_cd_no_overwrite(tmp_path: pathlib.Path):
     """Test execute no overwrite."""
     config = configparser.ConfigParser()
@@ -313,6 +332,7 @@ def test_ocp4_cis_profile_to_oscal_cd_no_overwrite(tmp_path: pathlib.Path):
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_ocp4_cis_profile_to_oscal_cd_duplicate_rule(tmp_path: pathlib.Path):
     """Test execute duplicate rule exists."""
     config = configparser.ConfigParser()
@@ -330,6 +350,7 @@ def test_ocp4_cis_profile_to_oscal_cd_duplicate_rule(tmp_path: pathlib.Path):
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_ocp4_cis_profile_to_oscal_cd_exception(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch):
     """Test _get_cis_rules exception."""
     monkeypatch.setattr(ocp4_cis_profile_to_oscal_cd.Ocp4CisProfileToOscalCD, '_get_cis_rules', monkey_exception)
@@ -345,6 +366,7 @@ def test_ocp4_cis_profile_to_oscal_cd_exception(tmp_path: pathlib.Path, monkeypa
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_ocp4_cis_profile_to_oscal_cd_missing_rules_section(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch):
     """Test missing section selected-rules."""
     monkeypatch.setattr(ocp4_cis_profile_to_oscal_cd.Ocp4CisProfileToOscalCD, '_get_cis_rules', monkey_exception)
@@ -361,6 +383,7 @@ def test_ocp4_cis_profile_to_oscal_cd_missing_rules_section(tmp_path: pathlib.Pa
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_ocp4_cis_profile_to_oscal_cd_missing_rules_file(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch):
     """Test missing file enabled-rules."""
     monkeypatch.setattr(ocp4_cis_profile_to_oscal_cd.Ocp4CisProfileToOscalCD, '_get_cis_rules', monkey_exception)
@@ -377,6 +400,7 @@ def test_ocp4_cis_profile_to_oscal_cd_missing_rules_file(tmp_path: pathlib.Path,
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_ocp4_cis_profile_to_oscal_cd_missing_parameters_key(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch):
     """Test missing file enabled-rules."""
     monkeypatch.setattr(ocp4_cis_profile_to_oscal_cd.Ocp4CisProfileToOscalCD, '_get_cis_rules', monkey_exception)
@@ -393,6 +417,7 @@ def test_ocp4_cis_profile_to_oscal_cd_missing_parameters_key(tmp_path: pathlib.P
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_ocp4_cis_profile_to_oscal_cd_missing_parameters_file(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch):
     """Test missing file enabled-rules."""
     monkeypatch.setattr(ocp4_cis_profile_to_oscal_cd.Ocp4CisProfileToOscalCD, '_get_cis_rules', monkey_exception)
@@ -409,6 +434,7 @@ def test_ocp4_cis_profile_to_oscal_cd_missing_parameters_file(tmp_path: pathlib.
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_ocp4_cis_profile_to_oscal_cd_bogus_rules_file(tmp_path: pathlib.Path):
     """Test bogus rules."""
     config = configparser.ConfigParser()

--- a/tests/trestle/tasks/oscal_catalog_to_csv_test.py
+++ b/tests/trestle/tasks/oscal_catalog_to_csv_test.py
@@ -22,6 +22,7 @@ from typing import Dict, List
 from _pytest.monkeypatch import MonkeyPatch
 
 from tests import test_utils
+from tests.test_utils import TEST_DIR, set_cwd_unsafe
 
 import trestle.tasks.oscal_catalog_to_csv as oscal_catalog_to_csv
 from trestle.core.catalog.catalog_interface import CatalogInterface
@@ -32,6 +33,8 @@ CONFIG_BY_CONTROL = 'test-oscal-catalog-to-csv-rev-5-by-control.config'
 CONFIG_BY_STATEMENT = 'test-oscal-catalog-to-csv-rev-5-by-statement.config'
 
 CONFIG_LIST = [f'{CONFIG_BY_CONTROL}', f'{CONFIG_BY_STATEMENT}']
+
+root_dir = TEST_DIR / '../'
 
 
 def monkey_exception():
@@ -110,6 +113,7 @@ def _get_config_section_init(tmp_path: pathlib.Path, fname: str) -> tuple:
     return _get_config_section(tmp_path, fname)
 
 
+@set_cwd_unsafe(root_dir)
 def test_print_info(tmp_path: pathlib.Path) -> None:
     """Test print_info."""
     for config in CONFIG_LIST:
@@ -119,6 +123,7 @@ def test_print_info(tmp_path: pathlib.Path) -> None:
         assert retval is None
 
 
+@set_cwd_unsafe(root_dir)
 def test_missing_section(tmp_path: pathlib.Path):
     """Test missing section."""
     section = None
@@ -127,6 +132,7 @@ def test_missing_section(tmp_path: pathlib.Path):
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_missing_input(tmp_path: pathlib.Path):
     """Test missing input."""
     for config in CONFIG_LIST:
@@ -137,6 +143,7 @@ def test_missing_input(tmp_path: pathlib.Path):
         assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_missing_output(tmp_path: pathlib.Path):
     """Test missing output."""
     for config in CONFIG_LIST:
@@ -147,6 +154,7 @@ def test_missing_output(tmp_path: pathlib.Path):
         assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_bogus_level(tmp_path: pathlib.Path):
     """Test bogus level."""
     for config in CONFIG_LIST:
@@ -157,6 +165,7 @@ def test_bogus_level(tmp_path: pathlib.Path):
         assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_simulate(tmp_path: pathlib.Path):
     """Test execute."""
     for config in CONFIG_LIST:
@@ -167,6 +176,7 @@ def test_simulate(tmp_path: pathlib.Path):
         assert retval == TaskOutcome.SIM_SUCCESS
 
 
+@set_cwd_unsafe(root_dir)
 def test_execute(tmp_path: pathlib.Path):
     """Test execute."""
     for config in CONFIG_LIST:
@@ -179,6 +189,7 @@ def test_execute(tmp_path: pathlib.Path):
         _validate(config, section)
 
 
+@set_cwd_unsafe(root_dir)
 def test_no_overwrite(tmp_path: pathlib.Path):
     """Test no overwrite."""
     for config in CONFIG_LIST:
@@ -192,6 +203,7 @@ def test_no_overwrite(tmp_path: pathlib.Path):
         assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_exception(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch):
     """Test exception."""
     monkeypatch.setattr(oscal_catalog_to_csv.CsvHelper, 'write', monkey_exception)
@@ -203,6 +215,7 @@ def test_exception(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch):
         assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_join():
     """Test join."""
     oscal_catalog_to_csv.join_str(None, None)
@@ -211,6 +224,7 @@ def test_join():
     oscal_catalog_to_csv.join_str('x', 'y')
 
 
+@set_cwd_unsafe(root_dir)
 def test_derive_id(tmp_path: pathlib.Path):
     """Test derive_id."""
     for config in CONFIG_LIST:
@@ -223,6 +237,7 @@ def test_derive_id(tmp_path: pathlib.Path):
             catalog_helper._derive_id(id_)
 
 
+@set_cwd_unsafe(root_dir)
 def test_unresolved_param(tmp_path: pathlib.Path):
     """Test unresolved param."""
     for config in CONFIG_LIST:
@@ -239,6 +254,7 @@ def test_unresolved_param(tmp_path: pathlib.Path):
                 break
 
 
+@set_cwd_unsafe(root_dir)
 def test_one_choice(tmp_path: pathlib.Path):
     """Test one choice."""
     for config in CONFIG_LIST:
@@ -255,6 +271,7 @@ def test_one_choice(tmp_path: pathlib.Path):
                         return
 
 
+@set_cwd_unsafe(root_dir)
 def test_duplicate(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch):
     """Test duplicate."""
     monkeypatch.setattr(CatalogInterface, 'get_dependent_control_ids', monkey_get_dependent_control_ids)

--- a/tests/trestle/tasks/oscal_profile_to_osco_profile_test.py
+++ b/tests/trestle/tasks/oscal_profile_to_osco_profile_test.py
@@ -21,12 +21,14 @@ import pathlib
 
 from ruamel.yaml import YAML
 
-from tests.test_utils import text_files_equal
+from tests.test_utils import TEST_DIR, set_cwd_unsafe, text_files_equal
 
 import trestle.tasks.oscal_profile_to_osco_profile as oscal_profile_to_osco_profile
 from trestle.oscal.profile import Profile
 from trestle.tasks.base_task import TaskOutcome
 from trestle.transforms.implementations.osco import OscalProfileToOscoProfileTransformer
+
+root_dir = TEST_DIR / '../'
 
 
 def setup_config(path: str):
@@ -37,6 +39,7 @@ def setup_config(path: str):
     return config
 
 
+@set_cwd_unsafe(root_dir)
 def test_oscal_profile_to_osco_profile_print_info(tmp_path):
     """Test print_info call."""
     config = setup_config('tests/data/tasks/oscal-profile-to-osco-profile/oscal-profile-to-osco-profile.config')
@@ -47,6 +50,7 @@ def test_oscal_profile_to_osco_profile_print_info(tmp_path):
     assert retval is None
 
 
+@set_cwd_unsafe(root_dir)
 def test_oscal_profile_to_osco_profile_simulate(tmp_path):
     """Test simulate call."""
     config = setup_config('tests/data/tasks/oscal-profile-to-osco-profile/oscal-profile-to-osco-profile.config')
@@ -58,12 +62,14 @@ def test_oscal_profile_to_osco_profile_simulate(tmp_path):
     assert len(os.listdir(str(tmp_path))) == 0
 
 
+@set_cwd_unsafe(root_dir)
 def test_oscal_profile_to_osco_profile_execute(tmp_path):
     """Test execute call."""
     config = setup_config('tests/data/tasks/oscal-profile-to-osco-profile/oscal-profile-to-osco-profile.config')
     _test_oscal_profile_to_osco_profile_execute_common(tmp_path, config)
 
 
+@set_cwd_unsafe(root_dir)
 def test_oscal_profile_to_osco_profile_execute_osco_0_1_39_parms_no(tmp_path):
     """Test execute call."""
     config = setup_config(
@@ -72,6 +78,7 @@ def test_oscal_profile_to_osco_profile_execute_osco_0_1_39_parms_no(tmp_path):
     _test_oscal_profile_to_osco_profile_execute_common(tmp_path, config)
 
 
+@set_cwd_unsafe(root_dir)
 def test_oscal_profile_to_osco_profile_execute_osco_0_1_39_parms_yes(tmp_path):
     """Test execute call."""
     config = setup_config(
@@ -80,6 +87,7 @@ def test_oscal_profile_to_osco_profile_execute_osco_0_1_39_parms_yes(tmp_path):
     _test_oscal_profile_to_osco_profile_execute_common(tmp_path, config)
 
 
+@set_cwd_unsafe(root_dir)
 def test_oscal_profile_to_osco_profile_execute_osco_0_1_40_parms_no(tmp_path):
     """Test execute call."""
     config = setup_config(
@@ -88,6 +96,7 @@ def test_oscal_profile_to_osco_profile_execute_osco_0_1_40_parms_no(tmp_path):
     _test_oscal_profile_to_osco_profile_execute_common(tmp_path, config)
 
 
+@set_cwd_unsafe(root_dir)
 def test_oscal_profile_to_osco_profile_execute_osco_0_1_40_parms_yes(tmp_path):
     """Test execute call."""
     config = setup_config(
@@ -96,6 +105,7 @@ def test_oscal_profile_to_osco_profile_execute_osco_0_1_40_parms_yes(tmp_path):
     _test_oscal_profile_to_osco_profile_execute_common(tmp_path, config)
 
 
+@set_cwd_unsafe(root_dir)
 def test_oscal_profile_to_osco_profile_execute_osco_0_2_0_parms_no(tmp_path):
     """Test execute call."""
     config = setup_config(
@@ -104,6 +114,7 @@ def test_oscal_profile_to_osco_profile_execute_osco_0_2_0_parms_no(tmp_path):
     _test_oscal_profile_to_osco_profile_execute_common(tmp_path, config)
 
 
+@set_cwd_unsafe(root_dir)
 def test_oscal_profile_to_osco_profile_execute_osco_1_0_0_parms_yes(tmp_path):
     """Test execute call."""
     config = setup_config(
@@ -112,6 +123,7 @@ def test_oscal_profile_to_osco_profile_execute_osco_1_0_0_parms_yes(tmp_path):
     _test_oscal_profile_to_osco_profile_execute_common(tmp_path, config)
 
 
+@set_cwd_unsafe(root_dir)
 def test_oscal_profile_to_osco_profile_execute_osco_parms_no(tmp_path):
     """Test execute call."""
     config = setup_config(
@@ -120,6 +132,7 @@ def test_oscal_profile_to_osco_profile_execute_osco_parms_no(tmp_path):
     _test_oscal_profile_to_osco_profile_execute_common(tmp_path, config)
 
 
+@set_cwd_unsafe(root_dir)
 def test_oscal_profile_to_osco_profile_execute_osco_parms_yes(tmp_path):
     """Test execute call."""
     config = setup_config(
@@ -128,6 +141,7 @@ def test_oscal_profile_to_osco_profile_execute_osco_parms_yes(tmp_path):
     _test_oscal_profile_to_osco_profile_execute_common(tmp_path, config)
 
 
+@set_cwd_unsafe(root_dir)
 def test_oscal_profile_to_osco_profile_execute_osco_scc(tmp_path):
     """Test execute call."""
     config = setup_config('tests/data/tasks/oscal-profile-to-osco-profile/oscal-profile-to-osco-profile-scc.config')
@@ -156,6 +170,7 @@ def _test_oscal_profile_to_osco_profile_execute_common(tmp_path, config):
         assert result
 
 
+@set_cwd_unsafe(root_dir)
 def test_oscal_profile_to_osco_profile_execute_bogus_profile(tmp_path):
     """Test execute call bogus profile."""
     config = setup_config('tests/data/tasks/oscal-profile-to-osco-profile/oscal-profile-to-osco-profile-bogus.config')
@@ -166,6 +181,7 @@ def test_oscal_profile_to_osco_profile_execute_bogus_profile(tmp_path):
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_oscal_profile_to_osco_profile_execute_bogus_config(tmp_path):
     """Test execute call bogus config."""
     section = None
@@ -174,6 +190,7 @@ def test_oscal_profile_to_osco_profile_execute_bogus_config(tmp_path):
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_oscal_profile_to_osco_profile_execute_no_input_file(tmp_path):
     """Test execute call no input file."""
     config = setup_config(
@@ -186,6 +203,7 @@ def test_oscal_profile_to_osco_profile_execute_no_input_file(tmp_path):
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_oscal_profile_to_osco_profile_execute_no_output_dir(tmp_path):
     """Test execute call no output file."""
     config = setup_config(
@@ -197,6 +215,7 @@ def test_oscal_profile_to_osco_profile_execute_no_output_dir(tmp_path):
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_oscal_profile_to_osco_profile_execute_no_overwrite(tmp_path):
     """Test execute call no overwrite."""
     config = setup_config(
@@ -224,6 +243,7 @@ def test_oscal_profile_to_osco_profile_execute_no_overwrite(tmp_path):
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_oscal_profile_to_osco_profile_execute_set(tmp_path):
     """Test execute call with set variables."""
     config = setup_config('tests/data/tasks/oscal-profile-to-osco-profile/oscal-profile-to-osco-profile-set.config')

--- a/tests/trestle/tasks/osco_result_to_oscal_ar_test.py
+++ b/tests/trestle/tasks/osco_result_to_oscal_ar_test.py
@@ -21,11 +21,13 @@ import uuid
 
 from _pytest.monkeypatch import MonkeyPatch
 
-from tests.test_utils import text_files_equal
+from tests.test_utils import TEST_DIR, set_cwd_unsafe, text_files_equal
 
 import trestle.tasks.osco_result_to_oscal_ar as osco_result_to_oscal_ar
 import trestle.transforms.implementations.osco as osco
 from trestle.tasks.base_task import TaskOutcome
+
+root_dir = TEST_DIR / '../'
 
 
 class MonkeyBusiness():
@@ -40,14 +42,14 @@ class MonkeyBusiness():
         return uuid.UUID('46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e')
 
 
-cf01 = 'tests/data/tasks/osco/test-osco-result-to-oscal-ar.config'
-cf02 = 'tests/data/tasks/osco/test-osco-result-to-oscal-ar-compressed.config'
-cf03 = 'tests/data/tasks/osco/test-osco-result-to-oscal-ar-fetcher.config'
-cf04 = 'tests/data/tasks/osco/test-osco-result-to-oscal-ar-bad-yaml.config'
-cf05 = 'tests/data/tasks/osco/test-osco-result-to-oscal-ar-1.3.5.config'
-cf06 = 'tests/data/tasks/osco/test-osco-result-to-oscal-ar-xml-rhel7.config'
-cf07 = 'tests/data/tasks/osco/test-osco-result-to-oscal-ar-xml-ocp4.config'
-cf08 = 'tests/data/tasks/osco/test-osco-result-to-oscal-ar-configmaps.config'
+cf01 = TEST_DIR / 'data/tasks/osco/test-osco-result-to-oscal-ar.config'
+cf02 = TEST_DIR / 'data/tasks/osco/test-osco-result-to-oscal-ar-compressed.config'
+cf03 = TEST_DIR / 'data/tasks/osco/test-osco-result-to-oscal-ar-fetcher.config'
+cf04 = TEST_DIR / 'data/tasks/osco/test-osco-result-to-oscal-ar-bad-yaml.config'
+cf05 = TEST_DIR / 'data/tasks/osco/test-osco-result-to-oscal-ar-1.3.5.config'
+cf06 = TEST_DIR / 'data/tasks/osco/test-osco-result-to-oscal-ar-xml-rhel7.config'
+cf07 = TEST_DIR / 'data/tasks/osco/test-osco-result-to-oscal-ar-xml-ocp4.config'
+cf08 = TEST_DIR / 'data/tasks/osco/test-osco-result-to-oscal-ar-configmaps.config'
 
 
 def setup_config(path: str):
@@ -58,6 +60,7 @@ def setup_config(path: str):
     return config
 
 
+@set_cwd_unsafe(root_dir)
 def test_osco_print_info(tmp_path):
     """Test print_info call."""
     config = setup_config(cf01)
@@ -68,6 +71,7 @@ def test_osco_print_info(tmp_path):
     assert retval is None
 
 
+@set_cwd_unsafe(root_dir)
 def test_osco_simulate(tmp_path):
     """Test simulate call."""
     config = setup_config(cf01)
@@ -79,6 +83,7 @@ def test_osco_simulate(tmp_path):
     assert len(os.listdir(str(tmp_path))) == 0
 
 
+@set_cwd_unsafe(root_dir)
 def test_osco_simulate_compressed(tmp_path):
     """Test simulate call with compressed OSCO xml data."""
     config = setup_config(cf02)
@@ -90,6 +95,7 @@ def test_osco_simulate_compressed(tmp_path):
     assert len(os.listdir(str(tmp_path))) == 0
 
 
+@set_cwd_unsafe(root_dir)
 def test_osco_simulate_no_config(tmp_path):
     """Test simulate no config call."""
     tgt = osco_result_to_oscal_ar.OscoResultToOscalAR(None)
@@ -98,6 +104,7 @@ def test_osco_simulate_no_config(tmp_path):
     assert len(os.listdir(str(tmp_path))) == 0
 
 
+@set_cwd_unsafe(root_dir)
 def test_osco_simulate_no_overwrite(tmp_path):
     """Test simulate no overwrite call."""
     config = setup_config(cf01)
@@ -115,6 +122,7 @@ def test_osco_simulate_no_overwrite(tmp_path):
     assert len(os.listdir(str(tmp_path))) == 1
 
 
+@set_cwd_unsafe(root_dir)
 def test_osco_simulate_no_input_dir(tmp_path):
     """Test simulate with no input dir call."""
     config = setup_config(cf01)
@@ -127,6 +135,7 @@ def test_osco_simulate_no_input_dir(tmp_path):
     assert len(os.listdir(str(tmp_path))) == 0
 
 
+@set_cwd_unsafe(root_dir)
 def test_osco_simulate_no_ouput_dir(tmp_path):
     """Test simulate with no output dir call."""
     config = setup_config(cf01)
@@ -138,6 +147,7 @@ def test_osco_simulate_no_ouput_dir(tmp_path):
     assert len(os.listdir(str(tmp_path))) == 0
 
 
+@set_cwd_unsafe(root_dir)
 def test_osco_simulate_input_fetcher(tmp_path):
     """Test simulate call OSCO fetcher json data."""
     config = setup_config(cf03)
@@ -149,6 +159,7 @@ def test_osco_simulate_input_fetcher(tmp_path):
     assert len(os.listdir(str(tmp_path))) == 0
 
 
+@set_cwd_unsafe(root_dir)
 def test_osco_simulate_input_bad_yaml(tmp_path):
     """Test simulate call OSCO bad yaml data."""
     config = setup_config(cf04)
@@ -160,6 +171,7 @@ def test_osco_simulate_input_bad_yaml(tmp_path):
     assert len(os.listdir(str(tmp_path))) == 0
 
 
+@set_cwd_unsafe(root_dir)
 def test_osco_execute(tmp_path, monkeypatch: MonkeyPatch):
     """Test execute call."""
     monkeybusiness = MonkeyBusiness()
@@ -182,6 +194,7 @@ def test_osco_execute(tmp_path, monkeypatch: MonkeyPatch):
         assert result
 
 
+@set_cwd_unsafe(root_dir)
 def test_osco_execute_checking(tmp_path, monkeypatch: MonkeyPatch):
     """Test execute call."""
     monkeybusiness = MonkeyBusiness()
@@ -205,6 +218,7 @@ def test_osco_execute_checking(tmp_path, monkeypatch: MonkeyPatch):
         assert result
 
 
+@set_cwd_unsafe(root_dir)
 def test_osco_execute_1_3_5(tmp_path, monkeypatch: MonkeyPatch):
     """Test execute call."""
     monkeybusiness = MonkeyBusiness()
@@ -227,6 +241,7 @@ def test_osco_execute_1_3_5(tmp_path, monkeypatch: MonkeyPatch):
         assert result
 
 
+@set_cwd_unsafe(root_dir)
 def test_osco_execute_1_3_5_checking(tmp_path, monkeypatch: MonkeyPatch):
     """Test execute call."""
     monkeybusiness = MonkeyBusiness()
@@ -250,6 +265,7 @@ def test_osco_execute_1_3_5_checking(tmp_path, monkeypatch: MonkeyPatch):
         assert result
 
 
+@set_cwd_unsafe(root_dir)
 def test_osco_execute_compressed(tmp_path, monkeypatch: MonkeyPatch):
     """Test execute call with compressed OSCO xml data."""
     monkeybusiness = MonkeyBusiness()
@@ -272,6 +288,7 @@ def test_osco_execute_compressed(tmp_path, monkeypatch: MonkeyPatch):
         assert result
 
 
+@set_cwd_unsafe(root_dir)
 def test_osco_execute_no_config(tmp_path):
     """Test execute no config call."""
     tgt = osco_result_to_oscal_ar.OscoResultToOscalAR(None)
@@ -280,6 +297,7 @@ def test_osco_execute_no_config(tmp_path):
     assert len(os.listdir(str(tmp_path))) == 0
 
 
+@set_cwd_unsafe(root_dir)
 def test_osco_execute_no_overwrite(tmp_path, monkeypatch: MonkeyPatch):
     """Test execute no overwrite call."""
     execute_no_overwrite_part1(tmp_path, monkeypatch)
@@ -322,6 +340,7 @@ def execute_no_overwrite_part2(tmp_path, monkeypatch: MonkeyPatch):
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_osco_execute_no_input_dir(tmp_path):
     """Test execute with no input dir call."""
     config = setup_config(cf01)
@@ -334,6 +353,7 @@ def test_osco_execute_no_input_dir(tmp_path):
     assert len(os.listdir(str(tmp_path))) == 0
 
 
+@set_cwd_unsafe(root_dir)
 def test_osco_execute_no_ouput_dir(tmp_path):
     """Test execute with no output dir call."""
     config = setup_config(cf01)
@@ -345,6 +365,7 @@ def test_osco_execute_no_ouput_dir(tmp_path):
     assert len(os.listdir(str(tmp_path))) == 0
 
 
+@set_cwd_unsafe(root_dir)
 def test_osco_execute_bad_timestamp(tmp_path):
     """Test execute with bad timestamp."""
     config = setup_config(cf01)
@@ -356,6 +377,7 @@ def test_osco_execute_bad_timestamp(tmp_path):
     assert len(os.listdir(str(tmp_path))) == 0
 
 
+@set_cwd_unsafe(root_dir)
 def test_osco_execute_input_fetcher(tmp_path, monkeypatch: MonkeyPatch):
     """Test execute call OSCO fetcher json data."""
     monkeybusiness = MonkeyBusiness()
@@ -378,6 +400,7 @@ def test_osco_execute_input_fetcher(tmp_path, monkeypatch: MonkeyPatch):
         assert result
 
 
+@set_cwd_unsafe(root_dir)
 def test_osco_execute_input_xml_rhel7(tmp_path, monkeypatch: MonkeyPatch):
     """Test execute call OSCO xml data."""
     monkeybusiness = MonkeyBusiness()
@@ -400,6 +423,7 @@ def test_osco_execute_input_xml_rhel7(tmp_path, monkeypatch: MonkeyPatch):
         assert result
 
 
+@set_cwd_unsafe(root_dir)
 def test_osco_execute_input_xml_ocp4(tmp_path, monkeypatch: MonkeyPatch):
     """Test execute call OSCO xml data."""
     monkeybusiness = MonkeyBusiness()
@@ -422,6 +446,7 @@ def test_osco_execute_input_xml_ocp4(tmp_path, monkeypatch: MonkeyPatch):
         assert result
 
 
+@set_cwd_unsafe(root_dir)
 def test_osco_execute_input_configmaps(tmp_path, monkeypatch: MonkeyPatch):
     """Test execute call OSCO configmaps data."""
     monkeybusiness = MonkeyBusiness()

--- a/tests/trestle/tasks/tanium_result_to_oscal_ar_test.py
+++ b/tests/trestle/tasks/tanium_result_to_oscal_ar_test.py
@@ -20,10 +20,14 @@ import pathlib
 
 from _pytest.monkeypatch import MonkeyPatch
 
+from tests.test_utils import TEST_DIR, set_cwd_unsafe
+
 import trestle.common.const as const
 import trestle.tasks.tanium_result_to_oscal_ar as tanium_result_to_oscal_ar
 import trestle.transforms.implementations.tanium as tanium
 from trestle.tasks.base_task import TaskOutcome
+
+root_dir = TEST_DIR / '../'
 
 
 class MonkeyBusiness():
@@ -71,9 +75,10 @@ def setup_config(path: str):
     return config
 
 
-cf01 = 'tests/data/tasks/tanium/demo-tanium-result-to-oscal-ar.config'
+cf01 = TEST_DIR / 'data/tasks/tanium/demo-tanium-result-to-oscal-ar.config'
 
 
+@set_cwd_unsafe(root_dir)
 def test_tanium_print_info(tmp_path):
     """Test print_info call."""
     config = setup_config(cf01)
@@ -84,6 +89,7 @@ def test_tanium_print_info(tmp_path):
     assert retval is None
 
 
+@set_cwd_unsafe(root_dir)
 def test_tanium_simulate(tmp_path):
     """Test simulate call."""
     config = setup_config(cf01)
@@ -95,6 +101,7 @@ def test_tanium_simulate(tmp_path):
     assert len(os.listdir(str(tmp_path))) == 0
 
 
+@set_cwd_unsafe(root_dir)
 def test_tanium_simulate_no_config(tmp_path):
     """Test simulate no config call."""
     tgt = tanium_result_to_oscal_ar.TaniumResultToOscalAR(None)
@@ -103,6 +110,7 @@ def test_tanium_simulate_no_config(tmp_path):
     assert len(os.listdir(str(tmp_path))) == 0
 
 
+@set_cwd_unsafe(root_dir)
 def test_tanium_simulate_no_overwrite(tmp_path):
     """Test simulate no overwrite call."""
     config = setup_config(cf01)
@@ -120,6 +128,7 @@ def test_tanium_simulate_no_overwrite(tmp_path):
     assert len(os.listdir(str(tmp_path))) == 1
 
 
+@set_cwd_unsafe(root_dir)
 def test_tanium_simulate_no_input_dir(tmp_path):
     """Test simulate with no input dir call."""
     config = setup_config(cf01)
@@ -132,6 +141,7 @@ def test_tanium_simulate_no_input_dir(tmp_path):
     assert len(os.listdir(str(tmp_path))) == 0
 
 
+@set_cwd_unsafe(root_dir)
 def test_tanium_simulate_no_ouput_dir(tmp_path):
     """Test simulate with no output dir call."""
     config = setup_config(cf01)
@@ -143,6 +153,7 @@ def test_tanium_simulate_no_ouput_dir(tmp_path):
     assert len(os.listdir(str(tmp_path))) == 0
 
 
+@set_cwd_unsafe(root_dir)
 def test_tanium_simulate_bad_input_file(tmp_path):
     """Test simulate with bad input file call."""
     config = setup_config(cf01)
@@ -156,6 +167,7 @@ def test_tanium_simulate_bad_input_file(tmp_path):
     assert len(os.listdir(str(tmp_path))) == 0
 
 
+@set_cwd_unsafe(root_dir)
 def test_tanium_execute(tmp_path, monkeypatch: MonkeyPatch):
     """Test execute call."""
     monkeybusiness = MonkeyBusiness()
@@ -178,6 +190,7 @@ def test_tanium_execute(tmp_path, monkeypatch: MonkeyPatch):
     assert list(open(f_produced, encoding=const.FILE_ENCODING)) == list(open(f_expected, encoding=const.FILE_ENCODING))
 
 
+@set_cwd_unsafe(root_dir)
 def test_tanium_execute_checking(tmp_path, monkeypatch: MonkeyPatch):
     """Test execute call."""
     monkeybusiness = MonkeyBusiness()
@@ -201,6 +214,7 @@ def test_tanium_execute_checking(tmp_path, monkeypatch: MonkeyPatch):
     assert list(open(f_produced, encoding=const.FILE_ENCODING)) == list(open(f_expected, encoding=const.FILE_ENCODING))
 
 
+@set_cwd_unsafe(root_dir)
 def test_tanium_execute_one_file(tmp_path, monkeypatch: MonkeyPatch):
     """Test execute call."""
     monkeybusiness = MonkeyBusiness()
@@ -219,6 +233,7 @@ def test_tanium_execute_one_file(tmp_path, monkeypatch: MonkeyPatch):
     assert len(os.listdir(str(tmp_path))) == 1
 
 
+@set_cwd_unsafe(root_dir)
 def test_tanium_execute_blocksize(tmp_path, monkeypatch: MonkeyPatch):
     """Test execute optional call."""
     monkeybusiness = MonkeyBusiness()
@@ -237,6 +252,7 @@ def test_tanium_execute_blocksize(tmp_path, monkeypatch: MonkeyPatch):
     assert retval == TaskOutcome.SUCCESS
 
 
+@set_cwd_unsafe(root_dir)
 def test_tanium_execute_cpus(tmp_path, monkeypatch: MonkeyPatch):
     """Test execute optional call."""
     monkeybusiness = MonkeyBusiness()
@@ -255,6 +271,7 @@ def test_tanium_execute_cpus(tmp_path, monkeypatch: MonkeyPatch):
     assert retval == TaskOutcome.SUCCESS
 
 
+@set_cwd_unsafe(root_dir)
 def test_tanium_execute_no_config(tmp_path):
     """Test execute no config call."""
     tgt = tanium_result_to_oscal_ar.TaniumResultToOscalAR(None)
@@ -263,6 +280,7 @@ def test_tanium_execute_no_config(tmp_path):
     assert len(os.listdir(str(tmp_path))) == 0
 
 
+@set_cwd_unsafe(root_dir)
 def test_tanium_execute_no_overwrite_dir(tmp_path, monkeypatch: MonkeyPatch):
     """Test execute no overwrite directory call."""
     tanium.TaniumTransformer.set_timestamp('2021-02-24T19:31:13+00:00')
@@ -307,6 +325,7 @@ def execute_no_overwrite_dir_part2(tmp_path, monkeypatch: MonkeyPatch):
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_tanium_execute_no_input_dir(tmp_path):
     """Test execute with no input dir call."""
     config = setup_config(cf01)
@@ -319,6 +338,7 @@ def test_tanium_execute_no_input_dir(tmp_path):
     assert len(os.listdir(str(tmp_path))) == 0
 
 
+@set_cwd_unsafe(root_dir)
 def test_tanium_execute_no_ouput_dir(tmp_path):
     """Test execute with no output dir call."""
     config = setup_config(cf01)
@@ -330,6 +350,7 @@ def test_tanium_execute_no_ouput_dir(tmp_path):
     assert len(os.listdir(str(tmp_path))) == 0
 
 
+@set_cwd_unsafe(root_dir)
 def test_tanium_execute_bad_timestamp(tmp_path):
     """Test execute with bad timestamp."""
     config = setup_config(cf01)
@@ -341,6 +362,7 @@ def test_tanium_execute_bad_timestamp(tmp_path):
     assert len(os.listdir(str(tmp_path))) == 0
 
 
+@set_cwd_unsafe(root_dir)
 def test_tanium_execute_override_timestamp(tmp_path, monkeypatch: MonkeyPatch):
     """Test execute override timestamp call."""
     monkeybusiness = MonkeyBusiness()

--- a/tests/trestle/tasks/xccdf_result_to_oscal_ar_test.py
+++ b/tests/trestle/tasks/xccdf_result_to_oscal_ar_test.py
@@ -21,11 +21,13 @@ import uuid
 
 from _pytest.monkeypatch import MonkeyPatch
 
-from tests.test_utils import text_files_equal
+from tests.test_utils import TEST_DIR, set_cwd_unsafe, text_files_equal
 
 import trestle.tasks.xccdf_result_to_oscal_ar as xccdf_result_to_oscal_ar
 import trestle.transforms.implementations.xccdf as xccdf
 from trestle.tasks.base_task import TaskOutcome
+
+root_dir = TEST_DIR / '../'
 
 
 class MonkeyBusiness():
@@ -40,16 +42,16 @@ class MonkeyBusiness():
         return uuid.UUID('46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e')
 
 
-cf01 = 'tests/data/tasks/xccdf/test-xccdf-result-to-oscal-ar.config'
-cf02 = 'tests/data/tasks/xccdf/test-xccdf-result-to-oscal-ar-compressed.config'
-cf03 = 'tests/data/tasks/xccdf/test-xccdf-result-to-oscal-ar-fetcher.config'
-cf04 = 'tests/data/tasks/xccdf/test-xccdf-result-to-oscal-ar-bad-yaml.config'
-cf05 = 'tests/data/tasks/xccdf/test-xccdf-result-to-oscal-ar-1.3.5.config'
-cf06 = 'tests/data/tasks/xccdf/test-xccdf-result-to-oscal-ar-xml-rhel7.config'
-cf07 = 'tests/data/tasks/xccdf/test-xccdf-result-to-oscal-ar-xml-ocp4.config'
-cf08 = 'tests/data/tasks/xccdf/test-xccdf-result-to-oscal-ar-configmaps.config'
-cf09 = 'tests/data/tasks/xccdf/test-xccdf-result-to-oscal-ar-input-oscap-results.config'
-cf10 = 'tests/data/tasks/xccdf/test-xccdf-result-to-oscal-ar-input-oscap-arf-results.config'
+cf01 = TEST_DIR / 'data/tasks/xccdf/test-xccdf-result-to-oscal-ar.config'
+cf02 = TEST_DIR / 'data/tasks/xccdf/test-xccdf-result-to-oscal-ar-compressed.config'
+cf03 = TEST_DIR / 'data/tasks/xccdf/test-xccdf-result-to-oscal-ar-fetcher.config'
+cf04 = TEST_DIR / 'data/tasks/xccdf/test-xccdf-result-to-oscal-ar-bad-yaml.config'
+cf05 = TEST_DIR / 'data/tasks/xccdf/test-xccdf-result-to-oscal-ar-1.3.5.config'
+cf06 = TEST_DIR / 'data/tasks/xccdf/test-xccdf-result-to-oscal-ar-xml-rhel7.config'
+cf07 = TEST_DIR / 'data/tasks/xccdf/test-xccdf-result-to-oscal-ar-xml-ocp4.config'
+cf08 = TEST_DIR / 'data/tasks/xccdf/test-xccdf-result-to-oscal-ar-configmaps.config'
+cf09 = TEST_DIR / 'data/tasks/xccdf/test-xccdf-result-to-oscal-ar-input-oscap-results.config'
+cf10 = TEST_DIR / 'data/tasks/xccdf/test-xccdf-result-to-oscal-ar-input-oscap-arf-results.config'
 
 
 def setup_config(path: str):
@@ -60,6 +62,7 @@ def setup_config(path: str):
     return config
 
 
+@set_cwd_unsafe(root_dir)
 def test_xccdf_print_info(tmp_path):
     """Test print_info call."""
     config = setup_config(cf01)
@@ -70,6 +73,7 @@ def test_xccdf_print_info(tmp_path):
     assert retval is None
 
 
+@set_cwd_unsafe(root_dir)
 def test_xccdf_simulate(tmp_path):
     """Test simulate call."""
     config = setup_config(cf01)
@@ -81,6 +85,7 @@ def test_xccdf_simulate(tmp_path):
     assert len(os.listdir(str(tmp_path))) == 0
 
 
+@set_cwd_unsafe(root_dir)
 def test_xccdf_simulate_compressed(tmp_path):
     """Test simulate call with compressed OSCO xml data."""
     config = setup_config(cf02)
@@ -92,6 +97,7 @@ def test_xccdf_simulate_compressed(tmp_path):
     assert len(os.listdir(str(tmp_path))) == 0
 
 
+@set_cwd_unsafe(root_dir)
 def test_xccdf_simulate_no_config(tmp_path):
     """Test simulate no config call."""
     tgt = xccdf_result_to_oscal_ar.XccdfResultToOscalAR(None)
@@ -100,6 +106,7 @@ def test_xccdf_simulate_no_config(tmp_path):
     assert len(os.listdir(str(tmp_path))) == 0
 
 
+@set_cwd_unsafe(root_dir)
 def test_xccdf_simulate_no_overwrite(tmp_path):
     """Test simulate no overwrite call."""
     config = setup_config(cf01)
@@ -117,6 +124,7 @@ def test_xccdf_simulate_no_overwrite(tmp_path):
     assert len(os.listdir(str(tmp_path))) == 1
 
 
+@set_cwd_unsafe(root_dir)
 def test_xccdf_simulate_no_input_dir(tmp_path):
     """Test simulate with no input dir call."""
     config = setup_config(cf01)
@@ -129,6 +137,7 @@ def test_xccdf_simulate_no_input_dir(tmp_path):
     assert len(os.listdir(str(tmp_path))) == 0
 
 
+@set_cwd_unsafe(root_dir)
 def test_xccdf_simulate_no_ouput_dir(tmp_path):
     """Test simulate with no output dir call."""
     config = setup_config(cf01)
@@ -140,6 +149,7 @@ def test_xccdf_simulate_no_ouput_dir(tmp_path):
     assert len(os.listdir(str(tmp_path))) == 0
 
 
+@set_cwd_unsafe(root_dir)
 def test_xccdf_simulate_input_fetcher(tmp_path):
     """Test simulate call OSCO fetcher json data."""
     config = setup_config(cf03)
@@ -151,6 +161,7 @@ def test_xccdf_simulate_input_fetcher(tmp_path):
     assert len(os.listdir(str(tmp_path))) == 0
 
 
+@set_cwd_unsafe(root_dir)
 def test_xccdf_simulate_input_bad_yaml(tmp_path):
     """Test simulate call OSCO bad yaml data."""
     config = setup_config(cf04)
@@ -162,6 +173,7 @@ def test_xccdf_simulate_input_bad_yaml(tmp_path):
     assert len(os.listdir(str(tmp_path))) == 0
 
 
+@set_cwd_unsafe(root_dir)
 def test_xccdf_execute(tmp_path, monkeypatch: MonkeyPatch):
     """Test execute call."""
     monkeybusiness = MonkeyBusiness()
@@ -184,6 +196,7 @@ def test_xccdf_execute(tmp_path, monkeypatch: MonkeyPatch):
         assert result
 
 
+@set_cwd_unsafe(root_dir)
 def test_xccdf_execute_checking(tmp_path, monkeypatch: MonkeyPatch):
     """Test execute call."""
     monkeybusiness = MonkeyBusiness()
@@ -207,6 +220,7 @@ def test_xccdf_execute_checking(tmp_path, monkeypatch: MonkeyPatch):
         assert result
 
 
+@set_cwd_unsafe(root_dir)
 def test_xccdf_execute_1_3_5(tmp_path, monkeypatch: MonkeyPatch):
     """Test execute call."""
     monkeybusiness = MonkeyBusiness()
@@ -229,6 +243,7 @@ def test_xccdf_execute_1_3_5(tmp_path, monkeypatch: MonkeyPatch):
         assert result
 
 
+@set_cwd_unsafe(root_dir)
 def test_xccdf_execute_1_3_5_checking(tmp_path, monkeypatch: MonkeyPatch):
     """Test execute call."""
     monkeybusiness = MonkeyBusiness()
@@ -252,6 +267,7 @@ def test_xccdf_execute_1_3_5_checking(tmp_path, monkeypatch: MonkeyPatch):
         assert result
 
 
+@set_cwd_unsafe(root_dir)
 def test_xccdf_execute_compressed(tmp_path, monkeypatch: MonkeyPatch):
     """Test execute call with compressed OSCO xml data."""
     monkeybusiness = MonkeyBusiness()
@@ -274,6 +290,7 @@ def test_xccdf_execute_compressed(tmp_path, monkeypatch: MonkeyPatch):
         assert result
 
 
+@set_cwd_unsafe(root_dir)
 def test_xccdf_execute_no_config(tmp_path):
     """Test execute no config call."""
     tgt = xccdf_result_to_oscal_ar.XccdfResultToOscalAR(None)
@@ -282,6 +299,7 @@ def test_xccdf_execute_no_config(tmp_path):
     assert len(os.listdir(str(tmp_path))) == 0
 
 
+@set_cwd_unsafe(root_dir)
 def test_xccdf_execute_no_overwrite(tmp_path, monkeypatch: MonkeyPatch):
     """Test execute no overwrite call."""
     execute_no_overwrite_part1(tmp_path, monkeypatch)
@@ -324,6 +342,7 @@ def execute_no_overwrite_part2(tmp_path, monkeypatch: MonkeyPatch):
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_xccdf_execute_no_input_dir(tmp_path):
     """Test execute with no input dir call."""
     config = setup_config(cf01)
@@ -336,6 +355,7 @@ def test_xccdf_execute_no_input_dir(tmp_path):
     assert len(os.listdir(str(tmp_path))) == 0
 
 
+@set_cwd_unsafe(root_dir)
 def test_xccdf_execute_no_ouput_dir(tmp_path):
     """Test execute with no output dir call."""
     config = setup_config(cf01)
@@ -347,6 +367,7 @@ def test_xccdf_execute_no_ouput_dir(tmp_path):
     assert len(os.listdir(str(tmp_path))) == 0
 
 
+@set_cwd_unsafe(root_dir)
 def test_xccdf_execute_bad_timestamp(tmp_path):
     """Test execute with bad timestamp."""
     config = setup_config(cf01)
@@ -358,6 +379,7 @@ def test_xccdf_execute_bad_timestamp(tmp_path):
     assert len(os.listdir(str(tmp_path))) == 0
 
 
+@set_cwd_unsafe(root_dir)
 def test_xccdf_execute_input_fetcher(tmp_path, monkeypatch: MonkeyPatch):
     """Test execute call OSCO fetcher json data."""
     monkeybusiness = MonkeyBusiness()
@@ -380,6 +402,7 @@ def test_xccdf_execute_input_fetcher(tmp_path, monkeypatch: MonkeyPatch):
         assert result
 
 
+@set_cwd_unsafe(root_dir)
 def test_xccdf_execute_input_xml_rhel7(tmp_path, monkeypatch: MonkeyPatch):
     """Test execute call OSCO xml data."""
     monkeybusiness = MonkeyBusiness()
@@ -402,6 +425,7 @@ def test_xccdf_execute_input_xml_rhel7(tmp_path, monkeypatch: MonkeyPatch):
         assert result
 
 
+@set_cwd_unsafe(root_dir)
 def test_xccdf_execute_input_xml_ocp4(tmp_path, monkeypatch: MonkeyPatch):
     """Test execute call OSCO xml data."""
     monkeybusiness = MonkeyBusiness()
@@ -424,6 +448,7 @@ def test_xccdf_execute_input_xml_ocp4(tmp_path, monkeypatch: MonkeyPatch):
         assert result
 
 
+@set_cwd_unsafe(root_dir)
 def test_xccdf_execute_input_configmaps(tmp_path, monkeypatch: MonkeyPatch):
     """Test execute call OSCO configmaps data."""
     monkeybusiness = MonkeyBusiness()
@@ -446,6 +471,7 @@ def test_xccdf_execute_input_configmaps(tmp_path, monkeypatch: MonkeyPatch):
         assert result
 
 
+@set_cwd_unsafe(root_dir)
 def test_xccdf_execute_input_oscap_result(tmp_path, monkeypatch: MonkeyPatch):
     """Test OpenSCAP XCCDF to OSCAL AR."""
     monkeybusiness = MonkeyBusiness()
@@ -468,6 +494,7 @@ def test_xccdf_execute_input_oscap_result(tmp_path, monkeypatch: MonkeyPatch):
         assert result
 
 
+@set_cwd_unsafe(root_dir)
 def test_xccdf_execute_input_oscap_arf_result(tmp_path, monkeypatch: MonkeyPatch):
     """Test OpenSCAP ARF to OSCAL AR."""
     monkeybusiness = MonkeyBusiness()

--- a/tests/trestle/tasks/xlsx_to_oscal_cd_test.py
+++ b/tests/trestle/tasks/xlsx_to_oscal_cd_test.py
@@ -20,7 +20,7 @@ import pathlib
 import uuid
 from unittest.mock import Mock, patch
 
-from tests.test_utils import text_files_equal
+from tests.test_utils import TEST_DIR, set_cwd_unsafe, text_files_equal
 
 import trestle.tasks.xlsx_to_oscal_cd as xlsx_to_oscal_cd
 from trestle.tasks.base_task import TaskOutcome
@@ -28,9 +28,11 @@ from trestle.tasks.base_task import TaskOutcome
 uuid_mock1 = Mock(return_value=uuid.UUID('56666738-0f9a-4e38-9aac-c0fad00a5821'))
 get_trestle_version_mock1 = Mock(return_value='0.21.0')
 
-CONFIG_PATH = 'tests/data/tasks/xlsx/test-xlsx-to-oscal-cd.config'
+root_dir = TEST_DIR / '../'
+CONFIG_PATH = TEST_DIR / 'data/tasks/xlsx/test-xlsx-to-oscal-cd.config'
 
 
+@set_cwd_unsafe(root_dir)
 def test_xlsx_print_info(tmp_path):
     """Test print_info call."""
     config = configparser.ConfigParser()
@@ -43,6 +45,7 @@ def test_xlsx_print_info(tmp_path):
     assert retval is None
 
 
+@set_cwd_unsafe(root_dir)
 def test_xlsx_simulate(tmp_path):
     """Test simulate call."""
     config = configparser.ConfigParser()
@@ -58,6 +61,7 @@ def test_xlsx_simulate(tmp_path):
 
 @patch(target='uuid.uuid4', new=uuid_mock1)
 @patch(target='trestle.tasks.xlsx_to_oscal_cd.get_trestle_version', new=get_trestle_version_mock1)
+@set_cwd_unsafe(root_dir)
 def test_xlsx_execute(tmp_path):
     """Test execute call."""
     config = configparser.ConfigParser()
@@ -81,6 +85,7 @@ def test_xlsx_execute(tmp_path):
         assert result
 
 
+@set_cwd_unsafe(root_dir)
 def test_xlsx_execute_bogus_spread_sheet(tmp_path):
     """Test execute call bogus spread sheet."""
     config = configparser.ConfigParser()
@@ -94,6 +99,7 @@ def test_xlsx_execute_bogus_spread_sheet(tmp_path):
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_xlsx_execute_bogus_config(tmp_path):
     """Test execute call bogus config."""
     section = None
@@ -102,6 +108,7 @@ def test_xlsx_execute_bogus_config(tmp_path):
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_xlsx_execute_missing_spread_sheet(tmp_path):
     """Test execute call missing spread sheet."""
     config = configparser.ConfigParser()
@@ -115,6 +122,7 @@ def test_xlsx_execute_missing_spread_sheet(tmp_path):
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_xlsx_execute_no_overwrite(tmp_path):
     """Test execute call output already exists."""
     config = configparser.ConfigParser()
@@ -130,6 +138,7 @@ def test_xlsx_execute_no_overwrite(tmp_path):
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_xlsx_execute_embedded_blank_in_parameter_name(tmp_path):
     """Test execute call embedded blank in parameter name."""
     config = configparser.ConfigParser()
@@ -143,6 +152,7 @@ def test_xlsx_execute_embedded_blank_in_parameter_name(tmp_path):
     assert retval == TaskOutcome.SUCCESS
 
 
+@set_cwd_unsafe(root_dir)
 def test_xlsx_execute_bad_entry(tmp_path):
     """Test execute call bad entry."""
     config = configparser.ConfigParser()
@@ -156,6 +166,7 @@ def test_xlsx_execute_bad_entry(tmp_path):
     assert retval == TaskOutcome.SUCCESS
 
 
+@set_cwd_unsafe(root_dir)
 def test_xlsx_execute_missing_column_heading(tmp_path):
     """Test execute call missing column heading."""
     config = configparser.ConfigParser()
@@ -169,6 +180,7 @@ def test_xlsx_execute_missing_column_heading(tmp_path):
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_xlsx_execute_duplicate_column_heading(tmp_path):
     """Test execute call duplicate column heading."""
     config = configparser.ConfigParser()
@@ -182,6 +194,7 @@ def test_xlsx_execute_duplicate_column_heading(tmp_path):
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_xlsx_execute_missing_resource_title(tmp_path):
     """Test execute call missing resource title."""
     config = configparser.ConfigParser()
@@ -195,6 +208,7 @@ def test_xlsx_execute_missing_resource_title(tmp_path):
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_xlsx_execute_catalog_missing(tmp_path):
     """Test execute call missing catalog."""
     config = configparser.ConfigParser()
@@ -208,6 +222,7 @@ def test_xlsx_execute_catalog_missing(tmp_path):
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_xlsx_execute_catalog_not_found(tmp_path):
     """Test execute call catalog not found."""
     config = configparser.ConfigParser()
@@ -221,6 +236,7 @@ def test_xlsx_execute_catalog_not_found(tmp_path):
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_xlsx_execute_spread_sheet_missing(tmp_path):
     """Test execute call spread sheet missing."""
     config = configparser.ConfigParser()
@@ -234,6 +250,7 @@ def test_xlsx_execute_spread_sheet_missing(tmp_path):
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_xlsx_execute_spread_sheet_not_found(tmp_path):
     """Test execute call spread sheet not found."""
     config = configparser.ConfigParser()
@@ -247,6 +264,7 @@ def test_xlsx_execute_spread_sheet_not_found(tmp_path):
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_xlsx_execute_work_sheet_name_missing(tmp_path):
     """Test execute call work sheet name missing."""
     config = configparser.ConfigParser()

--- a/tests/trestle/tasks/xlsx_to_oscal_profile_test.py
+++ b/tests/trestle/tasks/xlsx_to_oscal_profile_test.py
@@ -20,7 +20,7 @@ import pathlib
 import uuid
 from unittest.mock import Mock, patch
 
-from tests.test_utils import text_files_equal
+from tests.test_utils import TEST_DIR, set_cwd_unsafe, text_files_equal
 
 import trestle.tasks.xlsx_to_oscal_profile as xlsx_to_oscal_profile
 from trestle.tasks.base_task import TaskOutcome
@@ -28,9 +28,11 @@ from trestle.tasks.base_task import TaskOutcome
 uuid_mock1 = Mock(return_value=uuid.UUID('56666738-0f9a-4e38-9aac-c0fad00a5821'))
 get_trestle_version_mock1 = Mock(return_value='0.21.0')
 
-CONFIG_PATH = pathlib.Path('tests/data/tasks/xlsx/test-xlsx-to-oscal-profile.config')
+root_dir = TEST_DIR / '../'
+CONFIG_PATH = TEST_DIR / 'data/tasks/xlsx/test-xlsx-to-oscal-profile.config'
 
 
+@set_cwd_unsafe(root_dir)
 def test_xlsx_print_info(tmp_path):
     """Test print_info call."""
     config = configparser.ConfigParser()
@@ -43,6 +45,7 @@ def test_xlsx_print_info(tmp_path):
     assert retval is None
 
 
+@set_cwd_unsafe(root_dir)
 def test_xlsx_simulate(tmp_path):
     """Test simulate call."""
     config = configparser.ConfigParser()
@@ -58,6 +61,7 @@ def test_xlsx_simulate(tmp_path):
 
 @patch(target='uuid.uuid4', new=uuid_mock1)
 @patch(target='trestle.tasks.xlsx_to_oscal_profile.get_trestle_version', new=get_trestle_version_mock1)
+@set_cwd_unsafe(root_dir)
 def test_xlsx_execute(tmp_path):
     """Test execute call."""
     config = configparser.ConfigParser()
@@ -83,6 +87,7 @@ def test_xlsx_execute(tmp_path):
 
 @patch(target='uuid.uuid4', new=uuid_mock1)
 @patch(target='trestle.tasks.xlsx_to_oscal_profile.get_trestle_version', new=get_trestle_version_mock1)
+@set_cwd_unsafe(root_dir)
 def test_xlsx_execute_with_blank_rows(tmp_path):
     """Test execute call."""
     config = configparser.ConfigParser()
@@ -109,6 +114,7 @@ def test_xlsx_execute_with_blank_rows(tmp_path):
 
 @patch(target='uuid.uuid4', new=uuid_mock1)
 @patch(target='trestle.tasks.xlsx_to_oscal_profile.get_trestle_version', new=get_trestle_version_mock1)
+@set_cwd_unsafe(root_dir)
 def test_xlsx_execute_with_missing_control_id(tmp_path):
     """Test execute call."""
     config = configparser.ConfigParser()
@@ -135,6 +141,7 @@ def test_xlsx_execute_with_missing_control_id(tmp_path):
 
 @patch(target='uuid.uuid4', new=uuid_mock1)
 @patch(target='trestle.tasks.xlsx_to_oscal_profile.get_trestle_version', new=get_trestle_version_mock1)
+@set_cwd_unsafe(root_dir)
 def test_xlsx_execute_with_missing_rule_name_id(tmp_path):
     """Test execute call."""
     config = configparser.ConfigParser()
@@ -163,6 +170,7 @@ def test_xlsx_execute_with_missing_rule_name_id(tmp_path):
 
 @patch(target='uuid.uuid4', new=uuid_mock1)
 @patch(target='trestle.tasks.xlsx_to_oscal_profile.get_trestle_version', new=get_trestle_version_mock1)
+@set_cwd_unsafe(root_dir)
 def test_xlsx_execute_filter(tmp_path):
     """Test execute filter call."""
     config = configparser.ConfigParser()
@@ -189,6 +197,7 @@ def test_xlsx_execute_filter(tmp_path):
 
 @patch(target='uuid.uuid4', new=uuid_mock1)
 @patch(target='trestle.tasks.xlsx_to_oscal_profile.get_trestle_version', new=get_trestle_version_mock1)
+@set_cwd_unsafe(root_dir)
 def test_xlsx_execute_by_control(tmp_path):
     """Test execute call."""
     config = configparser.ConfigParser()
@@ -216,6 +225,7 @@ def test_xlsx_execute_by_control(tmp_path):
 
 @patch(target='uuid.uuid4', new=uuid_mock1)
 @patch(target='trestle.tasks.xlsx_to_oscal_profile.get_trestle_version', new=get_trestle_version_mock1)
+@set_cwd_unsafe(root_dir)
 def test_xlsx_execute_by_rule(tmp_path):
     """Test execute call."""
     config = configparser.ConfigParser()
@@ -243,6 +253,7 @@ def test_xlsx_execute_by_rule(tmp_path):
 
 @patch(target='uuid.uuid4', new=uuid_mock1)
 @patch(target='trestle.tasks.xlsx_to_oscal_profile.get_trestle_version', new=get_trestle_version_mock1)
+@set_cwd_unsafe(root_dir)
 def test_xlsx_execute_by_check(tmp_path):
     """Test execute call."""
     config = configparser.ConfigParser()
@@ -268,6 +279,7 @@ def test_xlsx_execute_by_check(tmp_path):
         assert result
 
 
+@set_cwd_unsafe(root_dir)
 def test_xlsx_execute_bogus_profile_type(tmp_path):
     """Test execute call bogus spread sheet."""
     config = configparser.ConfigParser()
@@ -281,6 +293,7 @@ def test_xlsx_execute_bogus_profile_type(tmp_path):
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_xlsx_execute_bogus_spread_sheet(tmp_path):
     """Test execute call bogus spread sheet."""
     config = configparser.ConfigParser()
@@ -294,6 +307,7 @@ def test_xlsx_execute_bogus_spread_sheet(tmp_path):
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_xlsx_execute_bogus_config(tmp_path):
     """Test execute call bogus config."""
     section = None
@@ -302,6 +316,7 @@ def test_xlsx_execute_bogus_config(tmp_path):
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_xlsx_execute_missing_spread_sheet(tmp_path):
     """Test execute call missing spread sheet."""
     config = configparser.ConfigParser()
@@ -315,6 +330,7 @@ def test_xlsx_execute_missing_spread_sheet(tmp_path):
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_xlsx_execute_missing_spread_sheet_url(tmp_path):
     """Test execute call missing spread sheet url."""
     config = configparser.ConfigParser()
@@ -328,6 +344,7 @@ def test_xlsx_execute_missing_spread_sheet_url(tmp_path):
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_xlsx_execute_missing_profile_title(tmp_path):
     """Test execute call missing profile title."""
     config = configparser.ConfigParser()
@@ -341,6 +358,7 @@ def test_xlsx_execute_missing_profile_title(tmp_path):
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_xlsx_execute_no_overwrite(tmp_path):
     """Test execute call output already exists."""
     config = configparser.ConfigParser()
@@ -356,6 +374,7 @@ def test_xlsx_execute_no_overwrite(tmp_path):
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_xlsx_execute_spread_sheet_missing(tmp_path):
     """Test execute call spread sheet missing."""
     config = configparser.ConfigParser()
@@ -369,6 +388,7 @@ def test_xlsx_execute_spread_sheet_missing(tmp_path):
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_xlsx_execute_spread_sheet_not_found(tmp_path):
     """Test execute call spread sheet not found."""
     config = configparser.ConfigParser()
@@ -382,6 +402,7 @@ def test_xlsx_execute_spread_sheet_not_found(tmp_path):
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_xlsx_execute_work_sheet_name_missing(tmp_path):
     """Test execute call work sheet name missing."""
     config = configparser.ConfigParser()
@@ -395,6 +416,7 @@ def test_xlsx_execute_work_sheet_name_missing(tmp_path):
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_xlsx_execute_missing_column_heading(tmp_path):
     """Test execute call missing column heading."""
     config = configparser.ConfigParser()
@@ -408,6 +430,7 @@ def test_xlsx_execute_missing_column_heading(tmp_path):
     assert retval == TaskOutcome.FAILURE
 
 
+@set_cwd_unsafe(root_dir)
 def test_xlsx_execute_embedded_blank_in_goal_name_id(tmp_path):
     """Test execute with embedded blank in goal_name_id."""
     config = configparser.ConfigParser()
@@ -421,6 +444,7 @@ def test_xlsx_execute_embedded_blank_in_goal_name_id(tmp_path):
     assert retval == TaskOutcome.SUCCESS
 
 
+@set_cwd_unsafe(root_dir)
 def test_xlsx_execute_embedded_blank_in_rule_name_id(tmp_path):
     """Test execute with embedded blank in rule_name_id."""
     config = configparser.ConfigParser()

--- a/trestle/core/catalog/catalog_interface.py
+++ b/trestle/core/catalog/catalog_interface.py
@@ -904,5 +904,5 @@ class CatalogInterface():
         if len(dup_comp_uuids) > 0:
             # throw an exception if there are repeated component uuids
             for comp_uuid in dup_comp_uuids:
-                logger.error(f'Component uuid { comp_uuid } is duplicated')
+                logger.error(f'Component uuid {comp_uuid} is duplicated')
             raise TrestleError('Component uuids cannot be duplicated between different component definitions')

--- a/trestle/core/control_interface.py
+++ b/trestle/core/control_interface.py
@@ -109,8 +109,8 @@ class ControlInterface:
 
     @staticmethod
     def _wrap_label(label: str):
-        l_side = '\['
-        r_side = '\]'
+        l_side = r'\['
+        r_side = r'\]'
         wrapped = '' if label == '' else f'{l_side}{label}{r_side}'
         return wrapped
 

--- a/trestle/core/control_writer.py
+++ b/trestle/core/control_writer.py
@@ -66,7 +66,7 @@ class ControlWriter():
         control_title = control.title
 
         if print_group_title:
-            group_name = ' \[' + group_title + '\]'
+            group_name = r' \[' + group_title + r'\]'
 
         title = f'{control_id} -{group_name} {control_title}'
 

--- a/trestle/transforms/implementations/tanium.py
+++ b/trestle/transforms/implementations/tanium.py
@@ -110,7 +110,7 @@ class TaniumResultToOscalARTransformer(ResultsTransformer):
         results.__root__ = tanium_oscal_factory.results
         ts1 = datetime.datetime.now()
         self._analysis = tanium_oscal_factory.analysis
-        self._analysis.append(f'transform time: {ts1-ts0}')
+        self._analysis.append(f'transform time: {ts1 - ts0}')
         return results
 
 
@@ -455,7 +455,7 @@ class TaniumOscalFactory():
         start = index * batch_size
         end = (index + 1) * batch_size
         end = min(end, len(self._rule_use_list))
-        logger.debug(f'start: {start} end: {end-1}')
+        logger.debug(f'start: {start} end: {end - 1}')
         # process just the one chunk
         for i in range(start, end):
             rule_use = self._rule_use_list[i]


### PR DESCRIPTION
* Where does pathlib.Path('tests/data') resolve the path from? It's
  relative to the current working directory.
* Where is the tests/data directory? Relative to the tests.
* PyCharm has quirks related to the current working directory when
  running and debugging tests.
* By using __file__ to resolve the test data directory, we remove the
  non-guaranteed assumption that the current working directory is always
  at the root of the repository, and we replace that assumption with a
  value that is always correct regardless of current working directory.
* As a result, the unit tests can now be debugged in PyCharm, unit tests
  can be executed from any directory, and test execution continues to
  work in all the places it originally worked.

Some of the handling is slightly messy but that can be cleaned up by
making the task config files themselves not dependent on the CWD

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
