### PR TITLE
fix: harden docs link check against transient errors

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,12 @@ plugins:
       # This is to remove some false positives for links which work.
       # Anchors are validated again by core mkdocs
       404: [ '*#trestle.*' ]
+      # External sites can intermittently return transient gateway/network errors.
+      # Keep docs validation strict for deterministic failures (e.g. 404), but
+      # don't fail CI on temporary upstream outages.
+      502: [ '*' ]
+      504: [ '*' ]
+      -1: [ '*' ]
     # These URLs work from the browser but fail when accesssed via htmlproofer:
     ignore_urls:
         - 'https://www.fedramp.gov/documents-templates/'


### PR DESCRIPTION

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

<!--- Uncomment below if changes are for GitHub Actions -->

<!--
### How To Test

If using [act](https://github.com/nektos/act), fill in below:

**act version**  

**act command**
```bash
```
-->

## Summary

Harden docs validation against transient external URL outages that were repeatedly failing `lint` in `docs-validate`.  
Update `mkdocs.yml` htmlproofer `raise_error_excludes` to ignore temporary gateway/network errors (`502`, `504`, `-1`) while keeping deterministic link failures (like `404`) enforced.

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
