### PR TITLE
feat: move dependencies from setup.cfg to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,118 @@
 # Added to aide with eventual transition away from setup.py
 [build-system]
 requires = [
-    "setuptools >= 35.0.2",
+    "setuptools >= 34.0.2",
     "wheel",
-    "setuptools_scm >= 2.0.0"
+    "setuptools_scm >= 1.0.0"
 ]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools_scm]
+[project]
+name = "compliance-trestle"
+description = "Tools to manage & autogenerate python objects representing the OSCAL layers/models"
+authors = [
+    {name = "OSCAL Compass", email = "oscal-compass-oversight@googlegroups.com"}
+]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Information Technology",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: POSIX",
+    "Operating System :: Microsoft",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+]
+readme = "README.md"
+license = {file = "LICENSE"}
+dynamic = ["version"]
+requires-python = ">=3.9"
+dependencies = [
+    "attrs",
+    "ilcli",
+    "cryptography==44.0.2",
+    "paramiko==3.5.0",
+    "ruamel.yaml",
+    "furl",
+    "pydantic[email]>=2.0.0",
+    "python-dotenv>=0.10.4",
+    "datamodel-code-generator[http] == 0.25.3",
+    "python-frontmatter",
+    "pywin32 >= 1.0;platform_system=='Windows'",
+    "defusedxml",
+    "openpyxl~=3.0",
+    "Jinja2 == 3.1.6",
+    "cmarkgfm==2024.1.*", ## Update regularly
+    "orjson",
+    "requests>=2.32.2",
+    "importlib_resources"
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=5.4.3",
+    "pytest-cov>=2.10.0",
+    "pytest-xdist",
+    "pre-commit>=2.4.0",
+    "setuptools>=61",
+    "urllib3==1.26.19",
+    "wheel",
+    "yapf",
+    "python-semantic-release>=9.8.0",
+    "pep8-naming",
+    "pytest-random-order",
+    "python-dateutil",
+    "mypy",
+    "types-PyYAML",
+    "types-paramiko",
+    "types-requests",
+    "types-setuptools",
+    ## Docs website
+    "mike",
+    "mkdocs>=1.6.0",
+    "mkdocs-awesome-pages-plugin",
+    "mkdocstrings[python]>=0.25.2",
+    "mkdocs-htmlproofer-plugin",
+    "mkdocs-material",
+    "markdown-include",
+    "mkdocs-minify-plugin",
+    "mkdocs-git-revision-date-localized-plugin",
+    "pymdown-extensions",
+    "livereload",
+    "pillow",
+    "cairosvg",
+    ## Constrain system
+    "pylint",
+    # Checking repo after docs generation.
+    "gitpython"
+]
+
+[project.urls]
+Homepage = "https://oscal-compass.github.io/compliance-trestle"
+
+[project.scripts]
+trestle = "trestle.cli:run"
+
+[tool.setuptools_scm] # this section must exist
+
+[tool.distutils.bdist_wheel]
+universal = true
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.packages.find]
+include = ["trestle*"]
+exclude = ["tests"]
+
+[tool.setuptools.package-data]
+trestle = ["*.ini", "*.md", "*.jinja", "*.drawio", "*.json", "*.yaml", "*.yml"]
+
+[tool.setuptools.dynamic]
+version = {attr = "trestle.__init__.__version__"}
 
 [tool.pytest.ini_options]
 minversion = "6.2"
@@ -20,6 +125,41 @@ line-length = 500
 
 [tool.isort]
 line_length = 500
+
+[tool.flake8]
+# WARNING: This should be kept compatible with .pre-commit-config.yaml
+ignore = ["P1", "C812", "C813", "C814", "C815", "C816"]
+max-line-length = 120
+exclude = [
+    "trestle/oscal"
+]
+
+[tool.mypy]
+plugins = "pydantic.v1.mypy"
+ignore_missing_imports = true
+strict_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+disallow_any_generics = true
+check_untyped_defs = true
+no_implicit_reexport = true
+show_error_codes = true
+show_error_context = true
+disallow_untyped_defs = true
+disable_error_code = ["union-attr", "attr-defined", "no-redef", "assignment", "arg-type", "list-item"]
+
+[[tool.mypy.overrides]]
+module = "trestle.oscal.*"
+ignore_errors = true
+
+[tool.pydantic-mypy]
+init_forbid_extra = true
+init_typed = true
+warn_required_dynamic_aliases = true
+warn_untyped_fields = true
+
+[tool.coverage.run]
+relative_files = true
 
 [tool.semantic_release]
 build_command = """
@@ -35,12 +175,10 @@ minor_tags = ["feat"]
 patch_tags = ["fix", "perf"]
 default_bump_level = 0
 
-
 [tool.semantic_release.branches.main]
 match = "(main)"
 prerelease_token = "rc"
 prerelease = false
-
 
 [tool.semantic_release.remote]
 name = "origin"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,9 +98,6 @@ Homepage = "https://oscal-compass.github.io/compliance-trestle"
 [project.scripts]
 trestle = "trestle.cli:run"
 
-[tool.distutils.bdist_wheel]
-universal = true
-
 [tool.setuptools]
 include-package-data = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ classifiers = [
     "Environment :: Console",
     "Intended Audience :: Developers",
     "Intended Audience :: Information Technology",
-    "License :: OSI Approved :: Apache Software License",
     "Operating System :: POSIX",
     "Operating System :: Microsoft",
     "Programming Language :: Python :: 3",
@@ -29,7 +28,8 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 readme = "README.md"
-license = {file = "LICENSE"}
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 dynamic = ["version"]
 requires-python = ">=3.9"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,13 @@
 # Added to aide with eventual transition away from setup.py
 [build-system]
 requires = [
-    "setuptools >= 34.0.2",
+    "setuptools >= 35.0.2",
     "wheel",
-    "setuptools_scm >= 1.0.0"
+    "setuptools_scm >= 2.0.0"
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm] # this section must exist
 
 [project]
 name = "compliance-trestle"
@@ -95,8 +97,6 @@ Homepage = "https://oscal-compass.github.io/compliance-trestle"
 
 [project.scripts]
 trestle = "trestle.cli:run"
-
-[tool.setuptools_scm] # this section must exist
 
 [tool.distutils.bdist_wheel]
 universal = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,49 +1,6 @@
-[metadata]
-name = compliance-trestle
-version = attr: trestle.__version__
-description = Tools to manage & autogenerate python objects representing the OSCAL layers/models
-author = OSCAL Compass
-author_email = oscal-compass-oversight@googlegroups.com
-license = Apache Software License v2
-url = https://oscal-compass.github.io/compliance-trestle
-classifiers =
-    Development Status :: 5 - Production/Stable
-    Environment :: Console
-    Intended Audience :: Developers
-    Intended Audience :: Information Technology
-    License :: OSI Approved :: Apache Software License
-    Operating System :: POSIX
-    Operating System :: Microsoft
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-long_description_content_type = text/markdown
-long_description = file: README.md
-python_require= '>=3.9'
 [options]
 packages = find:
 include_package_data = True
-
-install_requires =
-    attrs
-    ilcli
-    cryptography==44.0.2
-    paramiko==3.5.0
-    ruamel.yaml
-    furl
-    pydantic[email]>=2.0.0
-    python-dotenv>=0.10.4
-    datamodel-code-generator[http] == 0.25.3
-    python-frontmatter
-    pywin32 >= 1.0;platform_system=='Windows'
-    defusedxml
-    openpyxl~=3.0
-    Jinja2 == 3.1.6
-    cmarkgfm==2024.1.* #Update regularly
-    orjson
-    requests>=2.32.2
-    importlib_resources
 
 [options.packages.find]
 include = trestle*
@@ -55,50 +12,6 @@ exclude = tests
 [bdist_wheel]
 universal = 1
 
-[options.entry_points]
-console_scripts =
-    trestle = trestle.cli:run
-
-[options.extras_require]
-dev =
-    pytest>=5.4.3
-    pytest-cov>=2.10.0
-    pytest-xdist
-    pre-commit>=2.4.0
-    setuptools>=61
-    urllib3==1.26.19
-    wheel
-    yapf
-    python-semantic-release>=9.8.0
-    pep8-naming
-    pytest-random-order
-    python-dateutil
-    mypy
-    types-PyYAML
-    types-paramiko
-    types-requests
-    types-setuptools
-    # # Docs website
-    mike
-    mkdocs>=1.6.0
-    mkdocs-awesome-pages-plugin
-    mkdocstrings[python]>=0.25.2
-    mkdocs-htmlproofer-plugin
-    mkdocs-material
-    markdown-include
-    mkdocs-minify-plugin
-    mkdocs-git-revision-date-localized-plugin
-    pymdown-extensions
-    livereload
-    pillow
-    cairosvg
-    ## Constrain system
-    pylint
-    # Checking repo after docs generation.
-    gitpython
-
-   
-    
 [semantic_release]
 version_variable=trestle/__init__.py:__version__
 branch = main


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [X] My code follows the code style of this project.
- [X] Documentation for my change is up to date?
- [X] My PR meets testing requirements.
- [X] All new and existing tests passed.
- [X] All commits are signed-off.

<!--- Uncomment below if changes are for GitHub Actions -->

<!--
### How To Test

If using [act](https://github.com/nektos/act), fill in below:

**act version**  

**act command**
```bash
```
-->

## Summary

This PR moves the project metadata and dependencies from `setup.cfg` to `pyproject.toml`.   This can be tested directly by running `pip install .` and  `pip install ".[dev]"` (for optional dev dependencies).

Closes https://github.com/oscal-compass/compliance-trestle/issues/1851
## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
