### PR TITLE
feat: add RFC 8785 canonical JSON helpers

### DIFF
--- a/docs/reference/API/trestle/core/canonicalization.md
+++ b/docs/reference/API/trestle/core/canonicalization.md
@@ -1,0 +1,7 @@
+---
+title: trestle.core.canonicalization
+description: Documentation for trestle.core.canonicalization module
+---
+
+::: trestle.core.canonicalization
+handler: python

--- a/docs/reference/API/trestle/core/commands/canonicalize.md
+++ b/docs/reference/API/trestle/core/commands/canonicalize.md
@@ -1,0 +1,7 @@
+---
+title: trestle.core.commands.canonicalize
+description: Documentation for trestle.core.commands.canonicalize module
+---
+
+::: trestle.core.commands.canonicalize
+handler: python

--- a/docs/tutorials/canonicalization.md
+++ b/docs/tutorials/canonicalization.md
@@ -1,0 +1,52 @@
+---
+title: Canonicalizing JSON documents
+description: Canonicalizing JSON documents with RFC 8785
+---
+
+# Canonicalizing JSON documents
+
+Trestle can canonicalize JSON documents using RFC 8785.
+
+Canonical JSON is useful when the same logical JSON document needs to produce the same bytes every time. This is important for reproducible digests and later signing workflows.
+
+The canonicalization flow is:
+
+```text
+JSON document -> strict JSON parsing -> RFC 8785 canonical JSON bytes
+```
+
+The command reads the raw JSON document directly. It does not load the document through the OSCAL object models, so it does not change the artifact before canonicalization.
+
+This workflow can handle arbitrary valid JSON documents with a `.json` extension. The input does not need to be an OSCAL model.
+
+## Canonicalize to a file
+
+Use `trestle canonicalize` with an input JSON file and an output path:
+
+```bash
+trestle canonicalize \
+  -f catalog.json \
+  -o catalog.canonical.json
+```
+
+The original JSON file is not modified. The output file contains the RFC 8785 canonical JSON bytes. The recommended output extension is `.canonical.json`.
+
+## Canonicalize to stdout
+
+If `--output` is omitted, trestle writes the canonical JSON bytes to stdout:
+
+```bash
+trestle canonicalize -f catalog.json
+```
+
+This can be useful for shell pipelines that compute or compare digests.
+
+## JSON requirements
+
+The command is JSON-only.
+
+Trestle rejects ambiguous or unsupported JSON inputs before canonicalization, including:
+
+- non-`.json` input paths
+- duplicate object keys
+- non-finite JSON constants such as `NaN` and `Infinity`

--- a/docs/tutorials/cli.md
+++ b/docs/tutorials/cli.md
@@ -5,11 +5,12 @@ description: An introductory tutorial into trestle's CLI and OSCAL use cases
 
 # trestle CLI Overview and OSCAL usecases
 
-The trestle CLI has three primary use cases:
+The trestle CLI has four primary use cases:
 
 - Serve as tooling to generate and manipulate OSCAL files directly by an end user. The objective is to reduce the complexity of creating and editing workflows. Example commands are: `trestle import`, `trestle create`, `trestle split`, `trestle merge`.
 - Act as an automation tool that, by design, can be an integral part of a CI/CD pipeline e.g. `trestle validate`, `trestle tasks`.
 - Allow governance of markdown documents so they conform to specific style or structure requirements.
+- Canonicalize JSON documents with `trestle canonicalize`. See [Canonicalizing JSON documents](canonicalization.md).
 
 To support each of these use cases trestle creates an opinionated directory structure to manage governed documents.
 
@@ -267,7 +268,7 @@ In addition, `trestle create` can create new components within an existing file 
 
 For example,
 
-`$TRESTLE_BASEDIR/catalogs/nist800-53$ trestle create -f ./catalog.json -e catalog.metadata.roles `
+`$TRESTLE_BASEDIR/catalogs/nist800-53$ trestle create -f ./catalog.json -e catalog.metadata.roles`
 
 will add the following property under the `metadata` property for a catalog that will be written to the appropriate file under `catalogs/nist800-53` directory:
 
@@ -1412,7 +1413,7 @@ th, td {
 <tr>
 <td>ResourceTitle
 <td><ul>
-    <li>component.title    
+    <li>component.title
     <li>component.description
     <li>component.control-implementation.description + {text}
     </ul>
@@ -1431,7 +1432,7 @@ th, td {
     <li>implemented_requirement.property[name='goal_version'].value
     </ul>
 <td><ul>
-    <li>Value from spreadsheet is not currently used. 
+    <li>Value from spreadsheet is not currently used.
     <li>Value '1.0' is hard coded.
     </ul>
 <tr>
@@ -1449,7 +1450,7 @@ th, td {
     <li>implemented_requirement.set_parameter.values
     </ul>
 <td><ul>
-    <li>The expected text is of the following format: 
+    <li>The expected text is of the following format:
     <li>v0, [v1, v2...]
     <li>The value v0 is used.
     </ul>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "Jinja2 == 3.1.6",
     "cmarkgfm>=2024.1,<2025.11",
     "orjson",
+    "rfc8785>=0.1.4",
     "requests>=2.32.2",
     "importlib_resources",
 ]

--- a/tests/trestle/core/base_model_test.py
+++ b/tests/trestle/core/base_model_test.py
@@ -416,3 +416,16 @@ def test_oscal_serialize_json() -> None:
     new_catalog = oscatalog.Catalog.parse_obj(jsoned['catalog'])
 
     assert simple_catalog_obj.metadata.title == new_catalog.metadata.title
+
+
+def test_oscal_serialize_canonical_json() -> None:
+    """Test Oscal canonical json serialization."""
+    simple_catalog_obj = simple_catalog_utc()
+
+    serialized = simple_catalog_obj.oscal_serialize_json(canonical=True)
+    jsoned = json.loads(serialized)
+    new_catalog = oscatalog.Catalog.parse_obj(jsoned['catalog'])
+
+    assert serialized == simple_catalog_obj.oscal_serialize_json_bytes(canonical=True).decode(const.FILE_ENCODING)
+    assert '\n' not in serialized
+    assert simple_catalog_obj.metadata.title == new_catalog.metadata.title

--- a/tests/trestle/core/base_model_test.py
+++ b/tests/trestle/core/base_model_test.py
@@ -388,6 +388,14 @@ def test_oscal_write(tmp_path: pathlib.Path) -> None:
     component2.oscal_write(temp_cd_yaml)
 
     component.ComponentDefinition.oscal_read(temp_cd_yaml)
+
+    temp_cd_canonical_json = pathlib.Path(tmp_path) / 'component_test.canonical.json'
+    component2.oscal_write(temp_cd_canonical_json)
+    canonical_json = temp_cd_canonical_json.read_text(encoding=const.FILE_ENCODING)
+    assert canonical_json == component2.oscal_serialize_json(canonical=True)
+    assert '\n' not in canonical_json
+    component.ComponentDefinition.oscal_read(temp_cd_canonical_json)
+
     # test failure
     with pytest.raises(err.TrestleError):
         component2.oscal_write(tmp_path / 'target.borked')

--- a/tests/trestle/core/canonicalization_test.py
+++ b/tests/trestle/core/canonicalization_test.py
@@ -1,0 +1,175 @@
+# -*- mode:python; coding:utf-8 -*-
+
+# Copyright (c) 2026 The OSCAL Compass Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for canonical JSON helpers."""
+
+import pathlib
+
+import pytest
+
+import tests.test_utils as test_utils
+
+from trestle.common.err import TrestleError
+from trestle.core.canonicalization import (
+    canonicalize_json_object,
+    canonicalize_json_text,
+    load_canonical_json_file,
+    sha256_digest_hex,
+)
+
+
+def test_canonicalization_is_stable_for_equivalent_json() -> None:
+    """Equivalent JSON documents should produce identical canonical bytes and digests."""
+    first_json = '{"assessment-results":{"metadata":{"version":"0.1.0","title":"demo"},"results":[]}}'
+    second_json = """
+    {
+      "assessment-results": {
+        "results": [],
+        "metadata": {
+          "title": "demo",
+          "version": "0.1.0"
+        }
+      }
+    }
+    """
+
+    _, first_canonical = canonicalize_json_text(first_json)
+    _, second_canonical = canonicalize_json_text(second_json)
+
+    assert first_canonical == second_canonical
+    assert sha256_digest_hex(first_canonical) == sha256_digest_hex(second_canonical)
+    assert first_canonical == b'{"assessment-results":{"metadata":{"title":"demo","version":"0.1.0"},"results":[]}}'
+
+
+def test_canonicalization_rejects_duplicate_object_keys() -> None:
+    """Duplicate keys are ambiguous for signing and must fail before digesting."""
+    with pytest.raises(TrestleError, match='Duplicate JSON object key'):
+        canonicalize_json_text('{"metadata":{"title":"first","title":"second"}}')
+
+
+def test_canonicalization_rejects_invalid_json() -> None:
+    """Invalid JSON should fail before canonicalization starts."""
+    with pytest.raises(TrestleError, match='Input is not valid JSON'):
+        canonicalize_json_text('{"metadata":')
+
+
+def test_canonicalization_rejects_non_finite_numbers() -> None:
+    """Non-finite numeric values are outside valid canonical JSON."""
+    with pytest.raises(TrestleError, match='Non-finite JSON number'):
+        canonicalize_json_text('{"value": NaN}')
+
+
+def test_canonicalization_uses_rfc8785_number_serialization() -> None:
+    """Number output should match RFC 8785 / ECMAScript serialization examples."""
+    _, canonical_bytes = canonicalize_json_text(
+        '{"numbers":[333333333.33333329,1E30,4.50,2e-3,0.000000000000000000000000001]}'
+    )
+
+    assert canonical_bytes == b'{"numbers":[333333333.3333333,1e+30,4.5,0.002,1e-27]}'
+
+
+def test_canonicalization_matches_rfc8785_primitive_sample() -> None:
+    """Canonical output should match the RFC 8785 primitive serialization sample."""
+    _, canonical_bytes = canonicalize_json_text(
+        r"""
+        {
+          "numbers": [333333333.33333329, 1E30, 4.50,
+                      2e-3, 0.000000000000000000000000001],
+          "string": "\u20ac$\u000F\u000aA'\u0042\u0022\u005c\\\"/",
+          "literals": [null, true, false]
+        }
+        """
+    )
+
+    assert canonical_bytes == (
+        b'{"literals":[null,true,false],'
+        b'"numbers":[333333333.3333333,1e+30,4.5,0.002,1e-27],'
+        b'"string":"\xe2\x82\xac$\\u000f\\nA\'B\\"\\\\\\\\\\"/"}'
+    )
+
+
+def test_canonicalization_rejects_unsafe_integers() -> None:
+    """Integers outside the I-JSON safe range should not be signed silently."""
+    with pytest.raises(TrestleError, match='exceeds safe integer domain'):
+        canonicalize_json_text('{"value": 9007199254740992}')
+
+
+def test_canonicalization_rejects_number_overflow() -> None:
+    """Numbers that parse to infinity should fail before signing."""
+    with pytest.raises(TrestleError, match='not representable in JCS'):
+        canonicalize_json_text('{"value": 1e9999}')
+
+
+def test_canonicalization_uses_rfc8785_utf16_property_sorting() -> None:
+    """Property sorting should follow RFC 8785 UTF-16 code unit ordering."""
+    _, canonical_bytes = canonicalize_json_text(
+        """
+        {
+          "\\u20ac": "Euro Sign",
+          "\\r": "Carriage Return",
+          "\\ufb33": "Hebrew Letter Dalet With Dagesh",
+          "1": "One",
+          "\\ud83d\\ude00": "Emoji: Grinning Face",
+          "\\u0080": "Control",
+          "\\u00f6": "Latin Small Letter O With Diaeresis"
+        }
+        """
+    )
+
+    assert canonical_bytes == (
+        b'{"\\r":"Carriage Return","1":"One","\xc2\x80":"Control",'
+        b'"\xc3\xb6":"Latin Small Letter O With Diaeresis",'
+        b'"\xe2\x82\xac":"Euro Sign","\xf0\x9f\x98\x80":"Emoji: Grinning Face",'
+        b'"\xef\xac\xb3":"Hebrew Letter Dalet With Dagesh"}'
+    )
+
+
+def test_canonicalization_rejects_invalid_unicode() -> None:
+    """Lone surrogate code points should be rejected as invalid canonical JSON."""
+    with pytest.raises(TrestleError, match='input contains non-UTF-8 codepoints'):
+        canonicalize_json_text(r'{"value": "\ud800"}')
+
+
+def test_canonicalization_rejects_non_json_python_values() -> None:
+    """Programmatic callers should not silently canonicalize non-JSON values."""
+    with pytest.raises(TrestleError, match='Unable to canonicalize JSON object according to RFC 8785'):
+        canonicalize_json_object({'value': object()})
+
+
+def test_load_canonical_json_file(tmp_path: pathlib.Path) -> None:
+    """Files should load using the same strict canonicalization path as text."""
+    json_path = tmp_path / 'catalog.json'
+    json_path.write_text('{"catalog":{"uuid":"1","metadata":{"title":"demo"}}}', encoding='utf8')
+
+    json_obj, canonical_bytes = load_canonical_json_file(json_path)
+
+    assert json_obj['catalog']['metadata']['title'] == 'demo'
+    assert canonical_bytes == b'{"catalog":{"metadata":{"title":"demo"},"uuid":"1"}}'
+
+
+def test_load_canonical_json_file_handles_real_oscal_fixture() -> None:
+    """Canonicalization should produce stable bytes for a real OSCAL JSON fixture."""
+    json_path = test_utils.JSON_TEST_DATA_PATH / 'minimal_catalog.json'
+
+    json_obj, canonical_bytes = load_canonical_json_file(json_path)
+
+    assert json_obj['catalog']['metadata']['title'] == 'Minimal Catalog'
+    assert sha256_digest_hex(canonical_bytes) == 'a2d28078f30fd7db2a42bd02227b53881ef86647f84542e85a605075763926aa'
+
+
+def test_load_canonical_json_file_rejects_missing_path(tmp_path: pathlib.Path) -> None:
+    """Missing files should fail with a trestle error."""
+    with pytest.raises(TrestleError, match='JSON path does not exist or is not a file'):
+        load_canonical_json_file(tmp_path / 'missing.json')

--- a/tests/trestle/core/commands/canonicalize_test.py
+++ b/tests/trestle/core/commands/canonicalize_test.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 """Tests for trestle canonicalize command."""
 
+import argparse
 import pathlib
 import sys
 
@@ -22,10 +23,15 @@ from _pytest.monkeypatch import MonkeyPatch
 
 import pytest
 
+from tests import test_utils
+
 import trestle.common.const as const
+import trestle.core.commands.import_ as importcmd
 from trestle.cli import Trestle
+from trestle.common.model_utils import ModelUtils
 from trestle.core.commands.canonicalize import CanonicalizeCmd
 from trestle.core.commands.common.return_codes import CmdReturnCodes
+from trestle.oscal.catalog import Catalog
 
 
 class StdoutWithoutBuffer:
@@ -50,6 +56,28 @@ def test_canonicalize_writes_output_file(tmp_path: pathlib.Path, monkeypatch: Mo
 
     assert Trestle().run() == CmdReturnCodes.SUCCESS.value
     assert output_path.read_bytes() == b'{"a":1,"b":2}'
+
+
+def test_canonicalize_imported_nist_800_53_catalog_remains_oscal_readable(tmp_trestle_dir: pathlib.Path) -> None:
+    """A real imported NIST 800-53 catalog should still load after canonicalization."""
+    source_path = test_utils.JSON_NIST_DATA_PATH / test_utils.JSON_NIST_CATALOG_NAME
+    import_args = argparse.Namespace(
+        trestle_root=tmp_trestle_dir, file=str(source_path), output='nist_800_53', verbose=1, regenerate=False
+    )
+
+    assert importcmd.ImportCmd()._run(import_args) == CmdReturnCodes.SUCCESS.value
+
+    imported_path = tmp_trestle_dir / 'catalogs/nist_800_53/catalog.json'
+    imported_catalog = Catalog.oscal_read(imported_path)
+    assert imported_catalog is not None
+
+    canonical_path = tmp_trestle_dir / 'catalogs/nist_800_53/catalog.canonical.json'
+    CanonicalizeCmd.canonicalize(imported_path, canonical_path)
+
+    canonical_catalog = Catalog.oscal_read(canonical_path)
+    assert canonical_catalog is not None
+    assert ModelUtils.models_are_equivalent(imported_catalog, canonical_catalog)
+    assert b'\n' not in canonical_path.read_bytes()
 
 
 def test_canonicalize_writes_stdout(

--- a/tests/trestle/core/commands/canonicalize_test.py
+++ b/tests/trestle/core/commands/canonicalize_test.py
@@ -1,0 +1,119 @@
+# -*- mode:python; coding:utf-8 -*-
+
+# Copyright (c) 2026 The OSCAL Compass Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for trestle canonicalize command."""
+
+import pathlib
+import sys
+
+from _pytest.monkeypatch import MonkeyPatch
+
+import pytest
+
+import trestle.common.const as const
+from trestle.cli import Trestle
+from trestle.core.commands.canonicalize import CanonicalizeCmd
+from trestle.core.commands.common.return_codes import CmdReturnCodes
+
+
+class StdoutWithoutBuffer:
+    """Test stdout object that only supports text writes."""
+
+    def __init__(self) -> None:
+        self.value = ''
+
+    def write(self, text: str) -> int:
+        """Write text to the test stdout object."""
+        self.value += text
+        return len(text)
+
+
+def test_canonicalize_writes_output_file(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
+    """Canonicalize should write RFC 8785 bytes to the specified output file."""
+    input_path = tmp_path / 'artifact.json'
+    output_path = tmp_path / 'artifact.canonical.json'
+    input_path.write_text('{"b":2,"a":1}', encoding=const.FILE_ENCODING)
+
+    monkeypatch.setattr(sys, 'argv', ['trestle', 'canonicalize', '-f', str(input_path), '-o', str(output_path)])
+
+    assert Trestle().run() == CmdReturnCodes.SUCCESS.value
+    assert output_path.read_bytes() == b'{"a":1,"b":2}'
+
+
+def test_canonicalize_writes_stdout(
+    tmp_path: pathlib.Path, monkeypatch: MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Canonicalize should write canonical JSON to stdout when output is omitted."""
+    input_path = tmp_path / 'artifact.json'
+    input_path.write_text('{"b":2,"a":1}', encoding=const.FILE_ENCODING)
+
+    monkeypatch.setattr(sys, 'argv', ['trestle', 'canonicalize', '-f', str(input_path)])
+
+    assert Trestle().run() == CmdReturnCodes.SUCCESS.value
+    output, _ = capsys.readouterr()
+    assert output == '{"a":1,"b":2}'
+
+
+def test_canonicalize_rejects_non_json_input(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
+    """Canonicalize should reject non-JSON file extensions."""
+    input_path = tmp_path / 'artifact.yaml'
+    input_path.write_text('a: 1', encoding=const.FILE_ENCODING)
+    monkeypatch.setattr(sys, 'argv', ['trestle', 'canonicalize', '-f', str(input_path)])
+
+    assert Trestle().run() == CmdReturnCodes.COMMAND_ERROR.value
+
+
+def test_canonicalize_rejects_output_directory(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
+    """Canonicalize should reject output paths that are directories."""
+    input_path = tmp_path / 'artifact.json'
+    input_path.write_text('{"a":1}', encoding=const.FILE_ENCODING)
+    monkeypatch.setattr(sys, 'argv', ['trestle', 'canonicalize', '-f', str(input_path), '-o', str(tmp_path)])
+
+    assert Trestle().run() == CmdReturnCodes.COMMAND_ERROR.value
+
+
+def test_canonicalize_rejects_missing_file(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
+    """Canonicalize should fail clearly if the input path is missing."""
+    monkeypatch.setattr(sys, 'argv', ['trestle', 'canonicalize', '-f', str(tmp_path / 'missing.json')])
+
+    assert Trestle().run() == CmdReturnCodes.COMMAND_ERROR.value
+
+
+def test_canonicalize_rejects_invalid_json(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
+    """Canonicalize should reject invalid JSON."""
+    input_path = tmp_path / 'artifact.json'
+    input_path.write_text('{"a":', encoding=const.FILE_ENCODING)
+    monkeypatch.setattr(sys, 'argv', ['trestle', 'canonicalize', '-f', str(input_path)])
+
+    assert Trestle().run() == CmdReturnCodes.COMMAND_ERROR.value
+
+
+def test_canonicalize_rejects_duplicate_keys(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
+    """Canonicalize should reject duplicate JSON object keys."""
+    input_path = tmp_path / 'artifact.json'
+    input_path.write_text('{"a":1,"a":2}', encoding=const.FILE_ENCODING)
+    monkeypatch.setattr(sys, 'argv', ['trestle', 'canonicalize', '-f', str(input_path)])
+
+    assert Trestle().run() == CmdReturnCodes.COMMAND_ERROR.value
+
+
+def test_write_stdout_falls_back_to_text_stdout(monkeypatch: MonkeyPatch) -> None:
+    """Canonicalize should support stdout objects without a buffer attribute."""
+    stdout = StdoutWithoutBuffer()
+    monkeypatch.setattr(sys, 'stdout', stdout)
+
+    CanonicalizeCmd._write_stdout(b'{"a":1}')
+
+    assert stdout.value == '{"a":1}'

--- a/tests/trestle/core/models/file_content_type_test.py
+++ b/tests/trestle/core/models/file_content_type_test.py
@@ -36,6 +36,7 @@ def test_to_content_type() -> None:
 def test_to_file_extension() -> None:
     """Test to_file_extension method."""
     assert FileContentType.to_file_extension(FileContentType.JSON) == '.json'
+    assert FileContentType.to_file_extension(FileContentType.CANONICAL_JSON) == '.json'
     assert FileContentType.to_file_extension(FileContentType.YAML) == '.yaml'
 
     with pytest.raises(TrestleError):
@@ -47,6 +48,12 @@ def test_path_to_file_content_type(tmp_trestle_dir: Path) -> None:
     tmp_stem = tmp_trestle_dir / 'content_type_test'
 
     tmp_file = tmp_stem.with_suffix('.json')
+    tmp_file.touch()
+    assert FileContentType.JSON == FileContentType.path_to_content_type(tmp_file)
+    assert FileContentType.path_to_file_extension(tmp_file) == '.json'
+    tmp_file.unlink()
+
+    tmp_file = tmp_stem.with_suffix('.canonical.json')
     tmp_file.touch()
     assert FileContentType.JSON == FileContentType.path_to_content_type(tmp_file)
     assert FileContentType.path_to_file_extension(tmp_file) == '.json'
@@ -71,3 +78,19 @@ def test_path_to_file_content_type(tmp_trestle_dir: Path) -> None:
 def test_dir_to_content_type(tmp_path: Path) -> None:
     """Test failure of dir to file content type."""
     assert FileContentType.UNKNOWN == FileContentType.dir_to_content_type(tmp_path)
+
+    canonical_json_path = tmp_path / 'catalog.canonical.json'
+    canonical_json_path.touch()
+    assert FileContentType.JSON == FileContentType.dir_to_content_type(tmp_path)
+
+    json_path = tmp_path / 'catalog.json'
+    json_path.touch()
+    assert FileContentType.JSON == FileContentType.dir_to_content_type(tmp_path)
+
+
+def test_is_readable_file() -> None:
+    """Test readable file content types."""
+    assert FileContentType.is_readable_file(FileContentType.JSON)
+    assert FileContentType.is_readable_file(FileContentType.YAML)
+    assert FileContentType.is_readable_file(FileContentType.CANONICAL_JSON)
+    assert not FileContentType.is_readable_file(FileContentType.UNKNOWN)

--- a/tests/trestle/core/models/file_content_type_test.py
+++ b/tests/trestle/core/models/file_content_type_test.py
@@ -26,6 +26,7 @@ from trestle.core.models.file_content_type import FileContentType
 def test_to_content_type() -> None:
     """Test to_content_type method."""
     assert FileContentType.to_content_type('.json') == FileContentType.JSON
+    assert FileContentType.to_content_type('.canonical.json') == FileContentType.CANONICAL_JSON
     assert FileContentType.to_content_type('.yaml') == FileContentType.YAML
     assert FileContentType.to_content_type('') == FileContentType.DIRLIKE
 
@@ -50,12 +51,14 @@ def test_path_to_file_content_type(tmp_trestle_dir: Path) -> None:
     tmp_file = tmp_stem.with_suffix('.json')
     tmp_file.touch()
     assert FileContentType.JSON == FileContentType.path_to_content_type(tmp_file)
+    assert FileContentType.JSON == FileContentType.path_suffix_to_content_type(tmp_file)
     assert FileContentType.path_to_file_extension(tmp_file) == '.json'
     tmp_file.unlink()
 
     tmp_file = tmp_stem.with_suffix('.canonical.json')
     tmp_file.touch()
     assert FileContentType.JSON == FileContentType.path_to_content_type(tmp_file)
+    assert FileContentType.CANONICAL_JSON == FileContentType.path_suffix_to_content_type(tmp_file)
     assert FileContentType.path_to_file_extension(tmp_file) == '.json'
     tmp_file.unlink()
 

--- a/trestle/cli.py
+++ b/trestle/cli.py
@@ -20,6 +20,7 @@ import pathlib
 from trestle.common import const, log
 from trestle.core.commands.assemble import AssembleCmd
 from trestle.core.commands.author.command import AuthorCmd
+from trestle.core.commands.canonicalize import CanonicalizeCmd
 from trestle.core.commands.command_docs import CommandBase
 from trestle.core.commands.command_docs import CommandPlusDocs
 from trestle.core.commands.create import CreateCmd
@@ -46,6 +47,7 @@ class Trestle(CommandBase):
     subcommands = [
         AssembleCmd,
         AuthorCmd,
+        CanonicalizeCmd,
         CreateCmd,
         DescribeCmd,
         HrefCmd,

--- a/trestle/core/base_model.py
+++ b/trestle/core/base_model.py
@@ -43,6 +43,7 @@ import trestle.common.const as const
 import trestle.common.err as err
 from trestle.common.str_utils import AliasMode, classname_to_alias
 from trestle.common.type_utils import get_origin, is_collection_field_type
+from trestle.core.canonicalization import canonicalize_json_text
 from trestle.core.models.file_content_type import FileContentType
 from trestle.core.trestle_base_model import TrestleBaseModel
 
@@ -218,12 +219,13 @@ class OscalBaseModel(TrestleBaseModel):
             result[classname_to_alias(class_name, AliasMode.JSON)] = raw_dict
         return result
 
-    def oscal_serialize_json_bytes(self, pretty: bool = False, wrapped: bool = True) -> bytes:
+    def oscal_serialize_json_bytes(self, pretty: bool = False, wrapped: bool = True, canonical: bool = False) -> bytes:
         """
         Return an 'oscal wrapped' json object serialized in a compressed form as bytes.
 
         Args:
             pretty: Whether or not to pretty-print json output or have in compressed form.
+            canonical: Whether or not to return RFC 8785 canonical JSON bytes.
         Returns:
             Oscal model serialized to a json object including packaging inside of a single top level key.
         """
@@ -231,21 +233,26 @@ class OscalBaseModel(TrestleBaseModel):
             odict = self.oscal_dict()
         else:
             odict = self.dict(by_alias=True, exclude_none=True)
+        if canonical:
+            json_bytes = orjson.dumps(odict, default=self.__json_encoder__)
+            _, canonical_bytes = canonicalize_json_text(json_bytes.decode(const.FILE_ENCODING))
+            return canonical_bytes
         if pretty:
             return orjson.dumps(odict, default=self.__json_encoder__, option=orjson.OPT_INDENT_2)
         return orjson.dumps(odict, default=self.__json_encoder__)
 
-    def oscal_serialize_json(self, pretty: bool = False, wrapped: bool = True) -> str:
+    def oscal_serialize_json(self, pretty: bool = False, wrapped: bool = True, canonical: bool = False) -> str:
         """
         Return an 'oscal wrapped' json object serialized in a compressed form as bytes.
 
         Args:
             pretty: Whether or not to pretty-print json output or have in compressed form.
+            canonical: Whether or not to return RFC 8785 canonical JSON.
         Returns:
             Oscal model serialized to a json object including packaging inside of a single top level key.
         """
         # This function is provided for backwards compatibility
-        return self.oscal_serialize_json_bytes(pretty, wrapped).decode(const.FILE_ENCODING)
+        return self.oscal_serialize_json_bytes(pretty, wrapped, canonical).decode(const.FILE_ENCODING)
 
     def oscal_write(self, path: pathlib.Path) -> None:
         """

--- a/trestle/core/base_model.py
+++ b/trestle/core/base_model.py
@@ -268,7 +268,7 @@ class OscalBaseModel(TrestleBaseModel):
         Raises:
             err.TrestleError: If a unknown file extension is provided.
         """
-        content_type = FileContentType.to_content_type(path.suffix)
+        content_type = FileContentType.path_suffix_to_content_type(path)
         # The output will have \r\n newlines on windows and \n newlines elsewhere
 
         if content_type == FileContentType.YAML:
@@ -278,6 +278,9 @@ class OscalBaseModel(TrestleBaseModel):
         elif content_type == FileContentType.JSON:
             with pathlib.Path(path).open('wb') as write_file:
                 write_file.write(self.oscal_serialize_json_bytes(pretty=True))
+        elif content_type == FileContentType.CANONICAL_JSON:
+            with pathlib.Path(path).open('wb') as write_file:
+                write_file.write(self.oscal_serialize_json_bytes(canonical=True))
 
     @classmethod
     def oscal_read(cls, path: pathlib.Path) -> Optional['OscalBaseModel']:
@@ -294,7 +297,7 @@ class OscalBaseModel(TrestleBaseModel):
         # Create the wrapper model.
         alias = classname_to_alias(cls.__name__, AliasMode.JSON)
 
-        content_type = FileContentType.to_content_type(path.suffix)
+        content_type = FileContentType.path_suffix_to_content_type(path)
         logger.debug(f'oscal_read content type {content_type} and alias {alias} from {path}')
 
         if not path.exists():
@@ -307,7 +310,7 @@ class OscalBaseModel(TrestleBaseModel):
                 yaml = YAML(typ='safe')
                 with path.open('r', encoding=const.FILE_ENCODING) as fh:
                     obj = yaml.load(fh)
-            elif content_type == FileContentType.JSON:
+            elif content_type in [FileContentType.JSON, FileContentType.CANONICAL_JSON]:
                 obj = load_file(path, json_loads=cls.__config__.json_loads)
         except Exception as e:
             raise err.TrestleError(f'Error loading file {path} {str(e)}')

--- a/trestle/core/canonicalization.py
+++ b/trestle/core/canonicalization.py
@@ -1,0 +1,74 @@
+# -*- mode:python; coding:utf-8 -*-
+
+# Copyright (c) 2026 The OSCAL Compass Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Canonical JSON helpers for reproducible OSCAL artifact digests."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import pathlib
+from typing import Any, Dict, List, Tuple
+
+import rfc8785
+
+from trestle.common import const
+from trestle.common.err import TrestleError
+
+
+def load_canonical_json_file(path: pathlib.Path) -> Tuple[Any, bytes]:
+    """Load a JSON document and return its parsed object and canonical bytes."""
+    if not path.exists() or not path.is_file():
+        raise TrestleError(f'JSON path does not exist or is not a file: {path}')
+
+    return canonicalize_json_text(path.read_text(encoding=const.FILE_ENCODING))
+
+
+def canonicalize_json_text(json_text: str) -> Tuple[Any, bytes]:
+    """Parse JSON text and return its parsed object and canonical bytes."""
+    try:
+        json_obj = json.loads(
+            json_text, object_pairs_hook=_object_pairs_without_duplicates, parse_constant=_reject_json_constant
+        )
+    except json.JSONDecodeError as error:
+        raise TrestleError(f'Input is not valid JSON: {error}')
+
+    return json_obj, canonicalize_json_object(json_obj)
+
+
+def canonicalize_json_object(json_obj: Any) -> bytes:
+    """Return RFC 8785 canonical UTF-8 bytes for a parsed JSON-compatible object."""
+    try:
+        return rfc8785.dumps(json_obj)
+    except rfc8785.CanonicalizationError as error:
+        raise TrestleError(f'Unable to canonicalize JSON object according to RFC 8785: {error}')
+
+
+def sha256_digest_hex(data: bytes) -> str:
+    """Return a SHA-256 digest for canonical bytes."""
+    return hashlib.sha256(data).hexdigest()
+
+
+def _object_pairs_without_duplicates(pairs: List[Tuple[str, Any]]) -> Dict[str, Any]:
+    output: Dict[str, Any] = {}
+    for key, value in pairs:
+        if key in output:
+            raise TrestleError(f'Duplicate JSON object key is not supported for canonicalization: {key}')
+        output[key] = value
+    return output
+
+
+def _reject_json_constant(value: str) -> None:
+    raise TrestleError(f'Non-finite JSON number is not supported for canonicalization: {value}')

--- a/trestle/core/commands/canonicalize.py
+++ b/trestle/core/commands/canonicalize.py
@@ -1,0 +1,85 @@
+# -*- mode:python; coding:utf-8 -*-
+
+# Copyright (c) 2026 The OSCAL Compass Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Trestle Canonicalize Command."""
+
+import argparse
+import logging
+import pathlib
+import sys
+from typing import Optional
+
+from trestle.common import log
+from trestle.common.err import TrestleError, handle_generic_command_exception
+from trestle.core.canonicalization import load_canonical_json_file
+from trestle.core.commands.command_docs import CommandBase
+from trestle.core.commands.common.return_codes import CmdReturnCodes
+
+logger = logging.getLogger(__name__)
+
+
+class CanonicalizeCmd(CommandBase):
+    """Canonicalize an OSCAL JSON file using RFC 8785."""
+
+    name = 'canonicalize'
+
+    def _init_arguments(self) -> None:
+        self.add_argument(
+            '-f', '--file', help='Path to the OSCAL JSON file to canonicalize.', required=True, type=pathlib.Path
+        )
+        self.add_argument(
+            '-o',
+            '--output',
+            help='Output file for canonical JSON. If omitted, output is written to stdout.',
+            type=pathlib.Path,
+            default=None,
+        )
+
+    def _run(self, args: argparse.Namespace) -> int:
+        """Canonicalize an OSCAL JSON file."""
+        try:
+            log.set_log_level_from_args(args)
+            self.canonicalize(args.file, args.output)
+            return CmdReturnCodes.SUCCESS.value
+        except Exception as e:  # pragma: no cover
+            return handle_generic_command_exception(e, logger, 'Error while canonicalizing OSCAL JSON')
+
+    @classmethod
+    def canonicalize(cls, input_path: pathlib.Path, output_path: Optional[pathlib.Path] = None) -> None:
+        """Write RFC 8785 canonical JSON bytes for input_path to output_path or stdout."""
+        input_path = input_path.resolve()
+        if input_path.suffix.lower() != '.json':
+            raise TrestleError('Canonicalization is only supported for JSON files.')
+
+        _, canonical_bytes = load_canonical_json_file(input_path)
+
+        if output_path is None:
+            cls._write_stdout(canonical_bytes)
+            return
+
+        output_path = output_path.resolve()
+        if output_path.exists() and output_path.is_dir():
+            raise TrestleError(f'Canonical JSON output path is a directory: {output_path}')
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(canonical_bytes)
+
+    @staticmethod
+    def _write_stdout(canonical_bytes: bytes) -> None:
+        """Write canonical bytes to stdout."""
+        try:
+            sys.stdout.buffer.write(canonical_bytes)
+        except AttributeError:
+            sys.stdout.write(canonical_bytes.decode())

--- a/trestle/core/commands/canonicalize.py
+++ b/trestle/core/commands/canonicalize.py
@@ -31,13 +31,18 @@ logger = logging.getLogger(__name__)
 
 
 class CanonicalizeCmd(CommandBase):
-    """Canonicalize an OSCAL JSON file using RFC 8785."""
+    """Canonicalize a JSON document using RFC 8785.
+
+    This command reads the raw JSON input directly and writes canonical JSON
+    bytes. It is designed for OSCAL artifacts, but it does not load the input
+    through OSCAL models and can canonicalize any valid JSON document.
+    """
 
     name = 'canonicalize'
 
     def _init_arguments(self) -> None:
         self.add_argument(
-            '-f', '--file', help='Path to the OSCAL JSON file to canonicalize.', required=True, type=pathlib.Path
+            '-f', '--file', help='Path to the JSON document to canonicalize.', required=True, type=pathlib.Path
         )
         self.add_argument(
             '-o',
@@ -48,13 +53,13 @@ class CanonicalizeCmd(CommandBase):
         )
 
     def _run(self, args: argparse.Namespace) -> int:
-        """Canonicalize an OSCAL JSON file."""
+        """Canonicalize a JSON document."""
         try:
             log.set_log_level_from_args(args)
             self.canonicalize(args.file, args.output)
             return CmdReturnCodes.SUCCESS.value
         except Exception as e:  # pragma: no cover
-            return handle_generic_command_exception(e, logger, 'Error while canonicalizing OSCAL JSON')
+            return handle_generic_command_exception(e, logger, 'Error while canonicalizing JSON')
 
     @classmethod
     def canonicalize(cls, input_path: pathlib.Path, output_path: Optional[pathlib.Path] = None) -> None:

--- a/trestle/core/models/file_content_type.py
+++ b/trestle/core/models/file_content_type.py
@@ -28,18 +28,22 @@ class FileContentType(Enum):
     # YAML formatted content
     YAML = 2
 
+    # RFC 8785 canonical JSON formatted content. This is an explicit content type;
+    # extension inference still treats canonical JSON files as JSON.
+    CANONICAL_JSON = 3
+
     # No extension and possibly a DIR
-    DIRLIKE = 3
+    DIRLIKE = 4
 
     # Type could not be determined
-    UNKNOWN = 4
+    UNKNOWN = 5
 
     @classmethod
     def to_file_extension(cls, content_type: 'FileContentType') -> str:
         """Get file extension for the type, including the dot."""
         if content_type == FileContentType.YAML:
             return '.yaml'
-        if content_type == FileContentType.JSON:
+        if content_type in [FileContentType.JSON, FileContentType.CANONICAL_JSON]:
             return '.json'
         raise TrestleError(f'Invalid file content type {content_type}')
 
@@ -93,4 +97,4 @@ class FileContentType(Enum):
     @classmethod
     def is_readable_file(cls, content_type: 'FileContentType') -> bool:
         """Is the file a type that can be read directly."""
-        return content_type == FileContentType.JSON or content_type == FileContentType.YAML
+        return content_type in [FileContentType.JSON, FileContentType.YAML, FileContentType.CANONICAL_JSON]

--- a/trestle/core/models/file_content_type.py
+++ b/trestle/core/models/file_content_type.py
@@ -50,6 +50,8 @@ class FileContentType(Enum):
     @classmethod
     def to_content_type(cls, file_extension: str) -> 'FileContentType':
         """Get content type form file extension, including the dot."""
+        if file_extension == '.canonical.json':
+            return FileContentType.CANONICAL_JSON
         if file_extension == '.json':
             return FileContentType.JSON
         if file_extension == '.yaml' or file_extension == '.yml':
@@ -58,6 +60,18 @@ class FileContentType(Enum):
             return FileContentType.DIRLIKE
 
         raise TrestleError(f'Unsupported file extension {file_extension}')
+
+    @classmethod
+    def path_suffix_to_content_type(cls, file_path: Path) -> 'FileContentType':
+        """Get content type from an explicit file path's suffixes without checking existence."""
+        if cls._has_canonical_json_suffix(file_path):
+            return FileContentType.CANONICAL_JSON
+        return FileContentType.to_content_type(file_path.suffix)
+
+    @classmethod
+    def _has_canonical_json_suffix(cls, file_path: Path) -> bool:
+        """Return True if the path ends with the canonical JSON double extension."""
+        return ''.join(file_path.suffixes[-2:]) == '.canonical.json'
 
     @classmethod
     def path_to_content_type(cls, file_path: Path) -> 'FileContentType':


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

<!--- Uncomment below if changes are for GitHub Actions -->

<!--
### How To Test

If using [act](https://github.com/nektos/act), fill in below:

**act version**  

**act command**
```bash
```
-->

## Summary
Adds helpers that turn OSCAL JSON into a stable RFC 8785 format, so the same document always produces the same digest. It rejects unclear or unsafe JSON, such as duplicate keys, `NaN`, and `Infinity`, and adds tests for the new helpers.

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)
- Part of #2013
- Builds toward #2037
- Closes #2234
# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
