### PR TITLE
fix(remove-path): prune empty parent directories recursively

### DIFF
--- a/tests/trestle/core/models/remove_path_action_test.py
+++ b/tests/trestle/core/models/remove_path_action_test.py
@@ -95,3 +95,23 @@ def test_remove_path_magic_methods(tmp_path):
 
     action_desc = rpa.to_string()
     assert action_desc == f'{rpa.get_type()} {tmp_data_dir}'
+
+
+def test_remove_path_prunes_empty_parent_dirs(tmp_path: pathlib.Path) -> None:
+    """Test remove path deletes empty parent directories recursively."""
+    tmp_data_dir = tmp_path.joinpath('data')
+    nested_dir = tmp_data_dir.joinpath('nested1').joinpath('nested2')
+    tmp_data_file = nested_dir.joinpath('readme.md')
+    test_utils.ensure_trestle_config_dir(tmp_path)
+    nested_dir.mkdir(exist_ok=True, parents=True)
+
+    with open(tmp_data_file, 'a+', encoding=const.FILE_ENCODING) as fp:
+        fp.write('DUMMY DATA')
+
+    rpa = RemovePathAction(tmp_data_file)
+    rpa.execute()
+
+    assert tmp_data_file.exists() is False
+    assert nested_dir.exists() is False
+    assert nested_dir.parent.exists() is False
+    assert tmp_data_dir.exists() is False

--- a/trestle/core/models/actions.py
+++ b/trestle/core/models/actions.py
@@ -358,11 +358,13 @@ class RemovePathAction(Action):
 
         trash.store(self._sub_path, True)
 
-        # check if parent folder is empty and if so delete
-        parent_dir = pathlib.Path(os.path.dirname(self._sub_path))
-        files = list(parent_dir.iterdir())
-        if not files:
+        # check if parent folders are empty and if so delete them recursively up to the project root
+        parent_dir = self._sub_path.parent
+        while parent_dir != self._trestle_project_root:
+            if list(parent_dir.iterdir()):
+                break
             trash.store(parent_dir, True)
+            parent_dir = parent_dir.parent
         self._mark_executed()
 
     def rollback(self) -> None:


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [ ] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

<!--- Uncomment below if changes are for GitHub Actions -->

<!--
### How To Test

If using [act](https://github.com/nektos/act), fill in below:

**act version**  

**act command**
```bash
```
-->

## Summary

Fix `RemovePathAction` so it recursively prunes empty parent directories after deleting a file or directory. This prevents stale empty directory shells from lingering after merge or cleanup operations in nested decomposed trees.

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
