### PR TITLE
fix(ci): prevent maintenance branch releases from being marked latest

### DIFF
--- a/.github/workflows/python-push.yml
+++ b/.github/workflows/python-push.yml
@@ -216,6 +216,14 @@ jobs:
       with:
         github_token: ${{ steps.app-token.outputs.token }}
 
+    - name: Ensure non-main releases are not marked latest
+      if: github.ref != 'refs/heads/main' && steps.release.outputs.released == 'true'
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      run: |
+        echo "Un-marking release ${{ steps.release.outputs.tag }} as latest"
+        gh release edit "${{ steps.release.outputs.tag }}" --latest=false
+
     # --- Generate provenance for the ACTUAL RELEASE ARTIFACTS ---
 
     - name: Publish package distributions to PyPI
@@ -235,6 +243,7 @@ jobs:
       if: steps.release.outputs.released == 'true'
       with:
         github_token: ${{ steps.app-token.outputs.token }}
+        tag: ${{ steps.release.outputs.tag }}
 
   merge-main-to-develop:
     name: Merge main -> develop


### PR DESCRIPTION
## Summary
Cherry-pick of #2241 to the v3 maintenance branch.

Fixes two bugs in the release workflow when deploying from the v3 maintenance branch:

1. **v3 releases were being marked as "latest" on GitHub**, displacing the actual latest v4.x release
2. **Wheel and attestation artifacts were uploaded to the wrong release** (v4.x instead of v3.x)

## Changes

### 1. Added post-release step to un-mark non-main releases as latest
- Runs `gh release edit --latest=false` for non-main branch releases
- Skipped on main (v4.x releases should be latest)
- GitHub automatically recalculates "latest" to be the highest semver release

### 2. Pass explicit `tag` to upload-to-gh-release action
- Added `tag: ${{ steps.release.outputs.tag }}` input
- Prevents the action from auto-detecting the globally highest tag

## Root Causes
- `python-semantic-release` v10.5.3 doesn't expose a `make_latest` parameter, so GitHub API defaults to marking every new release as "latest"
- `upload-to-gh-release` without explicit `tag` runs semantic-release internally, finds v4.0.3 as the globally highest tag, and uploads artifacts there

## Testing Plan

After merge:
- [ ] Trigger a v3 release (push a `fix:` commit to v3 branch)
- [ ] Verify v3.x.x release is NOT marked "latest" on GitHub
- [ ] Verify v4.0.3 IS marked "latest"
- [ ] Verify wheel/sdist/sigstore files are attached to v3.x.x release
- [ ] Download from PyPI: `pip download compliance-trestle==<v3-version> --no-deps`
- [ ] Verify artifacts are correct

## Related
- Cherry-pick of #2241 (merged to develop)
- Parent commit: 64831075 from develop branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)