### PR TITLE
fix: correct typos in docstrings (hierarchical)

### DIFF
--- a/trestle/core/draw_io.py
+++ b/trestle/core/draw_io.py
@@ -114,7 +114,7 @@ class DrawIO:
 
     @classmethod
     def restructure_metadata(cls, input_dict: Dict[str, str]) -> Dict[str, Any]:
-        """Restructure metadata into a hierarchial dict assuming a period separator."""
+        """Restructure metadata into a hierarchical dict assuming a period separator."""
         # get the list of duplicate keys
         # Get a count of keys
         result = {}
@@ -183,7 +183,7 @@ class DrawIO:
             self.raw_xml.write(path)
 
     def _flatten_dictionary(self, metadata: Dict, parent_key='', separator='.') -> Dict[str, str]:
-        """Flatten hierarchial dict back to xml attributes."""
+        """Flatten hierarchical dict back to xml attributes."""
         items = []
         for key, value in metadata.items():
             new_key = parent_key + separator + key if parent_key else key

--- a/trestle/core/markdown/markdown_validator.py
+++ b/trestle/core/markdown/markdown_validator.py
@@ -79,7 +79,7 @@ class MarkdownValidator:
                 a. No additional headers of the level 1 were added
                 b. Headers were not reordered
                 c. Headers in the instance should be a superset of the template headers
-                d. Headers must be in heirarchical order (i.e. # then ### then ## is not allowed)
+                d. Headers must be in hierarchical order (i.e. # then ### then ## is not allowed)
             3. If Governed Header is given then:
                 a. Governed Header is not modified
                 b. All keys (i.e. key: something) inside the section are present


### PR DESCRIPTION
Fix two misspelled docstring words across `draw_io.py` and `markdown_validator.py`.

Changes:
- trestle/core/draw_io.py: correct `"hierarchial"` → `"hierarchical"` in `restructure_metadata` and `_flatten_dictionary` docstrings
- trestle/core/markdown/markdown_validator.py: correct `"heirarchical"` → `"hierarchical"` in `validate` docstring

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

<!--- Uncomment below if changes are for GitHub Actions -->

<!--
### How To Test

If using [act](https://github.com/nektos/act), fill in below:

**act version**  

**act command**
```bash
```
-->

## Summary

Three docstring typos corrected — no logic changes, no test changes required.

| File | Line | Before | After |
|---|---|---|---|
| `trestle/core/draw_io.py` | 117 | `hierarchial` | `hierarchical` |
| `trestle/core/draw_io.py` | 186 | `hierarchial` | `hierarchical` |
| `trestle/core/markdown/markdown_validator.py` | 82 | `heirarchical` | `hierarchical` |

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
