### PR TITLE
fix(model-utils): resolve indexed terminal alias

### DIFF
--- a/tests/trestle/utils/fs_test.py
+++ b/tests/trestle/utils/fs_test.py
@@ -448,6 +448,10 @@ def test_get_singular_alias() -> None:
     assert 'control' == ModelUtils.get_singular_alias(alias_path='catalog.groups.0.controls.0')
     assert 'control' == ModelUtils.get_singular_alias(alias_path='catalog.groups.0.controls')
 
+    # Cover indexed terminal error branch for short path depth
+    with pytest.raises(TrestleError, match='unable to resolve indexed collection alias'):
+        ModelUtils.get_singular_alias(alias_path='catalog.0')
+
     assert 'control' == ModelUtils.get_singular_alias(alias_path='catalog.groups.*.controls.*.controls')
 
 

--- a/tests/trestle/utils/fs_test.py
+++ b/tests/trestle/utils/fs_test.py
@@ -441,8 +441,12 @@ def test_get_singular_alias() -> None:
     assert 'control-implementation' == ModelUtils.get_singular_alias(
         alias_path='component-definition.components.0.control-implementations'
     )
-    # FIXME ideally this should report error
-    assert '0' == ModelUtils.get_singular_alias(alias_path='component-definition.components.0')
+    # Test indexed terminal paths resolve correctly
+    assert 'defined-component' == ModelUtils.get_singular_alias(alias_path='component-definition.components.0')
+
+    # Test indexed nested paths
+    assert 'control' == ModelUtils.get_singular_alias(alias_path='catalog.groups.0.controls.0')
+    assert 'control' == ModelUtils.get_singular_alias(alias_path='catalog.groups.0.controls')
 
     assert 'control' == ModelUtils.get_singular_alias(alias_path='catalog.groups.*.controls.*.controls')
 
@@ -478,6 +482,7 @@ def test_contextual_get_singular_alias(tmp_path: pathlib.Path, keep_cwd: pathlib
 
     rel_dir = group_dir.relative_to(tmp_path)
     assert 'control' == ModelUtils.get_singular_alias('group.controls.*.controls', rel_dir)
+    assert 'control' == ModelUtils.get_singular_alias('group.controls.0', rel_dir)
 
 
 def test_get_contextual_file_type(tmp_path: pathlib.Path) -> None:

--- a/tests/trestle/utils/fs_test.py
+++ b/tests/trestle/utils/fs_test.py
@@ -15,7 +15,7 @@
 
 import pathlib
 from datetime import datetime, timedelta
-from typing import List
+from typing import List, Union
 
 import pytest
 
@@ -25,7 +25,7 @@ import trestle.common.const as const
 import trestle.oscal.common as common
 from trestle.common import file_utils, trash
 from trestle.common.err import TrestleError
-from trestle.common.model_utils import ModelUtils
+from trestle.common.model_utils import ModelUtils, _get_model_type_from_union
 from trestle.core.models.file_content_type import FileContentType
 from trestle.oscal import catalog
 
@@ -732,3 +732,166 @@ def test_model_age_multiday(sample_catalog_rich_controls: catalog.Catalog) -> No
     age = ModelUtils.model_age(sample_catalog_rich_controls)
     # Two days is 172800 seconds; timedelta.seconds (old bug) would return 0, not 172800
     assert age >= 2 * const.DAY_SECONDS
+
+
+def test_get_model_type_from_union_with_exception() -> None:
+    """Test _get_model_type_from_union when alias_to_field_map raises an exception."""
+
+    class MockTypeWithFieldMap:
+        """Mock type that has alias_to_field_map method."""
+
+        @classmethod
+        def alias_to_field_map(cls):
+            return {'field1': 'value1', 'field2': 'value2'}
+
+    class MockTypeWithBrokenFieldMap:
+        """Mock type that has alias_to_field_map but raises an exception."""
+
+        @classmethod
+        def alias_to_field_map(cls):
+            raise RuntimeError('alias_to_field_map is broken')
+
+    class MockTypeWithoutFieldMap:
+        """Mock type without alias_to_field_map method."""
+
+        pass
+
+    union_type = Union[MockTypeWithBrokenFieldMap, MockTypeWithFieldMap]
+    result = _get_model_type_from_union(union_type, 'field1')
+    assert result == MockTypeWithFieldMap
+
+    union_type_no_map = Union[MockTypeWithoutFieldMap, int, str]
+    result_no_map = _get_model_type_from_union(union_type_no_map, 'field1')
+    assert result_no_map == MockTypeWithoutFieldMap
+
+    union_type_all_broken = Union[MockTypeWithBrokenFieldMap, MockTypeWithoutFieldMap]
+    result_fallback = _get_model_type_from_union(union_type_all_broken, 'field1')
+    assert result_fallback == MockTypeWithBrokenFieldMap
+
+    union_type_no_field = Union[MockTypeWithFieldMap, MockTypeWithoutFieldMap]
+    result_no_field = _get_model_type_from_union(union_type_no_field, None)
+    assert result_no_field == MockTypeWithFieldMap
+
+    result_non_union = _get_model_type_from_union(MockTypeWithFieldMap, 'field1')
+    assert result_non_union == MockTypeWithFieldMap
+
+
+def test_resolve_collection_item_alias_error() -> None:
+    """Test _resolve_collection_item_alias exception handling."""
+    from trestle.common.model_utils import _resolve_collection_item_alias
+
+    with pytest.raises(TrestleError, match='Error in json path'):
+        _resolve_collection_item_alias(str, 'invalid_field', 'test.path.invalid_field')
+
+    class MockTypeNoMap:
+        pass
+
+    with pytest.raises(TrestleError, match='Error in json path'):
+        _resolve_collection_item_alias(MockTypeNoMap, 'field1', 'test.path.field1')
+
+
+def test_dict_to_parameter_value_not_in_choices() -> None:
+    """Test dict_to_parameter when a value is not in the select choices."""
+    param_dict = {
+        'id': 'test_param',
+        'label': 'Test Parameter',
+        'values': ['invalid_value', 'choice1'],
+        'select': {'how_many': 'one-or-more', 'choice': ['choice1', 'choice2', 'choice3']},
+    }
+
+    param = ModelUtils.dict_to_parameter(param_dict)
+    assert param.id == 'test_param'
+    assert param.select is not None
+    assert param.select.choice == ['choice1', 'choice2', 'choice3']
+
+
+def test_objects_differ_enum_and_root_comparisons() -> None:
+    """Test _objects_differ with enum and __root__ wrapper comparisons."""
+    from enum import Enum
+
+    class TestEnum(Enum):
+        VALUE1 = 'value1'
+        VALUE2 = 'value2'
+
+    class MockRootWrapper:
+        def __init__(self, value):
+            self.__root__ = value
+
+    enum_val = TestEnum.VALUE1
+    assert not ModelUtils._objects_differ(enum_val, 'value1', [], [], False)
+    assert ModelUtils._objects_differ(enum_val, 'value2', [], [], False)
+
+    assert not ModelUtils._objects_differ('value1', enum_val, [], [], False)
+    assert ModelUtils._objects_differ('value2', enum_val, [], [], False)
+
+    root_wrapper = MockRootWrapper('value1')
+    assert not ModelUtils._objects_differ(enum_val, root_wrapper, [], [], False)
+
+    root_wrapper_diff = MockRootWrapper('value2')
+    assert ModelUtils._objects_differ(enum_val, root_wrapper_diff, [], [], False)
+
+    from pydantic.v1 import BaseModel as PydanticBaseModel
+
+    class TestModel(PydanticBaseModel):
+        value: str
+
+    def create_test_model_class():
+        class TestModel(PydanticBaseModel):
+            value: str
+
+        return TestModel
+
+    test_model2 = create_test_model_class()
+
+    obj1 = TestModel(value='test1')
+    obj2 = test_model2(value='test2')
+    assert ModelUtils._objects_differ(obj1, obj2, [], [], False)
+
+    prop1 = common.Property(name='test', value='val1')
+    prop2 = common.Property(name='test', value='val2')
+    assert ModelUtils._objects_differ(prop1, prop2, [], [], False)
+
+    role = common.Role(id='role1', title='Test Role')
+    assert ModelUtils._objects_differ(prop1, role, [], [], False)
+
+    assert ModelUtils._objects_differ(123, 'string', [], [], False)
+    assert not ModelUtils._objects_differ('', '', [], [], False)
+    assert not ModelUtils._objects_differ(0, 0, [], [], False)
+
+    prop3 = common.Property(name='test3', value='val3')
+    prop4 = common.Property(name='test4', value='val4')
+    assert not ModelUtils._objects_differ(prop3, prop4, [common.Property], [], False)
+
+
+def test_last_modified_at_time() -> None:
+    """Test last_modified_at_time with and without timestamp."""
+    from datetime import timezone
+
+    test_timestamp = datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+    result = ModelUtils.last_modified_at_time(test_timestamp)
+    assert result == test_timestamp
+
+    result_now = ModelUtils.last_modified_at_time(None)
+    assert result_now is not None
+    assert isinstance(result_now, datetime)
+    assert result_now.tzinfo is not None
+
+
+def test_objects_differ_dict_comparisons() -> None:
+    """Test _objects_differ with dict comparisons."""
+    dict_a = {'key1': 'value1', 'key2': 'value2'}
+    dict_b = {'key1': 'value1', 'key3': 'value3'}
+    assert ModelUtils._objects_differ(dict_a, dict_b, [], [], False)
+
+    dict_with_uuid_a = {'uuid': 'uuid-123', 'name': 'test'}
+    dict_with_uuid_b = {'uuid': 'uuid-456', 'name': 'test'}
+    assert not ModelUtils._objects_differ(dict_with_uuid_a, dict_with_uuid_b, [], [], True)
+    assert ModelUtils._objects_differ(dict_with_uuid_a, dict_with_uuid_b, [], [], False)
+
+    dict_diff_val_a = {'key1': 'value1', 'key2': 'value2'}
+    dict_diff_val_b = {'key1': 'value1', 'key2': 'different'}
+    assert ModelUtils._objects_differ(dict_diff_val_a, dict_diff_val_b, [], [], False)
+
+    dict_ignore_a = {'key1': 'value1', 'ignored_key': 'value2'}
+    dict_ignore_b = {'key1': 'value1', 'ignored_key': 'different'}
+    assert not ModelUtils._objects_differ(dict_ignore_a, dict_ignore_b, [], ['ignored_key'], False)

--- a/tests/trestle/utils/fs_test.py
+++ b/tests/trestle/utils/fs_test.py
@@ -438,17 +438,16 @@ def test_get_singular_alias() -> None:
     assert 'control-implementation' == ModelUtils.get_singular_alias(
         alias_path='component-definition.components.*.control-implementations'
     )
-    assert 'control-implementation' == ModelUtils.get_singular_alias(
-        alias_path='component-definition.components.0.control-implementations'
-    )
-    # Test indexed terminal paths resolve correctly
     assert 'defined-component' == ModelUtils.get_singular_alias(alias_path='component-definition.components.0')
 
     # Test indexed nested paths
+    assert 'control-implementation' == ModelUtils.get_singular_alias(
+        alias_path='component-definition.components.0.control-implementations'
+    )
     assert 'control' == ModelUtils.get_singular_alias(alias_path='catalog.groups.0.controls.0')
     assert 'control' == ModelUtils.get_singular_alias(alias_path='catalog.groups.0.controls')
 
-    # Cover indexed terminal error branch for short path depth
+    # Test that a too-shallow indexed path raises TrestleError (covers len(model_types) < 3 guard)
     with pytest.raises(TrestleError, match='unable to resolve indexed collection alias'):
         ModelUtils.get_singular_alias(alias_path='catalog.0')
 

--- a/trestle/common/model_utils.py
+++ b/trestle/common/model_utils.py
@@ -95,6 +95,21 @@ def _get_model_type_from_union(model_type: Type[Any], field_name: Optional[str] 
     return model_type
 
 
+def _resolve_collection_item_alias(parent_model_type: Type[Any], field_alias: str, alias_path: str) -> str:
+    """Resolve the singular alias for an item in a collection field."""
+    try:
+        parent_model_type = _get_model_type_from_union(parent_model_type, field_alias)
+        field_map = parent_model_type.alias_to_field_map()
+        field = field_map[field_alias]
+        outer_type = field.outer_type_
+        inner_type = utils.get_inner_type(outer_type)
+        inner_type = _get_model_type_from_union(inner_type)
+        inner_type_name = inner_type.__name__
+        return str_utils.classname_to_alias(inner_type_name, AliasMode.JSON)
+    except Exception as e:
+        raise err.TrestleError(f'Error in json path {alias_path}: {e}') from e
+
+
 class ModelUtils:
     """Utilities for the OSCAL models input and output."""
 
@@ -589,56 +604,20 @@ class ModelUtils:
         # Terminal numeric indexes (e.g. "component-definition.components.0")
         # refer to an item in the preceding collection; resolve to that item's alias.
         if path_parts[-1].isdigit():
+            if len(path_parts) < 2:
+                raise err.TrestleError(f'Error in json path {alias_path}: unable to resolve indexed collection alias')
             indexed_collection_alias = path_parts[-2]
             if len(model_types) < 3:
                 raise err.TrestleError(f'Error in json path {alias_path}: unable to resolve indexed collection alias')
             parent_model_type = model_types[-3]
-            try:
-                parent_model_type = _get_model_type_from_union(parent_model_type, indexed_collection_alias)
-                field_map = parent_model_type.alias_to_field_map()
-                field = field_map[indexed_collection_alias]
-                outer_type = field.outer_type_
-                inner_type = utils.get_inner_type(outer_type)
-
-                origin = utils.get_origin(inner_type)
-                if origin == Union or str(origin) == "<class 'types.UnionType'>":
-                    union_args = get_args(inner_type)
-                    for arg in union_args:
-                        if arg is not type(None):
-                            inner_type = arg
-                            break
-
-                inner_type_name = inner_type.__name__
-                return str_utils.classname_to_alias(inner_type_name, AliasMode.JSON)
-            except Exception as e:
-                raise err.TrestleError(f'Error in json path {alias_path}: {e}')
+            return _resolve_collection_item_alias(parent_model_type, indexed_collection_alias, alias_path)
 
         # generic model and not list, so return itself fixme doc
         if not utils.is_collection_field_type(model_type):
             return last_alias
 
         parent_model_type = model_types[-2]
-        try:
-            parent_model_type = _get_model_type_from_union(parent_model_type, last_alias)
-            field_map = parent_model_type.alias_to_field_map()
-            field = field_map[last_alias]
-            outer_type = field.outer_type_
-            inner_type = utils.get_inner_type(outer_type)
-
-            # Handle Union types - if inner_type is a Union, get the first non-None type
-            origin = utils.get_origin(inner_type)
-            if origin == Union or str(origin) == "<class 'types.UnionType'>":
-                union_args = get_args(inner_type)
-                # Find first non-None type in the union
-                for arg in union_args:
-                    if arg is not type(None):
-                        inner_type = arg
-                        break
-
-            inner_type_name = inner_type.__name__
-            singular_alias = str_utils.classname_to_alias(inner_type_name, AliasMode.JSON)
-        except Exception as e:
-            raise err.TrestleError(f'Error in json path {alias_path}: {e}')
+        singular_alias = _resolve_collection_item_alias(parent_model_type, last_alias, alias_path)
 
         return singular_alias
 

--- a/trestle/common/model_utils.py
+++ b/trestle/common/model_utils.py
@@ -582,8 +582,36 @@ class ModelUtils:
             model_types.append(model_type)
 
         last_alias = path_parts[-1]
+
         if last_alias == '*':
             last_alias = path_parts[-2]
+
+        # Terminal numeric indexes (e.g. "component-definition.components.0")
+        # refer to an item in the preceding collection; resolve to that item's alias.
+        if path_parts[-1].isdigit():
+            indexed_collection_alias = path_parts[-2]
+            if len(model_types) < 3:
+                raise err.TrestleError(f'Error in json path {alias_path}: unable to resolve indexed collection alias')
+            parent_model_type = model_types[-3]
+            try:
+                parent_model_type = _get_model_type_from_union(parent_model_type, indexed_collection_alias)
+                field_map = parent_model_type.alias_to_field_map()
+                field = field_map[indexed_collection_alias]
+                outer_type = field.outer_type_
+                inner_type = utils.get_inner_type(outer_type)
+
+                origin = utils.get_origin(inner_type)
+                if origin == Union or str(origin) == "<class 'types.UnionType'>":
+                    union_args = get_args(inner_type)
+                    for arg in union_args:
+                        if arg is not type(None):
+                            inner_type = arg
+                            break
+
+                inner_type_name = inner_type.__name__
+                return str_utils.classname_to_alias(inner_type_name, AliasMode.JSON)
+            except Exception as e:
+                raise err.TrestleError(f'Error in json path {alias_path}: {e}')
 
         # generic model and not list, so return itself fixme doc
         if not utils.is_collection_field_type(model_type):

--- a/trestle/common/model_utils.py
+++ b/trestle/common/model_utils.py
@@ -96,7 +96,7 @@ def _get_model_type_from_union(model_type: Type[Any], field_name: Optional[str] 
 
 
 def _resolve_collection_item_alias(parent_model_type: Type[Any], field_alias: str, alias_path: str) -> str:
-    """Resolve the singular alias for an item in a collection field."""
+    """Resolve the singular alias for a collection item field."""
     try:
         parent_model_type = _get_model_type_from_union(parent_model_type, field_alias)
         field_map = parent_model_type.alias_to_field_map()
@@ -104,8 +104,7 @@ def _resolve_collection_item_alias(parent_model_type: Type[Any], field_alias: st
         outer_type = field.outer_type_
         inner_type = utils.get_inner_type(outer_type)
         inner_type = _get_model_type_from_union(inner_type)
-        inner_type_name = inner_type.__name__
-        return str_utils.classname_to_alias(inner_type_name, AliasMode.JSON)
+        return str_utils.classname_to_alias(inner_type.__name__, AliasMode.JSON)
     except Exception as e:
         raise err.TrestleError(f'Error in json path {alias_path}: {e}') from e
 
@@ -601,8 +600,8 @@ class ModelUtils:
         if last_alias == '*':
             last_alias = path_parts[-2]
 
-        # Terminal numeric indexes (e.g. "component-definition.components.0")
-        # refer to an item in the preceding collection; resolve to that item's alias.
+        # Terminal numeric indexes (e.g. "component-definition.components.0") refer to an item in the
+        # preceding collection; resolve to that item's alias.
         if path_parts[-1].isdigit():
             if len(path_parts) < 2:
                 raise err.TrestleError(f'Error in json path {alias_path}: unable to resolve indexed collection alias')


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

<!--- Uncomment below if changes are for GitHub Actions -->

<!--
### How To Test

If using [act](https://github.com/nektos/act), fill in below:

**act version**  

**act command**
```bash
```
-->

## Summary

Fixes #2140 by correcting `ModelUtils.get_singular_alias()` behavior when the alias path ends with a numeric index.
Closes #2140 
Before:
- `component-definition.components.0` returned `0`

After:
- `component-definition.components.0` returns `defined-component`
- Indexed nested paths also resolve correctly (for example `catalog.groups.0.controls.0` -> `control`)

Code changes:
- Updated `trestle/common/model_utils.py` to resolve terminal numeric indexes as collection-item aliases.
- Updated `tests/trestle/utils/fs_test.py` assertions and added indexed-path coverage.

Test run:
- `python -m pytest tests/trestle/utils/fs_test.py -k "get_singular_alias or contextual_get_singular_alias"`
- Result: `2 passed`

## Key links:

- [Issue #2140](https://github.com/IBM/compliance-trestle/issues/2140)
- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
