### PR TITLE
fix: datetime.datetime.utcnow() is deprecated

### DIFF
--- a/trestle/tasks/csv_to_oscal_mc.py
+++ b/trestle/tasks/csv_to_oscal_mc.py
@@ -63,7 +63,8 @@ L_MAP_COVERAGE = MAP_COVERAGE.lower()
 
 logger = logging.getLogger(__name__)
 
-timestamp = datetime.datetime.utcnow().replace(microsecond=0).replace(tzinfo=datetime.timezone.utc).isoformat()
+timestamp = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0).isoformat()
+
 
 
 class CsvToOscalMappingCollection(TaskBase):
@@ -124,7 +125,8 @@ class CsvToOscalMappingCollection(TaskBase):
     def configure(self) -> bool:
         """Configure."""
         self._timestamp = (
-            datetime.datetime.utcnow().replace(microsecond=0).replace(tzinfo=datetime.timezone.utc).isoformat()
+            datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0).isoformat()
+
         )
         # config verbosity
         self._quiet = self._config.get('quiet', False)

--- a/trestle/tasks/csv_to_oscal_mc.py
+++ b/trestle/tasks/csv_to_oscal_mc.py
@@ -66,7 +66,6 @@ logger = logging.getLogger(__name__)
 timestamp = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0).isoformat()
 
 
-
 class CsvToOscalMappingCollection(TaskBase):
     """
     Task to create OSCAL mc.json.
@@ -124,10 +123,7 @@ class CsvToOscalMappingCollection(TaskBase):
 
     def configure(self) -> bool:
         """Configure."""
-        self._timestamp = (
-            datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0).isoformat()
-
-        )
+        self._timestamp = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0).isoformat()
         # config verbosity
         self._quiet = self._config.get('quiet', False)
         self._verbose = not self._quiet


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)


## Summary

while running tests there are warnings related to Deprecation of datetime.datetime.utcnow()

```
trestle/tasks/csv_to_oscal_mc.py:66: 16 warnings
  /mnt/d/compliance-trestle/trestle/tasks/csv_to_oscal_mc.py:66: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    timestamp = datetime.datetime.utcnow().replace(microsecond=0).replace(tzinfo=datetime.timezone.utc).isoformat()

tests/trestle/tasks/csv_to_oscal_mc_test.py: 24 warnings
  /mnt/d/compliance-trestle/trestle/tasks/csv_to_oscal_mc.py:127: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    datetime.datetime.utcnow().replace(microsecond=0).replace(tzinfo=datetime.timezone.utc).isoformat()
```    


These changes should fix the issue and running the tests after the changes had no more warnings related to this
@degenaro 