### PR TITLE
fix: preserve dotted catalog names in validate -a

### DIFF
--- a/docs/contributing/plugins.md
+++ b/docs/contributing/plugins.md
@@ -5,7 +5,7 @@ description: Trestle provides a mechanism for 3rd party providers to extend its 
 
 # Adding plugins to trestle
 
-Trestle provides a mechanism for 3rd party providers to extend its command interface via a plugin architecture. All trestle plugins that conforms to this specification will be automatically discovered by trestle if installed, and their command(s) will be added to trestle sub-commands list. Below we describe this plugin mechanism with the help of an example plugin [`compliance-trestle-fedramp`](https://github.com/oscal-compass/compliance-trestle-fedramp) that we created as a separate python project that can be installed via `pip`.
+Trestle provides a mechanism for 3rd party providers to extend its command interface via a plugin architecture. All trestle plugins that conforms to this specification will be automatically discovered by trestle if installed, and their command(s) will be added to trestle sub-commands list. Below we describe this plugin mechanism with the help of the [`compliance-trestle-fedramp`](../plugins/fedramp.md) example plugin that can be installed via `pip`.
 
 ## Create the trestle plugin proejct
 

--- a/tests/trestle/core/commands/validate_test.py
+++ b/tests/trestle/core/commands/validate_test.py
@@ -210,6 +210,22 @@ def test_oscal_version_validator(
     assert pytest_wrapped_e.value.code == CmdReturnCodes.SUCCESS.value
 
 
+def test_validate_all_with_dotted_catalog_name(
+    tmp_trestle_dir: pathlib.Path, sample_catalog_minimal: Catalog, monkeypatch: MonkeyPatch
+) -> None:
+    """Test validate -a succeeds when a top-level model directory name contains dots."""
+    mycat_dir = tmp_trestle_dir / 'catalogs/foo.bar'
+    mycat_dir.mkdir()
+    mycat_path = mycat_dir / 'catalog.json'
+    sample_catalog_minimal.oscal_write(mycat_path)
+    testcmd = 'trestle validate -a'
+    monkeypatch.setattr(sys, 'argv', testcmd.split())
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        cli.run()
+    assert pytest_wrapped_e.type == SystemExit
+    assert pytest_wrapped_e.value.code == CmdReturnCodes.SUCCESS.value
+
+
 def test_oscal_version_incorrect_validator(tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
     """Test validation fails for bad oscal version. Short pydantic message should be printed."""
     catalog_path = test_utils.JSON_TEST_DATA_PATH / 'minimal_catalog_bad_oscal_version.json'

--- a/tests/trestle/utils/fs_test.py
+++ b/tests/trestle/utils/fs_test.py
@@ -554,6 +554,18 @@ def test_get_models_of_type(tmp_trestle_dir) -> None:
         ModelUtils.get_models_of_type('foo', tmp_trestle_dir)
 
 
+def test_get_models_of_type_preserves_dots(tmp_trestle_dir) -> None:
+    """Test model discovery preserves dots in top-level model directory names."""
+    catalogs_dir = tmp_trestle_dir.resolve() / 'catalogs'
+    (catalogs_dir / 'foo.bar').mkdir()
+
+    models = ModelUtils.get_models_of_type('catalog', tmp_trestle_dir)
+    all_models = ModelUtils.get_all_models(tmp_trestle_dir)
+
+    assert 'foo.bar' in models
+    assert ('catalog', 'foo.bar') in all_models
+
+
 def test_get_models_of_type_bad_cwd(tmp_path) -> None:
     """Test fs.get_models_of_type() from outside trestle dir."""
     with pytest.raises(TrestleError):

--- a/trestle/common/model_utils.py
+++ b/trestle/common/model_utils.py
@@ -479,17 +479,15 @@ class ModelUtils:
         root_model_dir = trestle_root / model_dir_name
         model_list = []
         for f in root_model_dir.glob('*/'):
-            # Use f.name for directories to preserve full directory name including dots
-            # f.stem is for files and incorrectly treats dots as file extensions
-            dir_name = f.name
-            if not ModelUtils._should_ignore(dir_name):
+            # Use the full directory name; Path.stem would incorrectly strip dotted model names.
+            if not ModelUtils._should_ignore(f.name):
                 if not f.is_dir():
                     logger.warning(
-                        f'Ignoring validation of misplaced file {dir_name} '
+                        f'Ignoring validation of misplaced file {f.name} '
                         + f'found in the model directory, {model_dir_name}.'
                     )
                 else:
-                    model_list.append(dir_name)
+                    model_list.append(f.name)
         return model_list
 
     @staticmethod


### PR DESCRIPTION
## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary

Fixes `trestle validate -a` when a top-level catalog directory contains a `.` in its name, for example `catalogs/foo.bar`.

This change preserves the full directory name by using `Path.name` for top-level model discovery.

## Key links:

- Closes #2145
- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)
