### PR TITLE
fix: correct typos in docstrings and error messages

### DIFF
--- a/trestle/common/err.py
+++ b/trestle/common/err.py
@@ -30,7 +30,7 @@ class TrestleError(RuntimeError):
     """
 
     def __init__(self, msg: str):
-        """Intialization for TresleError.
+        """Initialization for TrestleError.
 
         Args:
             msg (str): The error message
@@ -53,7 +53,7 @@ class TrestleNotFoundError(TrestleError):
 
     def __init__(self, msg: str):
         """
-        Intialize TresleNotFoundError.
+        Initialize TrestleNotFoundError.
 
         Args:
             msg: The error message
@@ -88,7 +88,7 @@ class TrestleIncorrectArgsError(TrestleError):
 
 
 def handle_generic_command_exception(
-    exception: Exception, logger: Logger, msg: str = 'Exception occured during execution'
+    exception: Exception, logger: Logger, msg: str = 'Exception occurred during execution'
 ) -> int:
     """Print out error message based on the verbosity and return appropriate status code."""
     if get_current_verbosity_level(logger) == 0:

--- a/trestle/common/trash.py
+++ b/trestle/common/trash.py
@@ -53,7 +53,7 @@ def to_trash_file_path(file_path: pathlib.Path) -> pathlib.Path:
 
 
 def to_trash_path(path: pathlib.Path) -> pathlib.Path:
-    """Convert the dir or file path to apporpriate trash file or dir path."""
+    """Convert the dir or file path to appropriate trash file or dir path."""
     if path.suffix != '':
         return to_trash_file_path(path)
     return to_trash_dir_path(path)

--- a/trestle/core/commands/create.py
+++ b/trestle/core/commands/create.py
@@ -54,7 +54,7 @@ class CreateCmd(CommandPlusDocs):
             '-f', '--file', help='Optional existing OSCAL file that will have elements created within it.', type=str
         )
         self.add_argument(
-            '-e', '--element', help='Optional path of element to be created whithin the specified file.', type=str
+            '-e', '--element', help='Optional path of element to be created within the specified file.', type=str
         )
 
     def _run(self, args: argparse.Namespace) -> int:

--- a/trestle/core/commands/task.py
+++ b/trestle/core/commands/task.py
@@ -64,7 +64,7 @@ class TaskCmd(CommandPlusDocs):
 
             if not args.task and not args.list:
                 raise TrestleIncorrectArgsError(
-                    'Either a trestle task or "-l/--list" shoudl be passed as input arguments.'
+                    'Either a trestle task or "-l/--list" should be passed as input arguments.'
                 )
 
             # Ensure trestle directory (must be true)

--- a/trestle/core/commands/version.py
+++ b/trestle/core/commands/version.py
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Trestle Validate Command."""
+"""Trestle Version Command."""
 
 import argparse
 import logging

--- a/trestle/core/repository.py
+++ b/trestle/core/repository.py
@@ -58,7 +58,7 @@ class ManagedOSCAL:
         self.model_type = model_type
         self.model_name = name
 
-        # set model alais and dir
+        # set model alias and dir
         self.model_alias = classname_to_alias(self.model_type.__name__, AliasMode.JSON)
         if parser.to_full_model_name(self.model_alias) is None:
             raise TrestleError(f'Given model {self.model_alias} is not a top level model.')
@@ -145,13 +145,13 @@ class ManagedOSCAL:
         except Exception as e:
             raise TrestleError(f'Error in splitting model: {e}')
 
-        logger.debug(f'Model {self.model_name}, file {model_file} splitted successfully.')
+        logger.debug(f'Model {self.model_name}, file {model_file} split successfully.')
         return success
 
     def merge(self, elements: List[str], parent_model_dir: Optional[pathlib.Path] = None) -> bool:
         """Merge OSCAL elements in repository.
 
-        The parent_model_dir specifies the parent model direcotry in which to merge relative to main model dir.
+        The parent_model_dir specifies the parent model directory in which to merge relative to main model dir.
         For example, if we have to merge 'metadata.*' into 'metadata' then parent_model_dir should be the 'catalog'
         dir that contains the 'metadata.json' file or the 'metadata' directory
         """


### PR DESCRIPTION
## Issue

Several minor spelling mistakes were present in docstrings and user-facing error messages across multiple modules.

## Changes

- Corrected spelling and grammar in:
  - trestle/common/err.py
  - trestle/common/trash.py
  - trestle/core/commands/create.py
  - trestle/core/commands/task.py
  - trestle/core/commands/version.py
  - trestle/core/repository.py
