### PR TITLE
fix: raise TrestleError when get_singular_alias path ends with numeric index

### DIFF
--- a/tests/trestle/utils/fs_test.py
+++ b/tests/trestle/utils/fs_test.py
@@ -430,8 +430,8 @@ def test_get_singular_alias() -> None:
     assert 'control-implementation' == ModelUtils.get_singular_alias(
         alias_path='component-definition.components.0.control-implementations'
     )
-    # FIXME ideally this should report error
-    assert '0' == ModelUtils.get_singular_alias(alias_path='component-definition.components.0')
+    with pytest.raises(TrestleError):
+        ModelUtils.get_singular_alias(alias_path='component-definition.components.0')
 
     assert 'control' == ModelUtils.get_singular_alias(alias_path='catalog.groups.*.controls.*.controls')
 

--- a/trestle/common/model_utils.py
+++ b/trestle/common/model_utils.py
@@ -443,6 +443,10 @@ class ModelUtils:
         last_alias = path_parts[-1]
         if last_alias == '*':
             last_alias = path_parts[-2]
+        elif last_alias.isdigit():
+            raise err.TrestleError(
+                f'Invalid alias path {alias_path}: path cannot terminate with a numeric index.'
+            )
 
         # generic model and not list, so return itself fixme doc
         if not utils.is_collection_field_type(model_type):

--- a/trestle/common/model_utils.py
+++ b/trestle/common/model_utils.py
@@ -444,9 +444,7 @@ class ModelUtils:
         if last_alias == '*':
             last_alias = path_parts[-2]
         elif last_alias.isdigit():
-            raise err.TrestleError(
-                f'Invalid alias path {alias_path}: path cannot terminate with a numeric index.'
-            )
+            raise err.TrestleError(f'Invalid alias path {alias_path}: path cannot terminate with a numeric index.')
 
         # generic model and not list, so return itself fixme doc
         if not utils.is_collection_field_type(model_type):


### PR DESCRIPTION
## PR Title
fix: raise TrestleError when get_singular_alias path ends with numeric index (#2140)
Closes #2140 


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

<!--- Uncomment below if changes are for GitHub Actions -->

<!--
### How To Test

If using [act](https://github.com/nektos/act), fill in below:

**act version**  

**act command**
```bash
```
-->

## Summary

`ModelUtils.get_singular_alias()` previously returned the numeric index string (e.g. `'0'`) when called with a path that terminates on an array index such as `component-definition.components.0`. This is meaningless as an alias and was explicitly flagged in the test suite with a `# FIXME ideally this should report error` comment.

### Root cause

In `get_singular_alias()`, after the traversal loop, the branch that handles non-collection terminal model types (`if not utils.is_collection_field_type(model_type)`) returned `last_alias` without checking whether it was a numeric index. When an index like `0` was the last path segment, the loop unwrapped the collection's inner type (leaving a non-collection model type) and the function fell straight through to `return last_alias`, returning `'0'`.

### Fix

Added a guard after extracting `last_alias` to check whether it is a pure digit string. If so, a `TrestleError` is raised with a clear message before any further processing.

```python
elif last_alias.isdigit():
    raise err.TrestleError(
        f'Invalid alias path {alias_path}: path cannot terminate with a numeric index.'
    )
```

Numeric indices appearing **in the middle** of a path (e.g. `component-definition.components.0.control-implementations`) continue to work correctly and are unaffected.

### Changes

| File | Change |
|---|---|
| `trestle/common/model_utils.py` | Added `elif last_alias.isdigit()` guard to raise `TrestleError` |
| `tests/trestle/utils/fs_test.py` | Updated test: replaced `assert '0' == ...` + `# FIXME` with `pytest.raises(TrestleError)` |

Closes #2140

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
