### PR TITLE
ci: fixes pipeline failures in docs

### DIFF
--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -37,8 +37,10 @@ jobs:
       with:
         python-version: ${{ needs.set-versions.outputs.max }}
     - id: versions
+      env:
+        REF: ${{ github.event.ref }}
       run: |
-        mike_version=$(python ./scripts/mike_version_parse.py ${{ env.GITHUB_REF }})
+        mike_version=$(python ./scripts/mike_version_parse.py "$REF")
         echo "mver=$mike_version" >> $GITHUB_OUTPUT
   deploy-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -71,6 +71,12 @@ jobs:
     - name: Check if dirty (mkdocs)
       run: |
         make check-for-changes
+    - name: Test mike script
+      env:
+        REF: ${{ github.event.ref }}
+      run: |
+        mike_version=$(python ./scripts/mike_version_parse.py "$REF")
+        [[ -z "$mike_version" ]] && echo "mike_version is empty" && exit 1 || echo "$mike_version"
 
 # This test simulates what it is like for a user to install trestle today.
 # Coverage cannot be calculated as part of

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -72,11 +72,14 @@ jobs:
       run: |
         make check-for-changes
     - name: Test mike script
+      # Only run this check on PRs to develop to check that the
+      # script produce the proper version of latest.
+      if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.base.ref , 'develop') }}
       env:
-        REF: ${{ github.event.ref }}
+        REF: ${{ github.event.pull_request.base.ref }}
       run: |
         mike_version=$(python ./scripts/mike_version_parse.py "$REF")
-        [[ -z "$mike_version" ]] && echo "mike_version is empty" && exit 1 || echo "$mike_version"
+        [[ "$mike_version" == latest ]] && echo "mike_version should be latest" && exit 1 || echo "$mike_version"
 
 # This test simulates what it is like for a user to install trestle today.
 # Coverage cannot be calculated as part of

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -71,15 +71,6 @@ jobs:
     - name: Check if dirty (mkdocs)
       run: |
         make check-for-changes
-    - name: Test mike script
-      # Only run this check on PRs to develop to check that the
-      # script produce the proper version of latest.
-      if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.base.ref , 'develop') }}
-      env:
-        REF: ${{ github.event.pull_request.base.ref }}
-      run: |
-        mike_version=$(python ./scripts/mike_version_parse.py "$REF")
-        [[ "$mike_version" == latest ]] && echo "mike_version should be latest" && exit 1 || echo "$mike_version"
 
 # This test simulates what it is like for a user to install trestle today.
 # Coverage cannot be calculated as part of

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ Upon approval from reviewer(s), the working copy is squashed and merged into the
 Upon a cadence established by the maintainers, the develop branch is merged into the main branch and a new release is uniquely numbered and pushed to [pypi](https://pypi.org/project/compliance-trestle/).
 
 `trestle` employs `semantic release` to automatically control release numbering.
-Code deliveries should be tagged with prefix `fix:` for changes that are bug fixes or `feat:` for changes that are new features.  See [allowed_tags](https://python-semantic-release.readthedocs.io/en/latest/commit-parsing.html#:~:text=The%20default%20configuration%20options%20for%20semantic_release.commit_parser.AngularCommitParser%20are%3A) for a list of supported tags.
+Code deliveries should be tagged with prefix `fix:` for changes that are bug fixes or `feat:` for changes that are new features.  See [allowed_tags](https://python-semantic-release.readthedocs.io/en/latest/commit_parsing.html#commit-parser-builtin-angular) for a list of supported tags.
 
 ### Trestle merging and release workflow
 


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [X] My code follows the code style of this project.
- [ ] Documentation for my change is up to date?
- [ ] My PR meets testing requirements.
- [X] All new and existing tests passed.
- [X] All commits are signed-off.

## Summary

This PR fixes the two pipeline failures:
- [Docs update](https://github.com/oscal-compass/compliance-trestle/actions/runs/12120880496)
  - GITHUB_REF is [not available through the env context](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables). Switching to `github.event.ref`.
- Dead link on the `python-semantic-release` docs site

Adds (**If this add does not seem super valuable, I can remove from this PR**)
~~- A check in python test workflow where the mike-version script is checked against the environment.~~

### How To Test

The `mike-version` job should pass

```bash
act push -e test-event.json -W .github/workflows/docs-update.yml
```
test-event.json contains
```bash
{
  "ref": "refs/tags/v3.6.0"
}
```

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
