### PR TITLE
fix: latest pip-tools fails with pip 26.0

### DIFF
--- a/.github/actions/snyk-test/action.yaml
+++ b/.github/actions/snyk-test/action.yaml
@@ -20,6 +20,7 @@ runs:
         SNYK_TOKEN: ${{ inputs.token }}
       run: |
         echo "::group::Running snyk test ..."
+        # latest pip-tools incompatible with pip 26.0
         pip install --force-reinstall 'pip<26.0'
         pip install pip-tools
         pip-compile pyproject.toml -o requirements.txt


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [ ] My code follows the code style of this project.
- [ ] Documentation for my change is up to date?
- [ ] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

<!--- Uncomment below if changes are for GitHub Actions -->

<!--
### How To Test

If using [act](https://github.com/nektos/act), fill in below:

**act version**  

**act command**
```bash
```
-->

## Summary

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
