### PR TITLE
fix: preserve __bk names in trash restore

### DIFF
--- a/docs/contributing/.pages
+++ b/docs/contributing/.pages
@@ -4,7 +4,7 @@ nav:
 - OSCAL object model: oscal_object_model.md
 - Website development: website.md
 - Developing trestle plugins: plugins.md
-- Contributors: https://github.com/oscal-compass/compliance-trestle/graphs/contributors
+- Contributors: https://github.com/oscal-compass/compliance-trestle/contributors
 - Maintainers: maintainers.md
 - Developer Certificate of Originality: DCO.md
 - GitHub actions: github_actions_setup.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -121,7 +121,7 @@ Our project welcomes external contributions. Please consult [contributing](contr
 ## License & Authors
 
 If you would like to see the detailed LICENSE click [here](license.md).
-Consult [contributors](https://github.com/oscal-compass/compliance-trestle/graphs/contributors) for a list of authors and [maintainers](contributing/maintainers.md) for the core team.
+Consult [contributors](https://github.com/oscal-compass/compliance-trestle/contributors) for a list of authors and [maintainers](contributing/maintainers.md) for the core team.
 
 ```text
 # Copyright (c) 2024 The OSCAL Compass Authors. All rights reserved.

--- a/docs/tutorials/Transformers_and_Tasks/OCP4_CIS_profile_to_oscal_catalog.md
+++ b/docs/tutorials/Transformers_and_Tasks/OCP4_CIS_profile_to_oscal_catalog.md
@@ -5,7 +5,7 @@ description: Converting compliance as code profiles into an OSCAL catalog with c
 
 # Tutorial: Setup for and use of ComplianceAsCode profile to OSCAL Catalog transformer
 
-Here are step by step instructions for setup and transformation of [ComplianceAsCode](https://github.com/ComplianceAsCode/content) profile data files into [NIST](https://www.nist.gov/) standard [OSCAL](https://pages.nist.gov/OSCAL/) [Catalog](https://pages.nist.gov/OSCAL-Reference/models/latest/catalog/json-outline/) using the [compliance-trestle](../../index.md) tool.
+Here are step by step instructions for setup and transformation of [ComplianceAsCode](https://github.com/ComplianceAsCode/content) profile data files into [NIST](https://www.nist.gov/) standard [OSCAL](https://pages.nist.gov/OSCAL/) [Catalog](https://pages.nist.gov/OSCAL-Reference/models/) using the [compliance-trestle](../../index.md) tool.
 
 ## Objective
 

--- a/docs/tutorials/cli.md
+++ b/docs/tutorials/cli.md
@@ -118,11 +118,11 @@ Users can query the contents of files using `trestle describe`, and probe the co
 
 OSCAL models are rich and contain multiple nested data structures. Given this, a mechanism is required to address _elements_ /_attributes_ within an oscal object.
 
-This accessing method is called 'element path' and is similar to _jsonPath_. Commands provide element path by a `-e` argument where available, e.g. trestle split -f catalog.json -e 'catalog.metadata.\*'. This path is used whenever specifying an attribute or model, rather than exposing trestle's underlying object model name. Users can refer to [NIST's json outline](https://pages.nist.gov/OSCAL-Reference/models/latest/complete/json-outline/) to understand object names in trestle.
+This accessing method is called 'element path' and is similar to _jsonPath_. Commands provide element path by a `-e` argument where available, e.g. trestle split -f catalog.json -e 'catalog.metadata.\*'. This path is used whenever specifying an attribute or model, rather than exposing trestle's underlying object model name. Users can refer to [NIST's OSCAL model reference](https://pages.nist.gov/OSCAL-Reference/models/) to understand object names in trestle.
 
 ### Rules for element path
 
-1. Element path is an expression of the attribute names, [in json form](https://pages.nist.gov/OSCAL-Reference/models/latest/complete/json-outline/) , concatenated by a period (`.`).
+1. Element path is an expression of the attribute names, [in json form](https://pages.nist.gov/OSCAL-Reference/models/) , concatenated by a period (`.`).
    1. E.g. The metadata in a catalog is referred to as `catalog.metadata`
 1. Element paths are relative to the file.
    1. e.g. For `metadata.json` roles would be referred to as `metadata.roles`, from the catalog file that would be `catalog.metadata.roles`

--- a/tests/trestle/utils/trash_test.py
+++ b/tests/trestle/utils/trash_test.py
@@ -129,6 +129,28 @@ def test_to_origin_dir_path(tmp_path: pathlib.Path) -> None:
         trash.to_origin_dir_path(trash_file_path)
 
 
+def test_to_origin_dir_path_preserves_embedded_trash_marker(tmp_path: pathlib.Path) -> None:
+    """Test that origin path conversion preserves names containing __bk."""
+    test_utils.ensure_trestle_config_dir(tmp_path)
+    (tmp_path / trash.TRESTLE_TRASH_DIR).mkdir(exist_ok=True, parents=True)
+
+    original_dir = tmp_path / 'catalogs' / f'alpha{trash.TRESTLE_TRASH_DIR_EXT}beta'
+    trash_dir_path = trash.to_trash_dir_path(original_dir)
+    recovered_dir = trash.to_origin_dir_path(trash_dir_path)
+    assert recovered_dir.resolve() == original_dir.resolve()
+
+
+def test_to_origin_dir_path_preserves_trailing_trash_marker(tmp_path: pathlib.Path) -> None:
+    """Test that origin path conversion preserves names ending with __bk."""
+    test_utils.ensure_trestle_config_dir(tmp_path)
+    (tmp_path / trash.TRESTLE_TRASH_DIR).mkdir(exist_ok=True, parents=True)
+
+    original_dir = tmp_path / 'catalogs' / f'alpha{trash.TRESTLE_TRASH_DIR_EXT}'
+    trash_dir_path = trash.to_trash_dir_path(original_dir)
+    recovered_dir = trash.to_origin_dir_path(trash_dir_path)
+    assert recovered_dir.resolve() == original_dir.resolve()
+
+
 def test_to_origin_file_path(tmp_path: pathlib.Path) -> None:
     """Test to origin file path function."""
     test_utils.ensure_trestle_config_dir(tmp_path)

--- a/trestle/common/trash.py
+++ b/trestle/common/trash.py
@@ -94,8 +94,10 @@ def to_origin_dir_path(trash_dir_path: pathlib.Path) -> pathlib.Path:
 
     origin_path_parts: List[str] = []
     for item in relative_path.parts:
-        parts = item.split(TRESTLE_TRASH_DIR_EXT)
-        origin_path_parts.append(parts[0])
+        if item.endswith(TRESTLE_TRASH_DIR_EXT):
+            origin_path_parts.append(item[: -len(TRESTLE_TRASH_DIR_EXT)])
+        else:
+            origin_path_parts.append(item)
 
     origin_relative_path = pathlib.Path('/'.join(origin_path_parts))
     origin_path = trestle_root / origin_relative_path


### PR DESCRIPTION

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [ ] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

<!--- Uncomment below if changes are for GitHub Actions -->

<!--
### How To Test

If using [act](https://github.com/nektos/act), fill in below:

**act version**  

**act command**
```bash
```
-->

## Summary

Fix `to_origin_dir_path()` so directory names containing `__bk` are preserved during trash-path recovery.  
Previously, names were split on every `__bk`, which truncated valid directory names (e.g. `alpha__bkbeta` recovered as `alpha`).  
This change strips only the trailing trash marker and adds regression tests for embedded and trailing `__bk` name cases.

### Verification output

- `venv/bin/python -m pytest tests/trestle/utils/trash_test.py`
- Result:
  ```text
  ============================= test session starts ==============================
  platform linux -- Python 3.10.12, pytest-9.0.2, pluggy-1.6.0
  rootdir: /home/jay/compliance-trestle
  configfile: pyproject.toml
  plugins: anyio-4.13.0, typeguard-4.5.1
  collected 15 items

  tests/trestle/utils/trash_test.py ...............                        [100%]

  ============================== 15 passed in 0.10s ==============================
  ```

- Direct reproducer output:
  ```text
  original: /tmp/.../ws/catalogs/alpha__bkbeta
  trash: /tmp/.../ws/.trestle/_trash/catalogs/alpha__bkbeta__bk
  recovered: /tmp/.../ws/catalogs/alpha__bkbeta
  match: True
  ```

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)
- Fixes : #2210 

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
