### PR TITLE
refactor: isolate rules helpers into core rules module

### DIFF
--- a/docs/reference/API/trestle/core/rules/rule_parameters_validator.md
+++ b/docs/reference/API/trestle/core/rules/rule_parameters_validator.md
@@ -1,0 +1,7 @@
+---
+title: trestle.core.rules.rule_parameters_validator
+description: Documentation for trestle.core.rules.rule_parameters_validator module
+---
+
+::: trestle.core.rules.rule_parameters_validator
+handler: python

--- a/docs/reference/API/trestle/core/rules/rules_interface.md
+++ b/docs/reference/API/trestle/core/rules/rules_interface.md
@@ -1,0 +1,7 @@
+---
+title: trestle.core.rules.rules_interface
+description: Documentation for trestle.core.rules.rules_interface module
+---
+
+::: trestle.core.rules.rules_interface
+handler: python

--- a/tests/trestle/core/rule_parameters_validator_test.py
+++ b/tests/trestle/core/rule_parameters_validator_test.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2026 The OSCAL Compass Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for backward-compatible RuleParametersValidator import path."""
+
+from types import SimpleNamespace
+
+from trestle.core.rule_parameters_validator import RuleParametersValidator as CompatRuleParametersValidator
+from trestle.core.rules.rule_parameters_validator import RuleParametersValidator as NewRuleParametersValidator
+
+
+def test_rule_parameters_validator_backward_compatibility() -> None:
+    """Confirm old and new import paths resolve to the same validator class."""
+    assert CompatRuleParametersValidator is NewRuleParametersValidator
+
+
+def test_rule_parameters_validator_non_ssp_model_is_valid() -> None:
+    """Non-SSP models should always be treated as valid."""
+    validator = NewRuleParametersValidator()
+    assert validator.model_is_valid(object(), quiet=True, trestle_root=None) is True
+
+
+def test_rule_parameters_validator_handles_set_params_without_values() -> None:
+    """Union-style set parameters without a values field should not crash validation helpers."""
+    validator = NewRuleParametersValidator()
+    item = SimpleNamespace(set_parameters=[SimpleNamespace(param_id='rule-param')])
+    catalog_interface = SimpleNamespace(get_control_by_param_id=lambda param_id: None)
+
+    validator._add_rule_params(item, 'ac-1', catalog_interface, 'component-1')
+
+    assert validator._rule_param_values_dict == {'rule-param': {'component-1': {}}}

--- a/tests/trestle/core/rules_interface_test.py
+++ b/tests/trestle/core/rules_interface_test.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2026 The OSCAL Compass Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for RulesInterface."""
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+import pytest
+
+from trestle.common import const
+from trestle.common.err import TrestleError
+from trestle.core.rules import RulesInterface
+from trestle.oscal import common
+
+
+def _prop(name: str, value: str, remarks: Optional[str] = None) -> common.Property:
+    """Create a property with minimal required fields."""
+    return common.Property(name=name, value=value, remarks=remarks)
+
+
+@dataclass
+class DummyItem:
+    """Minimal item with props for rules parsing."""
+
+    props: Optional[List[common.Property]] = None
+
+
+@dataclass
+class DummyImpReq:
+    """Minimal implemented requirement with props and statements."""
+
+    props: Optional[List[common.Property]] = None
+    statements: Optional[List[DummyItem]] = None
+
+
+def test_get_rules_dict_from_item_multiple_and_missing() -> None:
+    """Test rules dict extraction with missing pair."""
+    props = [
+        _prop(const.RULE_ID, 'rule-a', 'rule-a-id'),
+        _prop(const.RULE_DESCRIPTION, 'desc-a'),
+        _prop(const.RULE_ID, 'rule-b', 'rule-b-id'),
+        _prop('other-prop', 'other'),
+    ]
+    rules_dict, rules_props = RulesInterface.get_rules_dict_from_item(DummyItem(props))
+    assert rules_dict == {'rule-a-id': {'name': 'rule-a', 'description': 'desc-a'}}
+    assert rules_props == props[:3]
+
+
+def test_item_has_rules_true_false() -> None:
+    """Test item_has_rules true and false paths."""
+    assert RulesInterface.item_has_rules(DummyItem([_prop(const.RULE_ID, 'rule-a', 'rule-a-id')]))
+    assert not RulesInterface.item_has_rules(DummyItem([_prop('other-prop', 'other')]))
+
+
+def test_get_rule_list_for_item() -> None:
+    """Test rule list extraction from item."""
+    props = [
+        _prop(const.RULE_ID, 'rule-a', 'rule-a-id'),
+        _prop(const.RULE_DESCRIPTION, 'desc-a'),
+        _prop('other-prop', 'other'),
+    ]
+    rule_list, rule_props = RulesInterface.get_rule_list_for_item(DummyItem(props))
+    assert rule_list == ['rule-a']
+    assert rule_props == [props[0]]
+
+
+def test_get_rule_list_for_imp_req() -> None:
+    """Test rule list extraction from implemented requirement."""
+    imp_req = DummyImpReq(
+        props=[_prop(const.RULE_ID, 'rule-a', 'rule-a-id')],
+        statements=[
+            DummyItem([_prop(const.RULE_ID, 'rule-b', 'rule-b-id')]),
+            DummyItem([_prop(const.RULE_ID, 'rule-c', 'rule-c-id')]),
+            DummyItem([_prop(const.RULE_ID, 'rule-b', 'rule-b-id')]),
+        ],
+    )
+    comp_rules, statement_rules, rule_props = RulesInterface.get_rule_list_for_imp_req(imp_req)
+    assert comp_rules == ['rule-a']
+    assert statement_rules == ['rule-b', 'rule-c']
+    assert len(rule_props) == 4
+
+
+def test_get_params_dict_from_item_normal_and_remarks_none() -> None:
+    """Test parameter parsing with valid rule id and ignored None remarks."""
+    props = [
+        _prop(const.PARAMETER_ID, 'param-1', 'rule-a-id'),
+        _prop(const.PARAMETER_DESCRIPTION, 'param-1 desc', 'rule-a-id'),
+        _prop(const.PARAMETER_VALUE_ALTERNATIVES, 'opt-1', 'rule-a-id'),
+        _prop(const.PARAMETER_ID, 'param-ignored', None),
+    ]
+    params_dict, params_props = RulesInterface.get_params_dict_from_item(DummyItem(props))
+    assert params_dict == {'rule-a-id': [{'name': 'param-1', 'description': 'param-1 desc', 'options': 'opt-1'}]}
+    assert params_props == props[:3]
+
+
+def test_get_params_dict_from_item_duplicate_param_id_raises() -> None:
+    """Test duplicate parameter id for same rule raises error."""
+    props = [_prop(const.PARAMETER_ID, 'param-1', 'rule-a-id'), _prop(const.PARAMETER_ID, 'param-1', 'rule-a-id')]
+    with pytest.raises(TrestleError):
+        _ = RulesInterface.get_params_dict_from_item(DummyItem(props))
+
+
+def test_get_params_dict_from_item_description_without_param_raises() -> None:
+    """Test description without matching param id raises error."""
+    props = [
+        _prop(const.PARAMETER_ID, 'param-1', 'rule-a-id'),
+        _prop(const.PARAMETER_ID, 'param-2', 'rule-b-id'),
+        _prop(const.PARAMETER_DESCRIPTION, 'param-1 desc', 'rule-a-id'),
+    ]
+    with pytest.raises(TrestleError):
+        _ = RulesInterface.get_params_dict_from_item(DummyItem(props))
+
+
+def test_get_params_dict_from_item_options_without_param_raises() -> None:
+    """Test options without matching param id raises error."""
+    props = [
+        _prop(const.PARAMETER_ID, 'param-1', 'rule-a-id'),
+        _prop(const.PARAMETER_ID, 'param-2', 'rule-b-id'),
+        _prop(const.PARAMETER_VALUE_ALTERNATIVES, 'opt-1', 'rule-a-id'),
+    ]
+    with pytest.raises(TrestleError):
+        _ = RulesInterface.get_params_dict_from_item(DummyItem(props))
+
+
+def test_get_rules_and_params_dict_from_item() -> None:
+    """Test combined rule and param parsing."""
+    props = [
+        _prop(const.RULE_ID, 'rule-a', 'rule-a-id'),
+        _prop(const.RULE_DESCRIPTION, 'desc-a'),
+        _prop(const.PARAMETER_ID, 'param-1', 'rule-a-id'),
+        _prop(const.PARAMETER_DESCRIPTION, 'param-1 desc', 'rule-a-id'),
+    ]
+    rules_dict, params_dict, rules_props = RulesInterface.get_rules_and_params_dict_from_item(DummyItem(props))
+    assert rules_dict == {'rule-a-id': {'name': 'rule-a', 'description': 'desc-a'}}
+    assert params_dict == {'rule-a-id': [{'name': 'param-1', 'description': 'param-1 desc', 'options': ''}]}
+    assert rules_props == props
+
+
+def test_cull_props_by_rules() -> None:
+    """Test culling properties by rule list."""
+    props = [
+        _prop(const.RULE_ID, 'rule-a', 'rule-a-id'),
+        _prop(const.RULE_DESCRIPTION, 'desc-a', 'rule-a-id'),
+        _prop('other-prop', 'other', 'rule-a-id'),
+        _prop('unrelated-prop', 'unrelated'),
+    ]
+    culled = RulesInterface.cull_props_by_rules(props, ['rule-a'])
+    assert culled == props[:3]

--- a/trestle/core/catalog/catalog_interface.py
+++ b/trestle/core/catalog/catalog_interface.py
@@ -38,6 +38,7 @@ from trestle.common.list_utils import (
 from trestle.common.model_utils import ModelUtils
 from trestle.core.control_context import ControlContext
 from trestle.core.control_interface import CompDict, ComponentImpInfo, ControlInterface
+from trestle.core.rules import RulesInterface
 from trestle.oscal import common
 from trestle.oscal import component as comp
 from trestle.oscal import profile as prof
@@ -848,7 +849,7 @@ class CatalogInterface:
     ) -> None:
         """Add component info to the impreqs of the control implementation based on applied rules."""
         control_imp_rules_dict, control_imp_rules_params_dict, ci_rules_props = (
-            ControlInterface.get_rules_and_params_dict_from_item(context.control_implementation)
+            RulesInterface.get_rules_and_params_dict_from_item(context.control_implementation)
         )  # noqa E501
         context.rules_dict[context.comp_name].update(control_imp_rules_dict)
         comp_rules_params_dict = context.rules_params_dict.get(context.comp_name, {})
@@ -863,13 +864,13 @@ class CatalogInterface:
                 )
             control_part_id_map = part_id_map.get(imp_req.control_id, {})
             # find if any rules apply to this control, including in statements
-            control_rules, statement_rules, ir_props = ControlInterface.get_rule_list_for_imp_req(imp_req)
+            control_rules, statement_rules, ir_props = RulesInterface.get_rule_list_for_imp_req(imp_req)
             rule_props = comp_rules_props[:]
             rule_props.extend(ci_rules_props)
             rule_props.extend(ir_props)
             rule_props = ControlInterface.clean_props(rule_props, remove_imp_status=False)
             status = ControlInterface.get_status_from_props(imp_req)
-            final_props = ControlInterface.cull_props_by_rules(rule_props, control_rules)
+            final_props = RulesInterface.cull_props_by_rules(rule_props, control_rules)
             comp_info = ComponentImpInfo(imp_req.description, control_rules, final_props, status)
             self.add_comp_info(imp_req.control_id, context.comp_name, '', comp_info)
             set_params = copy.deepcopy(ci_set_params)
@@ -878,7 +879,7 @@ class CatalogInterface:
                 # add to control_comp_set_params dict
                 self.add_comp_set_param(imp_req.control_id, context.comp_name, set_param)
             for statement in as_list(imp_req.statements):
-                rule_list, stat_props = ControlInterface.get_rule_list_for_item(statement)
+                rule_list, stat_props = RulesInterface.get_rule_list_for_item(statement)
                 status = ControlInterface.get_status_from_props(statement)
                 if statement.statement_id not in control_part_id_map:
                     label = statement.statement_id
@@ -889,7 +890,7 @@ class CatalogInterface:
                     label = control_part_id_map[statement.statement_id]
                 all_props = rule_props[:]
                 all_props.extend(stat_props)
-                final_props = ControlInterface.cull_props_by_rules(all_props, rule_list)
+                final_props = RulesInterface.cull_props_by_rules(all_props, rule_list)
                 comp_info = ComponentImpInfo(statement.description, rule_list, final_props, status)
                 self.add_comp_info(imp_req.control_id, context.comp_name, label, comp_info)
 
@@ -918,7 +919,7 @@ class CatalogInterface:
                 context.comp_name = component.title
                 # get top level rule info applying to all controls from the component props
                 comp_rules_dict, comp_rules_params_dict, comp_rules_props = (
-                    ControlInterface.get_rules_and_params_dict_from_item(component)
+                    RulesInterface.get_rules_and_params_dict_from_item(component)
                 )  # noqa E501
                 context.rules_dict[context.comp_name] = comp_rules_dict
                 deep_update(context.rules_params_dict, [context.comp_name], comp_rules_params_dict)

--- a/trestle/core/catalog/catalog_writer.py
+++ b/trestle/core/catalog/catalog_writer.py
@@ -25,6 +25,7 @@ from trestle.core.catalog.catalog_interface import CatalogInterface
 from trestle.core.catalog.catalog_merger import CatalogMerger
 from trestle.core.control_context import ContextPurpose, ControlContext
 from trestle.core.control_interface import ComponentImpInfo, ControlInterface
+from trestle.core.rules import RulesInterface
 from trestle.core.control_writer import ControlWriter
 from trestle.oscal import common
 from trestle.oscal import component as comp
@@ -338,14 +339,14 @@ class CatalogWriter:
             logger.warning(f'Component {context.comp_name} references controls {missing_controls} not in profile.')
 
         # get top level rule info applying to all controls
-        comp_rules_dict, comp_rules_params_dict, _ = ControlInterface.get_rules_and_params_dict_from_item(
+        comp_rules_dict, comp_rules_params_dict, _ = RulesInterface.get_rules_and_params_dict_from_item(
             context.component
-        )  # noqa E501
+        )
         context.rules_dict[context.comp_name] = comp_rules_dict
         context.rules_params_dict[context.comp_name] = comp_rules_params_dict
         for control_imp in as_list(context.component.control_implementations):
             control_imp_rules_dict, control_imp_rules_params_dict, _ = (
-                ControlInterface.get_rules_and_params_dict_from_item(control_imp)
+                RulesInterface.get_rules_and_params_dict_from_item(control_imp)
             )  # noqa E501
             context.rules_dict[context.comp_name].update(control_imp_rules_dict)
             comp_rules_params_dict = context.rules_params_dict.get(context.comp_name, {})
@@ -355,7 +356,7 @@ class CatalogWriter:
             for imp_req in as_list(control_imp.implemented_requirements):
                 control_part_id_map = part_id_map.get(imp_req.control_id, {})
                 status = ControlInterface.get_status_from_props(imp_req)
-                control_rules, _ = ControlInterface.get_rule_list_for_item(imp_req)
+                control_rules, _ = RulesInterface.get_rule_list_for_item(imp_req)
                 comp_info = ComponentImpInfo(imp_req.description, control_rules, [], status)
                 self._catalog_interface.add_comp_info(imp_req.control_id, context.comp_name, '', comp_info)
                 set_params = copy.deepcopy(ci_set_params)
@@ -369,7 +370,7 @@ class CatalogWriter:
                         logger.warning(f'No statement label found for statement id {label}.  Defaulting to {label}.')
                     else:
                         label = control_part_id_map[statement.statement_id]
-                    rule_list, _ = ControlInterface.get_rule_list_for_item(statement)
+                    rule_list, _ = RulesInterface.get_rule_list_for_item(statement)
                     comp_info = ComponentImpInfo(statement.description, rule_list, [], status)
                     self._catalog_interface.add_comp_info(imp_req.control_id, context.comp_name, label, comp_info)
 

--- a/trestle/core/commands/author/ssp.py
+++ b/trestle/core/commands/author/ssp.py
@@ -47,6 +47,7 @@ from trestle.core.crm.ssp_inheritance_api import SSPInheritanceAPI
 from trestle.core.models.file_content_type import FileContentType
 from trestle.core.profile_resolver import ProfileResolver
 from trestle.core.remote.cache import FetcherFactory
+from trestle.core.rules import RulesInterface
 from trestle.core.validator import Validator
 from trestle.core.validator_factory import validator_factory
 
@@ -369,7 +370,7 @@ class SSPAssemble(AuthorCommonCommand):
         local_set_params.extend(as_list(imp_req.set_parameters))
         local_set_params = ControlInterface.uniquify_set_params(local_set_params)
         # get any rules set at control level, if present
-        rules_list, _ = ControlInterface.get_rule_list_for_item(gen_imp_req)  # type: ignore
+        rules_list, _ = RulesInterface.get_rule_list_for_item(gen_imp_req)  # type: ignore
         # There should be no rule content at top level of imp_req in ssp so strip them out
         imp_req.props = none_if_empty(
             ControlInterface.clean_props(gen_imp_req.props, remove_imp_status=True, remove_all_rule_info=True)
@@ -389,12 +390,12 @@ class SSPAssemble(AuthorCommonCommand):
         # so insert the new by_comp directly into the ssp, generating parts as needed
         imp_req.statements = as_list(imp_req.statements)
         for statement in as_list(gen_imp_req.statements):
-            if ControlInterface.item_has_rules(statement):  # type: ignore
+            if RulesInterface.item_has_rules(statement):  # type: ignore
                 imp_req = CatalogReader._get_imp_req_for_statement(ssp, gen_imp_req.control_id, statement.statement_id)
                 by_comp = CatalogReader._get_by_comp_from_imp_req(imp_req, statement.statement_id, gen_comp.uuid)
                 by_comp.description = statement.description
                 by_comp.props = none_if_empty(ControlInterface.clean_props(statement.props))
-                rules_list, _ = ControlInterface.get_rule_list_for_item(statement)  # type: ignore
+                rules_list, _ = RulesInterface.get_rule_list_for_item(statement)  # type: ignore
                 by_comp.set_parameters = none_if_empty(
                     SSPAssemble._get_params_for_rules(context, rules_list, local_set_params)
                 )

--- a/trestle/core/control_interface.py
+++ b/trestle/core/control_interface.py
@@ -30,6 +30,7 @@ from trestle.common.err import TrestleError
 from trestle.common.list_utils import as_filtered_list, as_list, none_if_empty
 from trestle.common.model_utils import ModelUtils
 from trestle.common.str_utils import as_string, string_from_root, strip_lower_equals
+from trestle.core.rules import RulesInterface
 from trestle.oscal import common
 from trestle.oscal import component as comp
 from trestle.oscal import profile as prof
@@ -440,120 +441,36 @@ class ControlInterface:
     @staticmethod
     def get_rules_dict_from_item(item: TypeWithProps) -> Tuple[Dict[str, Dict[str, str]], List[common.Property]]:
         """Get all rules found in this items props."""
-        # rules is dict containing rule_id and description
-        rules_dict = {}
-        name = ''
-        desc = ''
-        id_ = ''
-        rules_props = []
-        for prop in as_list(item.props):
-            if prop.name == const.RULE_ID:
-                name = prop.value
-                id_ = prop.remarks
-                rules_props.append(prop)
-            elif prop.name == const.RULE_DESCRIPTION:
-                desc = prop.value
-                rules_props.append(prop)
-            # grab each pair in case there are multiple pairs
-            # then clear and look for new pair
-            if name and desc:
-                rules_dict[id_] = {'name': name, 'description': desc}
-                name = desc = id_ = ''
-        return rules_dict, rules_props
+        return RulesInterface.get_rules_dict_from_item(item)
 
     @staticmethod
     def item_has_rules(item: TypeWithProps) -> bool:
         """Determine if the item has rules in its props."""
-        _, rules_props = ControlInterface.get_rules_dict_from_item(item)
-        return bool(rules_props)
+        return RulesInterface.item_has_rules(item)
 
     @staticmethod
     def get_rule_list_for_item(item: TypeWithProps) -> Tuple[List[str], List[common.Property]]:
         """Get the list of rules applying to this item from its top level props."""
-        props = []
-        rule_list = []
-        for prop in as_list(item.props):
-            if prop.name == const.RULE_ID:
-                rule_list.append(prop.value)
-                props.append(prop)
-        return rule_list, props
+        return RulesInterface.get_rule_list_for_item(item)
 
     @staticmethod
     def get_rule_list_for_imp_req(
         imp_req: ossp.ImplementedRequirement,
     ) -> Tuple[List[str], List[str], List[common.Property]]:
         """Get the list of rules applying to an imp_req as two lists."""
-        comp_rules, rule_props = ControlInterface.get_rule_list_for_item(imp_req)
-        statement_rules = set()
-        for statement in as_list(imp_req.statements):
-            stat_rules, statement_props = ControlInterface.get_rule_list_for_item(statement)
-            statement_rules.update(stat_rules)
-            rule_props.extend(statement_props)
-        return comp_rules, sorted(statement_rules), rule_props
+        return RulesInterface.get_rule_list_for_imp_req(imp_req)
 
     @staticmethod
     def get_params_dict_from_item(item: TypeWithProps) -> Tuple[Dict[str, List[Dict[str, str]]], List[common.Property]]:
         """Get all params found in this item with rule_id as key."""
-        # id, description, options - where options is a string containing comma-sep list of items
-        # params is dict with rule_id as key and value contains: param_name, description and choices
-        params: Dict[str, List[Dict[str, str]]] = {}
-        props = []
-        for prop in as_list(item.props):
-            if const.PARAMETER_ID in prop.name:
-                rule_id = prop.remarks
-                param_name = prop.value
-                # rule already exists in parameters dict
-                if rule_id is not None:
-                    if rule_id in params.keys():
-                        existing_param = next((prm for prm in params[rule_id] if prm['name'] == param_name), None)
-                        if existing_param is not None:
-                            raise TrestleError(f'Param id for rule {rule_id} already exists')
-                        else:
-                            # append a new parameter for the current rule
-                            params[rule_id].append({'name': param_name})
-                    else:
-                        # create new param for this rule for the first parameter
-                        params[rule_id] = [{'name': param_name}]
-                        props.append(prop)
-            elif const.PARAMETER_DESCRIPTION in prop.name:
-                rule_id = prop.remarks
-                if rule_id in params:
-                    param = next((prm for prm in params[rule_id] if prm['name'] == param_name), None)
-                    if param is not None:
-                        param['description'] = prop.value
-                        props.append(prop)
-                    else:
-                        raise TrestleError(f'Param description for rule {rule_id} found with no param_id')
-            elif const.PARAMETER_VALUE_ALTERNATIVES in prop.name:
-                rule_id = prop.remarks
-                if rule_id in params:
-                    param = next((prm for prm in params[rule_id] if prm['name'] == param_name), None)
-                    if param is not None:
-                        param['options'] = prop.value
-                        props.append(prop)
-                    else:
-                        raise TrestleError(f'Param options for rule {rule_id} found with no param_id')
-        new_params: dict[str, list[dict[str, str]]] = {}
-        for rule_id, rule_params in params.items():
-            new_params[rule_id] = []
-            for param in rule_params:
-                if 'name' not in param:
-                    logger.warning(f'Parameter for rule_id {rule_id} has no matching name.  Ignoring the param.')
-                else:
-                    param['description'] = param.get('description', '')
-                    param['options'] = param.get('options', '')
-                    new_params[rule_id].append(param)
-        return new_params, props
+        return RulesInterface.get_params_dict_from_item(item)
 
     @staticmethod
     def get_rules_and_params_dict_from_item(
         item: TypeWithProps,
     ) -> Tuple[Dict[str, Dict[str, str]], Dict[str, List[Dict[str, str]]], List[common.Property]]:
         """Get the rule dict and params dict from item with props."""
-        rules_dict, rules_props = ControlInterface.get_rules_dict_from_item(item)
-        params_dict, params_props = ControlInterface.get_params_dict_from_item(item)
-        rules_props.extend(params_props)
-        return rules_dict, params_dict, rules_props
+        return RulesInterface.get_rules_and_params_dict_from_item(item)
 
     @staticmethod
     def get_set_params_from_item(
@@ -1147,15 +1064,7 @@ class ControlInterface:
     @staticmethod
     def cull_props_by_rules(props: Optional[List[common.Property]], rules: List[str]) -> List[common.Property]:
         """Cull properties to the ones needed by rules."""
-        needed_rule_ids: Set[str] = set()
-        culled_props: List[common.Property] = []
-        for prop in as_list(props):
-            if prop.value in rules and prop.remarks:
-                needed_rule_ids.add(prop.remarks)
-        for prop in as_list(props):
-            if prop.value in rules or prop.remarks in needed_rule_ids:
-                culled_props.append(prop)
-        return culled_props
+        return RulesInterface.cull_props_by_rules(props, rules)
 
     @staticmethod
     def _status_as_prop(status: common.ImplementationStatus) -> common.Property:

--- a/trestle/core/rules/__init__.py
+++ b/trestle/core/rules/__init__.py
@@ -1,6 +1,4 @@
-# -*- mode:python; coding:utf-8 -*-
-
-# Copyright (c) 2023 IBM Corp. All rights reserved.
+# Copyright (c) 2026 The OSCAL Compass Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Backward-compatible import path for RuleParametersValidator."""
+"""Rules support utilities."""
 
-from trestle.core.rules.rule_parameters_validator import RuleParametersValidator
+from trestle.core.rules.rules_interface import RulesInterface
 
-__all__ = ['RuleParametersValidator']
+__all__ = ['RulesInterface']

--- a/trestle/core/rules/rule_parameters_validator.py
+++ b/trestle/core/rules/rule_parameters_validator.py
@@ -1,0 +1,126 @@
+# -*- mode:python; coding:utf-8 -*-
+
+# Copyright (c) 2023 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Validate by confirming rule parameter values are consistent."""
+
+import logging
+import pathlib
+from typing import Any, Dict, Optional
+
+from trestle.common.common_types import TopLevelOscalModel
+from trestle.common.common_types import TypeWithSetParams
+from trestle.common.list_utils import as_list, deep_set
+from trestle.core.catalog.catalog_interface import CatalogInterface
+from trestle.core.profile_resolver import ProfileResolver
+from trestle.core.validator import Validator
+from trestle.oscal.ssp import ImplementedRequirement, SystemSecurityPlan
+
+logger = logging.getLogger(__name__)
+
+
+class RuleParametersValidator(Validator):
+    """Validator to confirm all rule parameter values are consistent."""
+
+    def __init__(self) -> None:
+        """Initialize rule param values dictionary."""
+        self._rule_param_values_dict: Dict[str, Any] = {}
+
+    def _add_imp_req_rule_params_to_dict(
+        self, imp_requirement: ImplementedRequirement, cat_int: CatalogInterface
+    ) -> None:
+        """
+        Iterate all by components in an object and add the rule shared parameter values to list.
+
+        args:
+            imp_requirement: Current implemented requirement.
+            cat_int: Instance of catalog interface with controls catalog loaded.
+        """
+        for by_component in as_list(imp_requirement.by_components):
+            # adds rule param values present in set parameters for current imp req
+            self._add_rule_params(imp_requirement, imp_requirement.control_id, cat_int, by_component.component_uuid)
+            # adds rule param values present in set parameters for current by_component in by_components list
+            # in the current implemented requirement
+            self._add_rule_params(by_component, imp_requirement.control_id, cat_int, by_component.component_uuid)
+            for statement in as_list(imp_requirement.statements):
+                # iterates by each by component inclded at each statemtent set for current imp req
+                for by_comp in as_list(statement.by_components):
+                    # adds rule param values present in set parameters for current by_component in by_components list
+                    # of current statement in current implemented requirement
+                    self._add_rule_params(by_comp, imp_requirement.control_id, cat_int, by_comp.component_uuid)
+
+    def _add_rule_params(
+        self, item: TypeWithSetParams, control_id: str, cat_int: CatalogInterface, comp_uuid: str = ''
+    ) -> None:
+        """
+        Add a rule shared parameter to the rule shared parameters list.
+
+        args:
+            item: Generic item to iterate over parameters.
+            control_id: Current control id.
+            cat_int: Instance of catalog interface with controls catalog loaded.
+            comp_uuid: Component uuid to save.
+        """
+        for set_param in as_list(item.set_parameters):
+            # validates if current param_id is or not associated with a control so we can assume it´s a rule param
+            control = cat_int.get_control_by_param_id(set_param.param_id)
+            if not control:
+                # SetParameter is a Union type - check for values field before accessing
+                values = set_param.values if hasattr(set_param, 'values') else None
+                deep_set(self._rule_param_values_dict, [set_param.param_id, comp_uuid, control_id], values)
+
+    def model_is_valid(
+        self, model: TopLevelOscalModel, quiet: bool, trestle_root: Optional[pathlib.Path] = None
+    ) -> bool:
+        """
+        Test if the model is valid.
+
+        args:
+            model: A top level OSCAL model.
+            quiet: Don't report msgs unless invalid.
+            trestle_root: Trestle root path.
+
+        returns:
+            True (valid) if the model's rule parameter values are the same across controls.
+        """
+        # Clear state from previous validations to avoid cross-test contamination
+        # This is not ideal.
+        self._rule_param_values_dict = {}
+
+        # verify if model type is either an SSP of a Component Definition
+        if not isinstance(model, SystemSecurityPlan):
+            return True
+
+        if not model.import_profile.href:
+            logger.info(f'INVALID: Model {model.metadata.title} has no referenced profile')
+            return False
+        profile_catalog = ProfileResolver().get_resolved_profile_catalog(trestle_root, model.import_profile.href)
+        catalog_interface = CatalogInterface(profile_catalog)
+        # iterate by each implemented requirement defined
+        for imp_req in model.control_implementation.implemented_requirements:
+            # adds rule param values to dict by implemented requirement basis
+            self._add_imp_req_rule_params_to_dict(imp_req, catalog_interface)
+        if self._rule_param_values_dict:
+            # compare all values in shared paramerets by component basis
+            for shared_param, values_dict in self._rule_param_values_dict.items():
+                for comp_name, value_dict in values_dict.items():
+                    expected_value = next(iter(value_dict.values()))
+                    if not all(value == expected_value for value in value_dict.values()):
+                        logger.error(
+                            f'Rule parameter values for param: {shared_param} in '
+                            f' {comp_name} are not consistent with '
+                            'other values provided across controls. Invalid model'
+                        )
+                        return False
+        return True

--- a/trestle/core/rules/rules_interface.py
+++ b/trestle/core/rules/rules_interface.py
@@ -1,0 +1,163 @@
+# Copyright (c) 2026 The OSCAL Compass Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Rules support helpers."""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, List, Optional, Set, Tuple
+
+from trestle.common import const
+from trestle.common.common_types import TypeWithProps
+from trestle.common.err import TrestleError
+from trestle.common.list_utils import as_list
+from trestle.oscal import common
+from trestle.oscal import ssp as ossp
+
+logger = logging.getLogger(__name__)
+
+
+class RulesInterface:
+    """Rule utilities for parsing and filtering rule properties."""
+
+    @staticmethod
+    def get_rules_dict_from_item(item: TypeWithProps) -> Tuple[Dict[str, Dict[str, str]], List[common.Property]]:
+        """Get all rules found in this items props."""
+        # rules is dict containing rule_id and description
+        rules_dict = {}
+        name = ''
+        desc = ''
+        id_ = ''
+        rules_props = []
+        for prop in as_list(item.props):
+            if prop.name == const.RULE_ID:
+                name = prop.value
+                id_ = prop.remarks
+                rules_props.append(prop)
+            elif prop.name == const.RULE_DESCRIPTION:
+                desc = prop.value
+                rules_props.append(prop)
+            # grab each pair in case there are multiple pairs
+            # then clear and look for new pair
+            if name and desc:
+                rules_dict[id_] = {'name': name, 'description': desc}
+                name = desc = id_ = ''
+        return rules_dict, rules_props
+
+    @staticmethod
+    def item_has_rules(item: TypeWithProps) -> bool:
+        """Determine if the item has rules in its props."""
+        _, rules_props = RulesInterface.get_rules_dict_from_item(item)
+        return bool(rules_props)
+
+    @staticmethod
+    def get_rule_list_for_item(item: TypeWithProps) -> Tuple[List[str], List[common.Property]]:
+        """Get the list of rules applying to this item from its top level props."""
+        props = []
+        rule_list = []
+        for prop in as_list(item.props):
+            if prop.name == const.RULE_ID:
+                rule_list.append(prop.value)
+                props.append(prop)
+        return rule_list, props
+
+    @staticmethod
+    def get_rule_list_for_imp_req(
+        imp_req: ossp.ImplementedRequirement,
+    ) -> Tuple[List[str], List[str], List[common.Property]]:
+        """Get the list of rules applying to an imp_req as two lists."""
+        comp_rules, rule_props = RulesInterface.get_rule_list_for_item(imp_req)
+        statement_rules = set()
+        for statement in as_list(imp_req.statements):
+            stat_rules, statement_props = RulesInterface.get_rule_list_for_item(statement)
+            statement_rules.update(stat_rules)
+            rule_props.extend(statement_props)
+        return comp_rules, sorted(statement_rules), rule_props
+
+    @staticmethod
+    def get_params_dict_from_item(item: TypeWithProps) -> Tuple[Dict[str, List[Dict[str, str]]], List[common.Property]]:
+        """Get all params found in this item with rule_id as key."""
+        # id, description, options - where options is a string containing comma-sep list of items
+        # params is dict with rule_id as key and value contains: param_name, description and choices
+        params: Dict[str, List[Dict[str, str]]] = {}
+        props = []
+        for prop in as_list(item.props):
+            if const.PARAMETER_ID in prop.name:
+                rule_id = prop.remarks
+                param_name = prop.value
+                # rule already exists in parameters dict
+                if rule_id is not None:
+                    if rule_id in params.keys():
+                        existing_param = next((prm for prm in params[rule_id] if prm['name'] == param_name), None)
+                        if existing_param is not None:
+                            raise TrestleError(f'Param id for rule {rule_id} already exists')
+                        else:
+                            # append a new parameter for the current rule
+                            params[rule_id].append({'name': param_name})
+                    else:
+                        # create new param for this rule for the first parameter
+                        params[rule_id] = [{'name': param_name}]
+                        props.append(prop)
+            elif const.PARAMETER_DESCRIPTION in prop.name:
+                rule_id = prop.remarks
+                if rule_id in params:
+                    param = next((prm for prm in params[rule_id] if prm['name'] == param_name), None)
+                    if param is not None:
+                        param['description'] = prop.value
+                        props.append(prop)
+                    else:
+                        raise TrestleError(f'Param description for rule {rule_id} found with no param_id')
+            elif const.PARAMETER_VALUE_ALTERNATIVES in prop.name:
+                rule_id = prop.remarks
+                if rule_id in params:
+                    param = next((prm for prm in params[rule_id] if prm['name'] == param_name), None)
+                    if param is not None:
+                        param['options'] = prop.value
+                        props.append(prop)
+                    else:
+                        raise TrestleError(f'Param options for rule {rule_id} found with no param_id')
+        new_params: dict[str, list[dict[str, str]]] = {}
+        for rule_id, rule_params in params.items():
+            new_params[rule_id] = []
+            for param in rule_params:
+                if 'name' not in param:
+                    logger.warning(f'Parameter for rule_id {rule_id} has no matching name.  Ignoring the param.')
+                else:
+                    param['description'] = param.get('description', '')
+                    param['options'] = param.get('options', '')
+                    new_params[rule_id].append(param)
+        return new_params, props
+
+    @staticmethod
+    def get_rules_and_params_dict_from_item(
+        item: TypeWithProps,
+    ) -> Tuple[Dict[str, Dict[str, str]], Dict[str, List[Dict[str, str]]], List[common.Property]]:
+        """Get the rule dict and params dict from item with props."""
+        rules_dict, rules_props = RulesInterface.get_rules_dict_from_item(item)
+        params_dict, params_props = RulesInterface.get_params_dict_from_item(item)
+        rules_props.extend(params_props)
+        return rules_dict, params_dict, rules_props
+
+    @staticmethod
+    def cull_props_by_rules(props: Optional[List[common.Property]], rules: List[str]) -> List[common.Property]:
+        """Cull properties to the ones needed by rules."""
+        needed_rule_ids: Set[str] = set()
+        culled_props: List[common.Property] = []
+        for prop in as_list(props):
+            if prop.value in rules and prop.remarks:
+                needed_rule_ids.add(prop.remarks)
+        for prop in as_list(props):
+            if prop.value in rules or prop.remarks in needed_rule_ids:
+                culled_props.append(prop)
+        return culled_props

--- a/trestle/core/ssp_io.py
+++ b/trestle/core/ssp_io.py
@@ -27,6 +27,7 @@ from trestle.core.control_interface import ControlInterface
 from trestle.core.docs_control_writer import DocsControlWriter
 from trestle.core.markdown.docs_markdown_node import DocsMarkdownNode
 from trestle.core.markdown.md_writer import MDWriter
+from trestle.core.rules import RulesInterface
 from trestle.oscal import ssp
 from trestle.oscal.catalog import Catalog
 
@@ -334,7 +335,7 @@ class SSPMarkdownWriter:
                 prose = by_comp.description
             if by_comp.implementation_status:
                 status = by_comp.implementation_status.state
-            rules, _ = ControlInterface.get_rule_list_for_item(by_comp)
+            rules, _ = RulesInterface.get_rule_list_for_item(by_comp)
 
             if prose or write_empty_responses:
                 if subheader:

--- a/trestle/core/validator_factory.py
+++ b/trestle/core/validator_factory.py
@@ -18,15 +18,9 @@
 from ilcli import Command
 
 from trestle.common import const
-from trestle.core import (
-    all_validator,
-    catalog_validator,
-    duplicates_validator,
-    links_validator,
-    refs_validator,
-    rule_parameters_validator,
-)  # noqa E501
+from trestle.core import all_validator, catalog_validator, duplicates_validator, links_validator, refs_validator  # noqa E501
 from trestle.core.object_factory import ObjectFactory
+from trestle.core.rules import rule_parameters_validator
 
 # Create the singleton validator factory
 validator_factory: ObjectFactory = ObjectFactory()


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)
- [x] Chore (Refactoring/Linting)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

<!--- Uncomment below if changes are for GitHub Actions -->

<!--
### How To Test

If using [act](https://github.com/nektos/act), fill in below:

**act version**  

**act command**
```bash
```
-->

## Summary
- Introduced `trestle.core.rules.RulesInterface` to centralize rule and parameter parsing logic, plus rule-based property culling.
- Refactored `CatalogInterface` and `ControlInterface` to delegate rule parsing/list extraction to the new module, keeping behavior consistent.
- Added a dedicated test suite (`tests/trestle/core/rules_interface_test.py`) covering rule/parameter extraction, error cases, and property culling.
## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)
- Part of #1880 

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
