### PR TITLE
fix(author): enforce semver matching and numeric template ordering

### DIFF
--- a/tests/trestle/core/commands/author/versioning/template_versioning_test.py
+++ b/tests/trestle/core/commands/author/versioning/template_versioning_test.py
@@ -107,6 +107,36 @@ def test_get_latest_version(tmp_path: pathlib.Path) -> None:
         TemplateVersioning.get_latest_version_for_task(template_v1)
 
 
+def test_get_latest_version_numeric_ordering(tmp_path: pathlib.Path) -> None:
+    """Test latest version selection uses numeric semver ordering, not lexicographic ordering."""
+    task_path = tmp_path.joinpath('trestle/author/sample_task/')
+    task_path.mkdir(parents=True)
+
+    task_path.joinpath('2.0.0').mkdir(parents=True)
+    task_path.joinpath('10.0.0').mkdir(parents=True)
+    task_path.joinpath('1.12.9').mkdir(parents=True)
+
+    latest_path, version = TemplateVersioning.get_latest_version_for_task(task_path)
+    assert latest_path == task_path.joinpath('10.0.0')
+    assert version == '10.0.0'
+
+
+def test_get_all_versions_for_task_strict_semver_dirs_only(tmp_path: pathlib.Path) -> None:
+    """Test only strict semantic version directories are considered template versions."""
+    task_path = tmp_path.joinpath('trestle/author/sample_task/')
+    task_path.mkdir(parents=True)
+
+    task_path.joinpath('1.2.3').mkdir(parents=True)
+    task_path.joinpath('10.0.0').mkdir(parents=True)
+    task_path.joinpath('v1.2.3').mkdir(parents=True)
+    task_path.joinpath('1.2.3-backup').mkdir(parents=True)
+    task_path.joinpath('1x2x3').mkdir(parents=True)
+
+    versions = TemplateVersioning.get_all_versions_for_task(task_path)
+
+    assert set(versions) == {'1.2.3', '10.0.0'}
+
+
 def test_get_versioned_template(tmp_path: pathlib.Path) -> None:
     """Test get template of the specified version."""
     task_path = tmp_path.joinpath('trestle/author/sample_task/')

--- a/trestle/common/const.py
+++ b/trestle/common/const.py
@@ -258,7 +258,7 @@ MATCH_ALL_EXCEPT_LETTERS_UNDERSCORE_SPACE_REGEX = '[^a-zA-Z0-9-_ \n]'
 MARKDOWN_URL_REGEX = r'\[([^\]]+)\]\(([^)]+)\)'
 
 # Governed header template version
-TEMPLATE_VERSION_REGEX = r'[0-9]+.[0-9]+.[0-9]+'
+TEMPLATE_VERSION_REGEX = r'^[0-9]+\.[0-9]+\.[0-9]+$'
 
 OBJECTIVE_PART = 'objective'
 ASSESMENT_OBJECTIVE_PART = 'assessment-objective'

--- a/trestle/core/commands/author/versioning/template_versioning.py
+++ b/trestle/core/commands/author/versioning/template_versioning.py
@@ -77,7 +77,7 @@ class TemplateVersioning:
             pattern = re.compile(TEMPLATE_VERSION_REGEX)
             all_non_template_directories = list(
                 filter(
-                    lambda p: p.is_dir() and pattern.search(p.parts[-1]) is None,
+                    lambda p: p.is_dir() and pattern.fullmatch(p.parts[-1]) is None,
                     file_utils.iterdir_without_hidden_files(task_path),
                 )
             )
@@ -139,7 +139,7 @@ class TemplateVersioning:
             logger.debug(f'No template versions were found for task: {task_path}, defaulting to 0.0.1')
             max_version = START_TEMPLATE_VERSION
         else:
-            max_version = max(all_versions)
+            max_version = max(all_versions, key=TemplateVersioning._version_sort_key)
 
         latest_path = Path(f'{task_path}/{max_version}')
 
@@ -150,13 +150,9 @@ class TemplateVersioning:
         """Get all versions for the task."""
         pattern = re.compile(TEMPLATE_VERSION_REGEX)
         all_versions = []
-        max_version = START_TEMPLATE_VERSION
         for p in task_path.iterdir():
-            if p.is_dir() and pattern.search(p.parts[-1]) is not None:
-                match = pattern.search(p.parts[-1]).string
-                all_versions.append(match)
-                if match > max_version:
-                    max_version = match
+            if p.is_dir() and pattern.fullmatch(p.parts[-1]) is not None:
+                all_versions.append(p.parts[-1])
 
         return all_versions
 
@@ -213,12 +209,19 @@ class TemplateVersioning:
             return True  # we can have empty version
         if template_version == '0.0.0':
             return False
-        version_regex = r'^[0-9]+\.[0-9]+\.[0-9]+$'
-        pattern = re.compile(version_regex)
-        if pattern.search(template_version):
+        if re.fullmatch(TEMPLATE_VERSION_REGEX, template_version):
             return True
         else:
             return False
+
+    @staticmethod
+    def _version_sort_key(version: str) -> Tuple[int, int, int]:
+        """Convert a semantic version string into an integer tuple for numeric comparisons."""
+        if not re.fullmatch(TEMPLATE_VERSION_REGEX, version):
+            raise TrestleError(f'Invalid template version format: {version}')
+
+        major, minor, patch = version.split('.')
+        return int(major), int(minor), int(patch)
 
     @staticmethod
     def _check_if_exists_and_dir(task_path: Path) -> None:


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

<!--- Uncomment below if changes are for GitHub Actions -->

<!--
### How To Test

If using [act](https://github.com/nektos/act), fill in below:

**act version**

**act command**
```bash
```
-->

## Summary

Fix template version parsing and ordering so template directories are identified strictly by semantic version and latest version selection is numeric (not lexicographic).

Changes made:
- `TEMPLATE_VERSION_REGEX` is now strict semver (`^X.Y.Z$`) instead of a loose pattern.
- `TemplateVersioning.update_template_folder_structure()` now uses strict full-match checks for version folders.
- `TemplateVersioning.get_all_versions_for_task()` now includes only strict semver directory names.
- `TemplateVersioning.get_latest_version_for_task()` now sorts versions numerically by `(major, minor, patch)`.
- `TemplateVersioning.is_valid_version()` now uses the shared strict regex constant.
- Added regression tests for:
  - numeric ordering (`10.0.0` over `2.0.0`)
  - strict semver-only directory filtering.

Files updated:
- `trestle/common/const.py`
- `trestle/core/commands/author/versioning/template_versioning.py`
- `tests/trestle/core/commands/author/versioning/template_versioning_test.py`

Validation run:
- `pytest tests/trestle/core/commands/author/versioning/template_versioning_test.py -q --basetemp .pytest_tmp`
- Result: `9 passed`

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
