### PR TITLE
fix: invalid escape sequence warning while running tests

### DIFF
--- a/tests/trestle/core/commands/author/catalog_test.py
+++ b/tests/trestle/core/commands/author/catalog_test.py
@@ -233,7 +233,7 @@ def test_catalog_assemble_version(sample_catalog_rich_controls: cat.Catalog, tmp
 
     assert creation_time < assembled_cat_path.stat().st_mtime
 
-    control_text = """# control_q - \[The xy controls\] this is control q
+    control_text = r"""# control_q - \[The xy controls\] this is control q
 
 ## Control Statement
 """
@@ -251,7 +251,7 @@ def test_catalog_assemble_version(sample_catalog_rich_controls: cat.Catalog, tmp
     assert interface.get_count_of_controls_in_catalog(True) == 7
 
     # make additions to a sub control and confirm they end up in the assembled catalog
-    control_d1_text = """---
+    control_d1_text = r"""---
 x-trestle-set-params:
   param_new:
     values: new param value
@@ -719,7 +719,7 @@ def test_catalog_duplicate_parts_statement(tmp_trestle_dir: pathlib.Path, monkey
     md_path = tmp_trestle_dir / 'md_catalog/ac/ac-2.md'
     assert md_path.exists()
 
-    control_statement_prose_with_parts = """The organization:
+    control_statement_prose_with_parts = r"""The organization:
 
 - \[a\] Part A
 - \[a\] Part A Duplicate.
@@ -755,13 +755,13 @@ def test_catalog_tab_in_statement(tmp_trestle_dir: pathlib.Path, monkeypatch: Mo
 \t
 \t
 \t
-- \[m\] Part M
-- \[n\] Part N
-\t- \[n.1\] Documents 1
-\t- \[n.2\] Documents 2
-\t\t- \[n.2.1\] SubDocuments 1
-\t\t- \[n.2.2\] SubDocuments 2
-- \[o\] Part O.
+- \\[m\\] Part M
+- \\[n\\] Part N
+\t- \\[n.1\\] Documents 1
+\t- \\[n.2\\] Documents 2
+\t\t- \\[n.2.1\\] SubDocuments 1
+\t\t- \\[n.2.2\\] SubDocuments 2
+- \\[o\\] Part O.
 \t
 \t
 \t

--- a/tests/trestle/core/commands/author/catalog_test.py
+++ b/tests/trestle/core/commands/author/catalog_test.py
@@ -750,7 +750,7 @@ def test_catalog_tab_in_statement(tmp_trestle_dir: pathlib.Path, monkeypatch: Mo
     test_utils.execute_command_and_assert(catalog_generate, 0, monkeypatch)
     md_path = tmp_trestle_dir / 'md_catalog/ac/ac-2.md'
     assert md_path.exists()
-
+    # Cannot use r-string here: \t must remain as tab charcters for markdown parsing
     control_statement_prose_with_parts = """The organization:
 \t
 \t

--- a/tests/trestle/core/commands/author/prof_test.py
+++ b/tests/trestle/core/commands/author/prof_test.py
@@ -891,7 +891,7 @@ def test_profile_generate_updates_statement(tmp_trestle_dir: pathlib.Path, monke
     test_utils.execute_command_and_assert(prof_generate, 0, monkeypatch)
 
     # confirm that disallowed edits to the control statement are overwritten on next generate
-    bad_text = '  - \[3.\] Count kangaroos.'
+    bad_text = r'  - \[3.\] Count kangaroos.'
     ac1_path = tmp_trestle_dir / md_name / 'ac/ac-1.md'
     tag = 'param, ac-1_prm_7'
     file_utils.insert_text_in_file(ac1_path, tag, bad_text)


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)


## Summary

while running `make clean && make test` , there were SyntaxWarning related to invalid escape sequence 

```
================================================== warnings summary ===================================================
tests/trestle/core/commands/author/catalog_test.py:236
tests/trestle/core/commands/author/catalog_test.py:236
tests/trestle/core/commands/author/catalog_test.py:236
tests/trestle/core/commands/author/catalog_test.py:236
tests/trestle/core/commands/author/catalog_test.py:236
tests/trestle/core/commands/author/catalog_test.py:236
tests/trestle/core/commands/author/catalog_test.py:236
  /mnt/d/compliance-trestle/tests/trestle/core/commands/author/catalog_test.py:236: SyntaxWarning: invalid escape sequence '\['
    control_text = """# control_q - \[The xy controls\] this is control q

tests/trestle/core/commands/author/catalog_test.py:254
tests/trestle/core/commands/author/catalog_test.py:254
tests/trestle/core/commands/author/catalog_test.py:254
tests/trestle/core/commands/author/catalog_test.py:254
tests/trestle/core/commands/author/catalog_test.py:254
tests/trestle/core/commands/author/catalog_test.py:254
tests/trestle/core/commands/author/catalog_test.py:254
  /mnt/d/compliance-trestle/tests/trestle/core/commands/author/catalog_test.py:254: SyntaxWarning: invalid escape sequence '\['
    control_d1_text = """---

tests/trestle/core/commands/author/catalog_test.py:722
tests/trestle/core/commands/author/catalog_test.py:722
tests/trestle/core/commands/author/catalog_test.py:722
tests/trestle/core/commands/author/catalog_test.py:722
tests/trestle/core/commands/author/catalog_test.py:722
tests/trestle/core/commands/author/catalog_test.py:722
tests/trestle/core/commands/author/catalog_test.py:722
  /mnt/d/compliance-trestle/tests/trestle/core/commands/author/catalog_test.py:722: SyntaxWarning: invalid escape sequence '\['
    control_statement_prose_with_parts = """The organization:

tests/trestle/core/commands/author/catalog_test.py:754
tests/trestle/core/commands/author/catalog_test.py:754
tests/trestle/core/commands/author/catalog_test.py:754
tests/trestle/core/commands/author/catalog_test.py:754
tests/trestle/core/commands/author/catalog_test.py:754
tests/trestle/core/commands/author/catalog_test.py:754
tests/trestle/core/commands/author/catalog_test.py:754
  /mnt/d/compliance-trestle/tests/trestle/core/commands/author/catalog_test.py:754: SyntaxWarning: invalid escape sequence '\['
    control_statement_prose_with_parts = """The organization:

tests/trestle/core/commands/author/prof_test.py:894: 10 warnings
  /mnt/d/compliance-trestle/tests/trestle/core/commands/author/prof_test.py:894: SyntaxWarning: invalid escape sequence '\['
    bad_text = '  - \[3.\] Count kangaroos.'
```


These changes should fix the issue and running the tests after the changes had no warnings related to this.
@degenaro 


