### PR TITLE
docs: add OpenSSF Security Insights file

### DIFF
--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -40,7 +40,7 @@ repository:
     primary:     true
   - name:        Manjiree Gadgil
     primary:     true
-  - name:        Vikas Agarwa
+  - name:        Vikas Agarwal
     primary:     true
   documentation:
     contributing-guide: https://github.com/oscal-compass/compliance-trestle/blob/develop/CONTRIBUTING.md

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -1,0 +1,69 @@
+header:
+  schema-version: 2.0.0
+  last-updated: '2025-03-06'
+  last-reviewed: '2025-03-06'
+  url: https://github.com/oscal-compass
+
+project:
+  name: OSCAL Compass
+  administrators:
+    - name: OSCAL Compass Oversight Committee
+      email: oscal-compass-oversight@googlegroups.com
+      primary: true
+  documentation:
+    code-of-conduct: https://github.com/oscal-compass/community/blob/main/CODE_OF_CONDUCT.md
+  repositories:
+    - name: Trestle
+      url: https://github.com/oscal-compass/compliance-trestle
+      comment: |
+        Command line tool and SDK for interacting with OSCAL-based compliance-as-code documents.
+  vulnerability-reporting:
+    reports-accepted: true
+    bug-bounty-available: false
+    security-policy: https://github.com/oscal-compass/community/blob/main/SECURITY.md
+
+repository:
+  url: https://github.com/oscal-compass/compliance-trestle
+  status: active
+  accepts-change-request: true
+  accepts-automated-change-request: true
+  # From the complaince-trestle MAINTAINER.md file
+  # https://github.com/oscal-compass/compliance-trestle/blob/develop/MAINTAINERS.md
+  core-team:
+  - name:        Alejandro Jose Leiva Palomo
+    primary:     true
+  - name:        Christopher Butler
+    primary:     true
+  - name:        Lou Degenaro
+    primary:     true
+  - name:        Jennifer Power
+    primary:     true
+  - name:        Manjiree Gadgil
+    primary:     true
+  - name:        Vikas Agarwa
+    primary:     true
+  documentation:
+    contributing-guide: https://github.com/oscal-compass/compliance-trestle/blob/develop/CONTRIBUTING.md
+    security-policy: https://github.com/oscal-compass/community/blob/main/SECURITY.md
+  license:
+    url: https://github.com/oscal-compass/compliance-trestle/blob/develop/LICENSE
+    expression: Apache 2.0
+  release:
+    changelog: https://github.com/oscal-compass/compliance-trestle/blob/develop/CHANGELOG.md
+    automated-pipeline: true
+    attestations:
+      - name: PyPI Publish Attestation
+        location: https://pypi.org/project/compliance-trestle/#compliance_trestle-{version}.tar.gz
+        predicate-uri: https://docs.pypi.org/attestations/publish/v1
+        comment: |
+          This attestation communicates the Trusted Publisher identity
+          used to publish the project.
+    distribution-points:
+      - uri: https://github.com/oscal-compass/compliance-trestle/releases
+        comment: GitHub Release Page
+      - uri: https://pypi.org/project/compliance-trestle/
+  security:
+    assessments:
+      self:
+        comment: |
+          Self assessment has not yet been completed.


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [X] My code follows the code style of this project.
- [X] Documentation for my change is up to date?
- [ ] My PR meets testing requirements.
- [ ] All new and existing tests passed.
- [X] All commits are signed-off.

## Summary

Adds an initial [OpenSSF Security Insights](https://github.com/ossf/security-insights-spec/tree/v2.0.0) file.
Reported as missing by [CLOMonitor](https://clomonitor.io/projects/cncf/oscal-compass#compliance-trestle_security).

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
