### PR TITLE
fix(docs-ci): pin MkDocs below 2.0 and suppress MkDocs 2 warning in docs workflows (fixes #2104)

### DIFF
--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -86,6 +86,8 @@ jobs:
         ID: ${{ steps.get-user-id.outputs.user-id }}
     - name: Create release
       shell: bash
+      env:
+        NO_MKDOCS_2_WARNING: 1
       run: |
         mike deploy --push ${{ needs.mike-version.outputs.mver }}
     - name: Ensure latest is latest

--- a/.github/workflows/python-push.yml
+++ b/.github/workflows/python-push.yml
@@ -101,6 +101,8 @@ jobs:
         make docs-ubuntu-deps
     - name: Validate website content (mkdocs)
       if: steps.core-version.outputs.core == 'true'
+      env:
+        NO_MKDOCS_2_WARNING: 1
       run: |
         make docs-validate
     - name: Pytest Fast

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -67,6 +67,8 @@ jobs:
       run: |
         make docs-ubuntu-deps
     - name: Validate website content (mkdocs)
+      env:
+        NO_MKDOCS_2_WARNING: 1
       run: |
         make docs-validate
     - name: Check if dirty (mkdocs)

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ submodules: ## Initialize git submodules (nist-content, oscal)
 	git submodule update --init
 
 develop: submodules ## Set up development environment
-	pip install hatch "virtualenv>=20.26.6,<21"  # Pin until hatch supports virtualenv 21.x
+	pip install hatch
 	pip install -e .[dev]
 
 pre-commit: ## Install pre-commit hooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,15 +113,6 @@ packages = ["trestle"]
 [tool.hatch.envs.default]
 dependencies = [
   "coverage[toml]~=7.4",
-  "virtualenv>=20.26.6,<21",  # Pin until hatch supports virtualenv 21.x
-]
-
-# Constrains the internal environment hatch uses to run build hooks.
-# Without this, hatch resolves the latest virtualenv (21.x+) which breaks
-# the hatch-build env due to removed `propose_interpreters` API.
-[tool.hatch.envs.hatch-build]
-dependencies = [
-  "virtualenv>=20.26.6,<21",  # Pin until hatch supports virtualenv 21.x
 ]
 
 [tool.hatch.envs.hatch-test]
@@ -134,7 +125,6 @@ dependencies = [
     "pytest-xdist[psutil]>=3.5",
     "pytest-randomly>=3.15",
     "mypy",
-    "virtualenv>=20.26.6,<21",  # Pin until hatch supports virtualenv 21.x
 ]
 
 [[tool.hatch.envs.hatch-test.matrix]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ typing = [
 # Documentation website
 docs = [
     "mike",
-    "mkdocs>=1.6.0",
+    "mkdocs>=1.6.0,<2.0.0",
     "mkdocs-awesome-pages-plugin",
     "mkdocstrings[python]>=0.25.2",
     "mkdocs-htmlproofer-plugin",


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an x in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (develop -> main)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

<!--- Uncomment below if changes are for GitHub Actions -->

<!--
### How To Test

If using act, fill in below:

act version  

act command
bash
-->

## Summary

This PR fixes issue #2104 by preventing accidental adoption of MkDocs 2.0, which is currently incompatible with our Material-based docs stack.

Changes included:
- Pinned MkDocs dependency to a safe range in pyproject.toml:
  - from mkdocs>=1.6.0
  - to mkdocs>=1.6.0,<2.0.0
- Added NO_MKDOCS_2_WARNING=1 in documentation-related GitHub Actions steps to keep CI logs clean while we remain on MkDocs 1.x:
  - python-test workflow docs validation step
  - python-push workflow docs validation step
  - docs-update workflow release step

Why:
- MkDocs 2.0 removes plugin support used by our current documentation setup.
- This keeps docs builds stable and non-breaking while the ecosystem migration path matures.

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)
- [Issue #2104](https://github.com/oscal-compass/compliance-trestle/issues/2104)

# Before you merge

- Ensure it is a squash commit if not a release.
- Ensure CI is currently passing.
- Check Sonar. If you are working on a fork, a maintainer will reach out if required.