### PR TITLE
ci: add multi-train release and act workflow testing support

### DIFF
--- a/.github/workflows/act-test.yml
+++ b/.github/workflows/act-test.yml
@@ -1,0 +1,38 @@
+name: Test workflows with act
+
+on:
+  pull_request:
+    types: [labeled, synchronize, opened]
+    paths:
+      - '.github/**'
+
+permissions: read-all
+
+jobs:
+  act-dry-run:
+    if: contains(github.event.pull_request.labels.*.name, 'github_actions')
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        submodules: true
+
+    - name: Install act
+      run: |
+        curl -fsSL https://raw.githubusercontent.com/nektos/act/6ee387ebd0426e57223315c47b0299a721041df8/install.sh | sudo bash -s -- -b /usr/local/bin v0.2.87
+
+    - name: Dry-run actionlint workflow
+      run: |
+        act -n -W .github/workflows/actionlint.yml --container-architecture linux/amd64
+
+    - name: Dry-run PR test pipeline
+      run: |
+        act -n -W .github/workflows/python-test.yml --container-architecture linux/amd64
+
+    - name: Dry-run deploy pipeline
+      run: |
+        act -n -W .github/workflows/python-push.yml --container-architecture linux/amd64
+
+    - name: Dry-run conventional PR pipeline
+      run: |
+        act -n -W .github/workflows/conventional-pr.yml --container-architecture linux/amd64

--- a/.github/workflows/act-test.yml
+++ b/.github/workflows/act-test.yml
@@ -19,7 +19,9 @@ jobs:
 
     - name: Install act
       run: |
-        curl -fsSL https://raw.githubusercontent.com/nektos/act/6ee387ebd0426e57223315c47b0299a721041df8/install.sh | sudo bash -s -- -b /usr/local/bin v0.2.87
+        curl -fsSL https://raw.githubusercontent.com/nektos/act/36add66f6520c77c15dfce4715ba6c689d427981/install.sh | sudo bash -s -- -b /usr/local/bin v0.2.87
+        mkdir -p ~/.config/act
+        printf -- '-P ubuntu-latest=ghcr.io/catthehacker/ubuntu:act-latest\n' > ~/.config/act/actrc
 
     - name: Dry-run actionlint workflow
       run: |

--- a/.github/workflows/conventional-pr.yml
+++ b/.github/workflows/conventional-pr.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - 'main'
       - 'develop'
+      - 'v[0-9]*'
 permissions:
   contents: read
 
@@ -27,3 +28,14 @@ jobs:
       run: |
         PR_TITLE=$(jq -r '.pull_request.title' "$GITHUB_EVENT_PATH")
         echo "$PR_TITLE" | npx commitlint --config commitlint.config.js
+
+    - name: Validate commit type for maintenance branch
+      if: startsWith(github.base_ref, 'v')
+      run: |
+        PR_TITLE=$(jq -r '.pull_request.title' "$GITHUB_EVENT_PATH" | sed 's/^[[:space:]]*//')
+        ALLOWED_TYPES='^(fix|perf|chore|ci|docs|build|refactor|style|test|revert)(\(.*\))?:'
+        if ! echo "$PR_TITLE" | grep -qiE "$ALLOWED_TYPES"; then
+          echo "::error::PR title must use an allowed type for maintenance branches: fix, perf, chore, ci, docs, build, refactor, style, test, revert."
+          echo "::error::Got: $PR_TITLE"
+          exit 1
+        fi

--- a/.github/workflows/python-push.yml
+++ b/.github/workflows/python-push.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - 'v[0-9]*'
 
 permissions: {}
 
@@ -113,6 +114,9 @@ jobs:
         make test-cov
   deploy:
     runs-on: ubuntu-latest
+    concurrency:
+      group: deploy-${{ github.ref }}
+      cancel-in-progress: false
     needs: [ build, set-versions ]
     permissions:
       id-token: write
@@ -121,9 +125,18 @@ jobs:
     environment:
       name: release
       url: https://pypi.org/p/compliance-trestle
-    if: github.ref == 'refs/heads/main' && github.repository == 'oscal-compass/compliance-trestle'
+    if: >-
+      github.repository == 'oscal-compass/compliance-trestle'
+      && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/v'))
     steps:
-    - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+    - name: Validate branch name
+      if: github.ref != 'refs/heads/main'
+      run: |
+        if [[ ! "$GITHUB_REF_NAME" =~ ^v[0-9]+$ ]]; then
+          echo "::error::Branch '$GITHUB_REF_NAME' does not match required pattern ^v[0-9]+$"
+          exit 1
+        fi
+    - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       id: app-token
       with:
         app-id: ${{ secrets.APP_ID }}
@@ -141,6 +154,62 @@ jobs:
       run: |
         make develop
 
+    - name: Validate build command
+      if: github.ref != 'refs/heads/main'
+      run: |
+        BUILD_CMD=$(python -c "
+        import tomllib, sys
+        with open('pyproject.toml', 'rb') as f:
+            cfg = tomllib.load(f)
+        cmd = cfg.get('tool', {}).get('semantic_release', {}).get('build_command', '')
+        sys.stdout.write(cmd)
+        ")
+        ALLOWED='
+            python -m pip install build --upgrade
+            python -m build
+        '
+        NORM_BUILD=$(echo "$BUILD_CMD" | tr -s '[:space:]' ' ' | sed 's/^ *//;s/ *$//')
+        NORM_ALLOW=$(echo "$ALLOWED" | tr -s '[:space:]' ' ' | sed 's/^ *//;s/ *$//')
+        if [ "$NORM_BUILD" != "$NORM_ALLOW" ]; then
+          echo "::error::build_command in pyproject.toml has been modified from the expected value."
+          echo "::error::Expected: $NORM_ALLOW"
+          echo "::error::Got: $NORM_BUILD"
+          exit 1
+        fi
+
+    - name: Validate version matches branch
+      if: github.ref != 'refs/heads/main'
+      run: |
+        BRANCH_MAJOR="${GITHUB_REF_NAME#v}"
+        FILE_VERSION=$(python -c "
+        import re
+        with open('trestle/__init__.py') as f:
+            m = re.search(r\"__version__\s*=\s*['\\\"]([^'\\\"]+)\", f.read())
+            print(m.group(1) if m else '')
+        ")
+        FILE_MAJOR="${FILE_VERSION%%.*}"
+        if [ "$BRANCH_MAJOR" != "$FILE_MAJOR" ]; then
+          echo "::error::Version mismatch: branch $GITHUB_REF_NAME expects major version $BRANCH_MAJOR but trestle/__init__.py has $FILE_VERSION (major: $FILE_MAJOR)"
+          exit 1
+        fi
+
+    - name: Validate commit types on maintenance branch
+      if: github.ref != 'refs/heads/main'
+      run: |
+        LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+        if [ -z "$LAST_TAG" ]; then
+          LAST_TAG=$(git merge-base HEAD origin/main)
+          echo "No tag found; scanning commits since merge-base with main ($LAST_TAG)"
+        fi
+        ALLOWED_TYPES='^(fix|perf|chore|ci|docs|build|refactor|style|test|revert)(\(.*\))?:'
+        BAD_COMMITS=$(git log "$LAST_TAG"..HEAD --format='%s' | grep -iEvx "$ALLOWED_TYPES.*" || true)
+        if [ -n "$BAD_COMMITS" ]; then
+          echo "::error::All commits on maintenance branches must use an allowed type: fix, perf, chore, ci, docs, build, refactor, style, test, revert."
+          echo "::error::The following commits do not match:"
+          echo "$BAD_COMMITS"
+          exit 1
+        fi
+
     - name: Python Semantic Release
       id: release
       uses: python-semantic-release/python-semantic-release@350c48fcb3ffcdfd2e0a235206bc2ecea6b69df0 # v10.5.3
@@ -156,7 +225,7 @@ jobs:
       if: steps.release.outputs.released == 'true'
 
     # Sign artifacts to be uploaded to github releases after pypi. Pypi signs it's own
-    - uses: sigstore/gh-action-sigstore-python@v3.2.0
+    - uses: sigstore/gh-action-sigstore-python@04cffa1d795717b140764e8b640de88853c92acc # v3.3.0
       if: steps.release.outputs.released == 'true'
       with:
         inputs: "dist/*"

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ tmp_bin_test
 
 # mkdocs
 .cache/
+/.ruff_cache/
+
+# Local-only configuration docs
+manual-steps.md

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: check-yaml
         exclude: "tests/data/yaml/bad_simple.yaml"
       - id: no-commit-to-branch
-        args: [--branch, develop, --branch, main]
+        args: [--branch, develop, --branch, main, --pattern, 'v\d+$']
 
   - repo: local
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,28 @@ docs-validate: docs-clean ## Validate documentation (build + link check)
 docs-clean: clean-tmp
 
 # ============================================================================
+# Workflow Testing (via act + podman)
+# ============================================================================
+
+.PHONY: act-lint act-actionlint act-test-dry act-deploy-dry act-conventional-dry
+
+ACT_FLAGS := --container-architecture linux/amd64
+
+act-lint: ## Run the actionlint workflow locally with act
+	act -W .github/workflows/actionlint.yml $(ACT_FLAGS)
+
+act-actionlint: act-lint ## Alias for act-lint
+
+act-test-dry: ## Dry-run the PR test pipeline locally with act
+	act -n -W .github/workflows/python-test.yml $(ACT_FLAGS)
+
+act-deploy-dry: ## Dry-run the deploy pipeline locally with act
+	act -n -W .github/workflows/python-push.yml $(ACT_FLAGS)
+
+act-conventional-dry: ## Dry-run the conventional PR pipeline locally with act
+	act -n -W .github/workflows/conventional-pr.yml $(ACT_FLAGS)
+
+# ============================================================================
 # Utilities
 # ============================================================================
 

--- a/docs/contributing/.pages
+++ b/docs/contributing/.pages
@@ -8,4 +8,5 @@ nav:
 - Maintainers: maintainers.md
 - Developer Certificate of Originality: DCO.md
 - GitHub actions: github_actions_setup.md
+- Maintenance releases: maintenance_releases.md
 - Testing workflows locally: workflow_testing.md

--- a/docs/contributing/.pages
+++ b/docs/contributing/.pages
@@ -8,3 +8,4 @@ nav:
 - Maintainers: maintainers.md
 - Developer Certificate of Originality: DCO.md
 - GitHub actions: github_actions_setup.md
+- Testing workflows locally: workflow_testing.md

--- a/docs/contributing/github_actions_setup.md
+++ b/docs/contributing/github_actions_setup.md
@@ -12,7 +12,7 @@ Project maintainers, after an initial review, will allow github actions workflow
 
 ## Secrets
 
-- `APP_ID` and `PRIVATE_KEY`: GitHub App information with sufficient write access to merge content into `develop` and commit to `gh-pages` and `main`
+- `APP_ID` and `PRIVATE_KEY`: GitHub App information with sufficient write access to merge content into `develop` and commit to `gh-pages`, `main`, and maintenance branches (`v3`, `v4`, etc.)
 
 - `SONAR_TOKEN`: Token to sonarcloud with rights to the appropriate project.
 
@@ -21,3 +21,11 @@ Project maintainers, after an initial review, will allow github actions workflow
 Pypi authorization must be setup following the procedure in the following documents
 
 - https://docs.pypi.org/trusted-publishers/adding-a-publisher/
+
+## Maintenance branch configuration
+
+Trestle supports releasing patches from maintenance branches (e.g., `v3`, `v4`). When creating a new maintenance branch, the following GitHub configuration is required:
+
+- **Branch protection**: Create a ruleset for `v[0-9]*` branches requiring PR reviews, status checks, squash merges, and restricted push access. See [Maintenance releases](maintenance_releases.md) for details.
+- **Release environment**: The `release` environment's deployment branch rules must include maintenance branches (add `v*` pattern or list branches explicitly).
+- **PyPI trusted publisher**: Verify the trusted publisher configuration does not restrict publishing to `main` only.

--- a/docs/contributing/maintenance_releases.md
+++ b/docs/contributing/maintenance_releases.md
@@ -1,0 +1,113 @@
+---
+title: Maintenance releases
+description: How to create security and patch releases for older major versions
+---
+
+# Maintenance releases
+
+Trestle supports releasing security and bug fixes for older major versions through **maintenance branches**. This allows patching e.g. v3.x while active development continues on v4.x.
+
+## Overview
+
+- Maintenance branches are named `v<major>` (e.g., `v3`, `v4`)
+- Patch-safe commit types are allowed (`fix:`, `perf:`, `chore:`, `ci:`, `docs:`, `build:`, `refactor:`, `style:`, `test:`, `revert:`) — `feat:` and breaking changes (`!`) are blocked by CI
+- Releases are automated via the same semantic-release pipeline as `main`
+- Documentation is automatically updated when a maintenance release is tagged
+
+## Developer workflow for security fixes
+
+1. **Branch from the maintenance branch**, not from `develop`:
+
+   ```bash
+   git checkout v3
+   git pull origin v3
+   git checkout -b fix/cve-2026-xxxx
+   ```
+
+1. **Make the fix and commit** using conventional commits:
+
+   ```bash
+   git commit --signoff -m "fix: address CVE-2026-XXXX in authentication module"
+   ```
+
+1. **Open a PR targeting the maintenance branch** (e.g., `v3`, not `develop`)
+
+1. **CI runs automatically**:
+
+   - Full test suite via `python-test.yml`
+   - PR title validation -- `feat:` titles are rejected on maintenance branches
+   - Standard code quality checks
+
+1. **After merge** (squash merge required), the deploy pipeline:
+
+   - Validates the branch name and version consistency
+   - Runs semantic-release to bump the patch version (e.g., `3.12.0` -> `3.12.1`)
+   - Publishes to PyPI, signs with sigstore, creates a GitHub Release
+   - Updates versioned documentation
+
+## Security fix propagation
+
+When a security fix is applied to a maintenance branch, it **must** also be applied to all other affected release trains:
+
+1. After merging the fix to the maintenance branch, cherry-pick to `develop`:
+
+   ```bash
+   git checkout develop
+   git pull origin develop
+   git checkout -b fix/cve-2026-xxxx-develop
+   git cherry-pick <commit-sha-from-maintenance-branch>
+   ```
+
+1. Open a PR targeting `develop` with the cherry-picked fix
+
+1. Track progress in the original security issue with a cross-train checklist:
+
+   ```markdown
+   - [x] v3 (v3.12.1)
+   - [ ] v4 (pending PR #NNN)
+   ```
+
+1. A security fix is **not considered complete** until all affected trains are patched
+
+## Creating a new maintenance branch
+
+When a new major version is released (e.g., v5.0.0), create a maintenance branch for the previous major version:
+
+1. **Create the branch** from `main` at the last release tag before the breaking change:
+
+   ```bash
+   git checkout v4.x.y  # last v4 tag
+   git checkout -b v4
+   git push origin v4
+   ```
+
+1. **The CI pipeline automatically supports the new branch** -- the `v[0-9]*` glob patterns in workflow triggers match any `v<number>` branch without code changes.
+
+1. **Configure branch protection** (see [GitHub actions setup](github_actions_setup.md)):
+
+   - Require pull requests with at least one CODEOWNER review
+   - Require status checks to pass
+   - Require squash merges only
+   - Restrict push access to maintainers
+   - Disallow force pushes and deletions
+
+1. **Update the GitHub `release` environment** if it uses an explicit branch list (add the new branch)
+
+1. **Consider enabling Dependabot** for security updates on the new maintenance branch
+
+## CI/CD behavior on maintenance branches
+
+| Pipeline                | Behavior                                                                                                                                              |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `python-test.yml`       | Runs on PRs targeting maintenance branches (same as `develop`)                                                                                        |
+| `python-push.yml`       | Triggers on push to maintenance branches; validates branch name, build command, version consistency, and commit types before running semantic-release |
+| `conventional-pr.yml`   | Validates PR titles; blocks `feat:` commits on maintenance branches                                                                                   |
+| `docs-update.yml`       | Automatically triggered by version tags (e.g., `v3.12.1`)                                                                                             |
+| `merge-main-to-develop` | Does **not** run -- maintenance releases are isolated                                                                                                 |
+
+## Restrictions on maintenance branches
+
+- **No feature releases**: `feat:` commits are blocked at the PR level and verified server-side before release. Minor version bumps cannot happen on maintenance branches.
+- **No direct pushes**: Branch protection requires all changes go through reviewed PRs.
+- **Version consistency**: The major version in `trestle/__init__.py` must match the branch name (e.g., branch `v3` must have version `3.x.x`).
+- **Build command integrity**: The `build_command` in `pyproject.toml` is validated against an allowlist before each release.

--- a/docs/contributing/workflow_testing.md
+++ b/docs/contributing/workflow_testing.md
@@ -1,0 +1,130 @@
+---
+title: Testing GitHub Actions locally
+description: How to test CI/CD workflow changes locally using act
+---
+
+# Testing GitHub Actions locally
+
+When modifying GitHub Actions workflows, you can validate changes locally before pushing using [act](https://github.com/nektos/act). This avoids slow feedback loops from CI and reduces noise on the PR.
+
+## Prerequisites
+
+- **act**: See installation options below
+- **Container runtime**: Either [podman](https://podman.io/) or [Docker](https://www.docker.com/)
+
+### Installing act
+
+- **macOS**: `brew install act`
+
+- **Linux**: Download from [GitHub releases](https://github.com/nektos/act/releases) or use the install script:
+
+  ```bash
+  curl -fsSL https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash -s -- -b /usr/local/bin
+  ```
+
+- **Windows**: act requires Linux containers and is not supported for local workflow testing. Use the CI-based validation instead (see [CI integration](#ci-integration)).
+
+For other installation methods, see [act installation](https://nektosact.com/installation/).
+
+### Configuring act with podman
+
+Act needs the `DOCKER_HOST` environment variable to find the podman socket. The setup differs by platform.
+
+**macOS** (podman runs in a VM via `podman machine`):
+
+```bash
+export DOCKER_HOST="unix://$(podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}')"
+```
+
+Ensure the podman machine is running:
+
+```bash
+podman machine start
+```
+
+**Linux** (podman runs natively):
+
+```bash
+# For rootless podman (recommended)
+export DOCKER_HOST="unix://$XDG_RUNTIME_DIR/podman/podman.sock"
+
+# Ensure the podman socket is active
+systemctl --user start podman.socket
+```
+
+Add the appropriate `DOCKER_HOST` export to your shell profile (`.zshrc`, `.bashrc`) to make it persistent.
+
+## Makefile targets
+
+The following make targets are available for local workflow testing:
+
+```bash
+# Run actionlint workflow locally (validates workflow YAML syntax)
+make act-lint
+
+# Dry-run the full PR test pipeline (validates structure without executing)
+make act-test-dry
+
+# Dry-run the deploy pipeline (validates structure without executing)
+make act-deploy-dry
+
+# Dry-run the conventional PR pipeline (validates structure without executing)
+make act-conventional-dry
+```
+
+All targets use `--container-architecture linux/amd64` automatically for Apple Silicon compatibility.
+
+## Running act directly
+
+For more control, run `act` directly:
+
+```bash
+# List all jobs across all workflows
+act --list
+
+# List jobs in a specific workflow
+act --list -W .github/workflows/python-test.yml
+
+# Dry-run a specific job
+act -n -W .github/workflows/python-test.yml -j lint --container-architecture linux/amd64
+
+# Actually run the actionlint workflow (requires container runtime)
+act -W .github/workflows/actionlint.yml --container-architecture linux/amd64
+```
+
+## What can and cannot be tested locally
+
+| What                                  | Testable locally?   | Notes                                                                                                             |
+| ------------------------------------- | ------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| Workflow YAML syntax                  | Yes                 | `act --list` or `act -n` catches parse errors                                                                     |
+| Job dependencies and ordering         | Yes                 | Dry-run validates the DAG                                                                                         |
+| Step conditionals (`if:` expressions) | Partial             | Dry-run shows which steps would run, but context variables like `github.ref` need to be simulated via event files |
+| Shell scripts in `run:` steps         | Yes (with full run) | Requires container runtime; secrets won't be available                                                            |
+| Actions that require secrets          | No                  | GitHub App tokens, SonarCloud, Snyk, PyPI publishing cannot be tested locally                                     |
+| Matrix strategies                     | Yes                 | Dry-run expands the matrix                                                                                        |
+| Platform-specific jobs (Windows)      | No                  | Act only supports Linux containers                                                                                |
+
+## Simulating different contexts
+
+To test branch-specific logic (e.g., maintenance branch validation), create an event JSON file:
+
+```bash
+# Create an event file simulating a push to the v3 branch
+cat > /tmp/act-event.json << 'EOF'
+{
+  "ref": "refs/heads/v3",
+  "repository": {
+    "full_name": "oscal-compass/compliance-trestle"
+  }
+}
+EOF
+
+# Dry-run the deploy pipeline with the simulated event
+act push -n -W .github/workflows/python-push.yml \
+  --container-architecture linux/amd64 \
+  -e /tmp/act-event.json
+```
+
+## CI integration
+
+PRs that modify files under `.github/` and have the `github_actions` label will automatically run `act` dry-runs in CI via the `act-test.yml` workflow. This validates that workflow changes parse correctly before merge.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -321,6 +321,10 @@ match = "(main)"
 prerelease_token = "rc"
 prerelease = false
 
+[tool.semantic_release.branches.maintenance]
+match = "^v\\d+$"
+prerelease = false
+
 [tool.semantic_release.remote]
 name = "origin"
 type = "github"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 dependencies = [
     "attrs",
     "ilcli",
-    "cryptography==46.0.5",
+    "cryptography==46.0.7",
     "paramiko==4.0.0",
     "ruamel.yaml",
     "furl",


### PR DESCRIPTION
## Summary

Cherry-picks the CI pipeline changes from `develop` onto the `v3` maintenance branch so that the multi-train release infrastructure is operational:

- Cherry-pick of `cc76c3a9` — act-based local workflow testing (PR #2202)
- Cherry-pick of `a013ac82` — multi-train release support (PR #2201)

Conflict resolutions applied:
- `python-push.yml`: kept v3's `needs: [build, set-versions]` (no `test-with-codegen` job on v3); added concurrency group; upgraded `create-github-app-token` to v3.1.1; upgraded sigstore to SHA-pinned v3.3.0
- `.gitignore`: accepted both `/.ruff_cache/` and `manual-steps.md` additions

## Test plan

- [ ] CI (`python-test.yml`) passes on this PR
- [ ] `conventional-pr.yml` lint passes (PR title uses `ci:` type)
- [ ] `python-push.yml` deploy job would correctly guard on `v3` branch push
- [ ] `pyproject.toml` has `[tool.semantic_release.branches.maintenance]` section
- [ ] `act-test.yml` present with correct SHA and actrc config

🤖 Generated with [Claude Code](https://claude.com/claude-code)