### PR TITLE
feat: add OSCAL signing and verification flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Trestle provides tooling to help orchestrate the compliance process across a num
 - Tooling manage authoring and governance of markdown and drawio files within a repository.
 - Support within trestle to streamline management within a managed git environment.
 - An underlying object model that supports developers interacting with OSCAL artifacts.
+- Detached signing and verification for JSON artifacts.
 
 ## Why Trestle
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,7 @@ Trestle provides tooling to help orchestrate the compliance process across a num
 - Tooling manage authoring and governance of markdown and drawio files withn a repository.
 - Support within trestle to streamline management within a managed git environment.
 - An underlying object model that supports developers interacting with OSCAL artefacts.
+- Detached signing and verification for JSON artifacts. See the [`trestle sign` and `trestle verify` CLI documentation](tutorials/cli.md#trestle-sign).
 
 ## Important Note:
 

--- a/docs/predicates/oscal-signing/v1.md
+++ b/docs/predicates/oscal-signing/v1.md
@@ -1,0 +1,122 @@
+---
+title: OSCAL Signing Predicate v1
+description: Predicate type used by compliance-trestle detached OSCAL JSON signatures
+---
+
+# OSCAL Signing Predicate v1
+
+Trestle uses this predicate type in the in-toto Statement created by `trestle sign`:
+
+```text
+https://oscal-compass.github.io/compliance-trestle/predicates/oscal-signing/v1
+```
+
+The predicate describes how trestle created the digest for a signed OSCAL JSON
+artifact. The predicate type URI is recorded in the signed Statement and is not
+fetched during verification.
+
+## What is signed
+
+`trestle sign` creates a detached DSSE envelope. The envelope payload is an in-toto Statement that records:
+
+- the subject file name
+- the SHA-256 digest of the RFC 8785 canonical JSON bytes
+- the predicate type and predicate fields described below
+
+The DSSE signature is made over the DSSE pre-authentication encoding of the
+Statement payload. The original OSCAL JSON file is not modified.
+
+## Statement
+
+The DSSE payload is a base64-encoded in-toto Statement with the following shape:
+
+```json
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "subject": [
+    {
+      "name": "catalog.json",
+      "digest": {
+        "sha256": "..."
+      }
+    }
+  ],
+  "predicateType": "https://oscal-compass.github.io/compliance-trestle/predicates/oscal-signing/v1",
+  "predicate": {
+    "canonicalization": "RFC8785",
+    "digestAlgorithm": "sha256",
+    "digestSource": "canonical-json",
+    "tool": "compliance-trestle"
+  }
+}
+```
+
+## Predicate fields
+
+`canonicalization`
+: The canonicalization algorithm applied before hashing. Trestle uses `RFC8785`.
+
+`digestAlgorithm`
+: The digest algorithm used over the canonical JSON bytes. Trestle uses `sha256`.
+
+`digestSource`
+: The bytes that were hashed. `canonical-json` means the digest was computed
+over the RFC 8785 canonical JSON bytes, not the original file bytes.
+
+`tool`
+: The producer of the predicate. Trestle writes `compliance-trestle`.
+
+## Sign an OSCAL JSON file
+
+Use `trestle sign` with the OSCAL JSON file, a PEM private key, and an output
+path for the detached envelope:
+
+```bash
+trestle sign \
+  -f catalog.json \
+  --key private.pem \
+  -o catalog.json.dsse
+```
+
+Trestle reads and canonicalizes the JSON file, computes the digest, builds the
+in-toto Statement, signs it as a DSSE payload, and writes the detached envelope.
+
+Only JSON files are supported. Trestle rejects non-`.json` input paths, invalid
+JSON, duplicate JSON object keys, and non-finite JSON constants such as `NaN`
+and `Infinity`.
+
+Use `--subject-name` to record a subject name other than the input file name:
+
+```bash
+trestle sign \
+  -f catalog.json \
+  --key private.pem \
+  -o catalog.json.dsse \
+  --subject-name catalogs/nist/catalog.json
+```
+
+## Verify an OSCAL JSON file
+
+Use `trestle verify` with the OSCAL JSON file, the detached envelope, and the
+PEM public key:
+
+```bash
+trestle verify \
+  -f catalog.json \
+  --signature catalog.json.dsse \
+  --key public.pem
+```
+
+Verification checks the DSSE signature, parses the signed Statement, confirms
+the predicate type and predicate fields, canonicalizes the OSCAL JSON file, and
+compares the computed digest with the signed subject digest.
+
+If signing used a custom subject name, pass the same value during verification:
+
+```bash
+trestle verify \
+  -f catalog.json \
+  --signature catalog.json.dsse \
+  --key public.pem \
+  --subject-name catalogs/nist/catalog.json
+```

--- a/docs/predicates/oscal-signing/v1.md
+++ b/docs/predicates/oscal-signing/v1.md
@@ -1,6 +1,6 @@
 ---
 title: OSCAL Signing Predicate v1
-description: Predicate type used by compliance-trestle detached OSCAL JSON signatures
+description: Predicate type used by compliance-trestle detached JSON signatures
 ---
 
 # OSCAL Signing Predicate v1
@@ -11,9 +11,11 @@ Trestle uses this predicate type in the in-toto Statement created by `trestle si
 https://oscal-compass.github.io/compliance-trestle/predicates/oscal-signing/v1
 ```
 
-The predicate describes how trestle created the digest for a signed OSCAL JSON
-artifact. The predicate type URI is recorded in the signed Statement and is not
-fetched during verification.
+The predicate describes how trestle created the digest for a signed JSON artifact.
+The predicate type URI is recorded in the signed Statement and is not fetched
+during verification.
+
+For command usage, see the [`trestle sign` and `trestle verify` CLI documentation](../../tutorials/cli.md#trestle-sign).
 
 ## What is signed
 
@@ -24,11 +26,11 @@ fetched during verification.
 - the predicate type and predicate fields described below
 
 The DSSE signature is made over the DSSE pre-authentication encoding of the
-Statement payload. The original OSCAL JSON file is not modified.
+Statement payload. The original JSON file is not modified.
 
 ## Statement
 
-The DSSE payload is a base64-encoded in-toto Statement with the following shape:
+The DSSE payload is a base64-encoded in-toto Statement with exactly one subject:
 
 ```json
 {
@@ -53,70 +55,9 @@ The DSSE payload is a base64-encoded in-toto Statement with the following shape:
 
 ## Predicate fields
 
-`canonicalization`
-: The canonicalization algorithm applied before hashing. Trestle uses `RFC8785`.
-
-`digestAlgorithm`
-: The digest algorithm used over the canonical JSON bytes. Trestle uses `sha256`.
-
-`digestSource`
-: The bytes that were hashed. `canonical-json` means the digest was computed
-over the RFC 8785 canonical JSON bytes, not the original file bytes.
-
-`tool`
-: The producer of the predicate. Trestle writes `compliance-trestle`.
-
-## Sign an OSCAL JSON file
-
-Use `trestle sign` with the OSCAL JSON file, a PEM private key, and an output
-path for the detached envelope:
-
-```bash
-trestle sign \
-  -f catalog.json \
-  --key private.pem \
-  -o catalog.json.dsse
-```
-
-Trestle reads and canonicalizes the JSON file, computes the digest, builds the
-in-toto Statement, signs it as a DSSE payload, and writes the detached envelope.
-
-Only JSON files are supported. Trestle rejects non-`.json` input paths, invalid
-JSON, duplicate JSON object keys, and non-finite JSON constants such as `NaN`
-and `Infinity`.
-
-Use `--subject-name` to record a subject name other than the input file name:
-
-```bash
-trestle sign \
-  -f catalog.json \
-  --key private.pem \
-  -o catalog.json.dsse \
-  --subject-name catalogs/nist/catalog.json
-```
-
-## Verify an OSCAL JSON file
-
-Use `trestle verify` with the OSCAL JSON file, the detached envelope, and the
-PEM public key:
-
-```bash
-trestle verify \
-  -f catalog.json \
-  --signature catalog.json.dsse \
-  --key public.pem
-```
-
-Verification checks the DSSE signature, parses the signed Statement, confirms
-the predicate type and predicate fields, canonicalizes the OSCAL JSON file, and
-compares the computed digest with the signed subject digest.
-
-If signing used a custom subject name, pass the same value during verification:
-
-```bash
-trestle verify \
-  -f catalog.json \
-  --signature catalog.json.dsse \
-  --key public.pem \
-  --subject-name catalogs/nist/catalog.json
-```
+| Field              | Description                                                                                                                                     |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `canonicalization` | The canonicalization algorithm applied before hashing. Trestle uses `RFC8785`.                                                                  |
+| `digestAlgorithm`  | The digest algorithm used over the canonical JSON bytes. Trestle uses `sha256`.                                                                 |
+| `digestSource`     | The bytes that were hashed. `canonical-json` means the digest was computed over the RFC 8785 canonical JSON bytes, not the original file bytes. |
+| `tool`             | The producer of the predicate. Trestle writes `compliance-trestle`.                                                                             |

--- a/docs/tutorials/cli.md
+++ b/docs/tutorials/cli.md
@@ -5,13 +5,14 @@ description: An introductory tutorial into trestle's CLI and OSCAL use cases
 
 # trestle CLI Overview and OSCAL usecases
 
-The trestle CLI has five primary use cases:
+The trestle CLI has six primary use cases:
 
 - Serve as tooling to generate and manipulate OSCAL files directly by an end user. The objective is to reduce the complexity of creating and editing workflows. Example commands are: `trestle import`, `trestle create`, `trestle split`, `trestle merge`.
 - Act as an automation tool that, by design, can be an integral part of a CI/CD pipeline e.g. `trestle validate`, `trestle tasks`.
 - Allow governance of markdown documents so they conform to specific style or structure requirements.
 - Canonicalize JSON documents with `trestle canonicalize`. See [Canonicalizing JSON documents](canonicalization.md).
 - Manage experimental commands with `trestle beta`.
+- Sign and verify JSON artifacts with detached DSSE envelopes.
 
 To support each of these use cases trestle creates an opinionated directory structure to manage governed documents.
 
@@ -592,6 +593,60 @@ By default validate will display warning messages and a message indicating the f
 
 The links validator is special because it always returns success that the file is valid - but it will list any inconsistencies it finds between the
 references to links, and corresponding links in the backmatter.
+
+## `trestle sign`
+
+Trestle sign writes a detached DSSE envelope for a JSON file. It canonicalizes the JSON using RFC 8785, computes a SHA-256 digest, records that digest in an in-toto Statement, and signs the Statement with a PEM private key.
+
+Generate an Ed25519 private/public key pair with OpenSSL:
+
+```bash
+openssl genpkey -algorithm ed25519 -out private.pem
+openssl pkey -in private.pem -pubout -out public.pem
+chmod 600 private.pem
+```
+
+The private key is used for signing. Keep it secret. The public key can be shared with users or systems that need to verify signatures.
+
+```bash
+trestle sign \
+  -f catalog.json \
+  --key private.pem \
+  -o catalog.json.dsse
+```
+
+For an encrypted private key, use `--key-password-env`. The option names an environment variable that contains the password, so the password is not passed as a command-line argument.
+
+```bash
+export TRESTLE_KEY_PASSWORD='replace-with-your-password'
+openssl genpkey -algorithm ed25519 -aes-256-cbc -pass env:TRESTLE_KEY_PASSWORD -out private-encrypted.pem
+openssl pkey -in private-encrypted.pem -passin env:TRESTLE_KEY_PASSWORD -pubout -out public.pem
+chmod 600 private-encrypted.pem
+trestle sign \
+  -f catalog.json \
+  --key private-encrypted.pem \
+  --key-password-env TRESTLE_KEY_PASSWORD \
+  -o catalog.json.dsse
+```
+
+RSA PEM keys may also be used.
+
+The `--subject-name` option records a subject name other than the input file name. Verification must use the same subject name.
+
+The signed Statement uses the [OSCAL signing predicate](../predicates/oscal-signing/v1.md).
+
+## `trestle verify`
+
+Trestle verify checks a JSON file against a detached DSSE envelope and a PEM public key. Verification checks the DSSE signature, the predicate fields, and the SHA-256 digest of the RFC 8785 canonical JSON bytes.
+
+```bash
+trestle verify \
+  -f catalog.json \
+  --signature catalog.json.dsse \
+  --key public.pem
+```
+
+If signing used `--subject-name`, pass the same value during verification.
 
 ## `trestle tasks`
 

--- a/docs/tutorials/cli.md
+++ b/docs/tutorials/cli.md
@@ -598,6 +598,14 @@ references to links, and corresponding links in the backmatter.
 
 Trestle sign writes a detached DSSE envelope for a JSON file. It canonicalizes the JSON using RFC 8785, computes a SHA-256 digest, records that digest in an in-toto Statement, and signs the Statement with a PEM private key.
 
+The sign and verify commands are beta features. Enable them before use:
+
+```bash
+trestle beta enable json-signing
+```
+
+You can also pass `--beta` to `trestle sign` or `trestle verify` to run the beta command one time without writing beta state to config.
+
 Generate an Ed25519 private/public key pair with OpenSSL:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
     "cmarkgfm>=2024.1,<2025.11",
     "orjson",
     "rfc8785>=0.1.4",
+    "securesystemslib[crypto]>=1.3.1",
     "requests>=2.32.2",
     "importlib_resources",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "cmarkgfm>=2024.1,<2025.11",
     "orjson",
     "rfc8785>=0.1.4",
-    "securesystemslib[crypto]>=1.3.1",
+    "securesystemslib[crypto]>=1.3.1,<2.0",
     "requests>=2.32.2",
     "importlib_resources",
 ]

--- a/tests/trestle/core/commands/sign_verify_test.py
+++ b/tests/trestle/core/commands/sign_verify_test.py
@@ -55,6 +55,68 @@ def write_ed25519_key_pair(
     return private_key_path, public_key_path
 
 
+@pytest.fixture(autouse=True)
+def enable_json_signing_beta(monkeypatch: MonkeyPatch) -> None:
+    """Enable the JSON signing beta feature for sign/verify command tests."""
+    monkeypatch.setenv('TRESTLE_BETA_FEATURES', 'json-signing')
+
+
+def test_sign_and_verify_require_beta_feature(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
+    """Sign and verify commands should be blocked unless the beta feature is enabled."""
+    monkeypatch.delenv('TRESTLE_BETA_FEATURES', raising=False)
+    monkeypatch.setenv('XDG_CONFIG_HOME', str(tmp_path / 'xdg-config'))
+    input_path = tmp_path / 'catalog.json'
+    key_path = tmp_path / 'key.pem'
+    envelope_path = tmp_path / 'catalog.json.dsse'
+
+    monkeypatch.setattr(
+        sys, 'argv', ['trestle', 'sign', '-f', str(input_path), '--key', str(key_path), '-o', str(envelope_path)]
+    )
+    assert Trestle().run() == CmdReturnCodes.COMMAND_ERROR.value
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['trestle', 'verify', '-f', str(input_path), '--signature', str(envelope_path), '--key', str(key_path)],
+    )
+    assert Trestle().run() == CmdReturnCodes.COMMAND_ERROR.value
+
+
+def test_sign_and_verify_accept_one_time_beta_flag(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
+    """Sign and verify should run with --beta without persisting beta config."""
+    monkeypatch.delenv('TRESTLE_BETA_FEATURES', raising=False)
+    monkeypatch.setenv('XDG_CONFIG_HOME', str(tmp_path / 'xdg-config'))
+    private_key_path, public_key_path = write_ed25519_key_pair(tmp_path)
+    input_path = tmp_path / 'catalog.json'
+    envelope_path = tmp_path / 'catalog.json.dsse'
+    input_path.write_text('{"b":2,"a":1}', encoding=const.FILE_ENCODING)
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['trestle', 'sign', '--beta', '-f', str(input_path), '--key', str(private_key_path), '-o', str(envelope_path)],
+    )
+    assert Trestle().run() == CmdReturnCodes.SUCCESS.value
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'trestle',
+            'verify',
+            '--beta',
+            '-f',
+            str(input_path),
+            '--signature',
+            str(envelope_path),
+            '--key',
+            str(public_key_path),
+        ],
+    )
+    assert Trestle().run() == CmdReturnCodes.SUCCESS.value
+    assert not (tmp_path / 'xdg-config').exists()
+
+
 def test_sign_and_verify_round_trip(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
     """Sign should write a DSSE sidecar that verify accepts."""
     private_key_path, public_key_path = write_ed25519_key_pair(tmp_path)

--- a/tests/trestle/core/commands/sign_verify_test.py
+++ b/tests/trestle/core/commands/sign_verify_test.py
@@ -1,0 +1,232 @@
+# -*- mode:python; coding:utf-8 -*-
+
+# Copyright (c) 2026 The OSCAL Compass Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for trestle sign and verify commands."""
+
+import json
+import pathlib
+import sys
+from typing import Tuple
+
+from _pytest.monkeypatch import MonkeyPatch
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ed25519
+
+from tests import test_utils
+
+import trestle.common.const as const
+from trestle.cli import Trestle
+from trestle.core.commands.common.return_codes import CmdReturnCodes
+
+
+def write_ed25519_key_pair(tmp_path: pathlib.Path, prefix: str = 'test-key') -> Tuple[pathlib.Path, pathlib.Path]:
+    """Write a temporary Ed25519 private/public key pair."""
+    private_key = ed25519.Ed25519PrivateKey.generate()
+    private_key_path = tmp_path / f'{prefix}.pem'
+    public_key_path = tmp_path / f'{prefix}.pub.pem'
+    private_key_path.write_bytes(
+        private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+    )
+    public_key_path.write_bytes(
+        private_key.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM, format=serialization.PublicFormat.SubjectPublicKeyInfo
+        )
+    )
+    return private_key_path, public_key_path
+
+
+def test_sign_and_verify_round_trip(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
+    """Sign should write a DSSE sidecar that verify accepts."""
+    private_key_path, public_key_path = write_ed25519_key_pair(tmp_path)
+    input_path = tmp_path / 'catalog.json'
+    envelope_path = tmp_path / 'catalog.json.dsse'
+    input_path.write_text('{"b":2,"a":1}', encoding=const.FILE_ENCODING)
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['trestle', 'sign', '-f', str(input_path), '--key', str(private_key_path), '-o', str(envelope_path)],
+    )
+    assert Trestle().run() == CmdReturnCodes.SUCCESS.value
+    assert input_path.read_text(encoding=const.FILE_ENCODING) == '{"b":2,"a":1}'
+
+    envelope = json.loads(envelope_path.read_text(encoding=const.FILE_ENCODING))
+    assert envelope['payloadType'] == 'application/vnd.in-toto+json'
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['trestle', 'verify', '-f', str(input_path), '--signature', str(envelope_path), '--key', str(public_key_path)],
+    )
+    assert Trestle().run() == CmdReturnCodes.SUCCESS.value
+
+
+def test_sign_and_verify_real_nist_800_53_catalog(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
+    """Sign and verify should support a real NIST 800-53 OSCAL catalog."""
+    private_key_path, public_key_path = write_ed25519_key_pair(tmp_path)
+    input_path = test_utils.JSON_NIST_DATA_PATH / test_utils.JSON_NIST_CATALOG_NAME
+    envelope_path = tmp_path / 'nist-800-53-catalog.json.dsse'
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['trestle', 'sign', '-f', str(input_path), '--key', str(private_key_path), '-o', str(envelope_path)],
+    )
+    assert Trestle().run() == CmdReturnCodes.SUCCESS.value
+    assert envelope_path.exists()
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['trestle', 'verify', '-f', str(input_path), '--signature', str(envelope_path), '--key', str(public_key_path)],
+    )
+    assert Trestle().run() == CmdReturnCodes.SUCCESS.value
+
+
+def test_sign_rejects_output_that_matches_input(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
+    """Sign should not overwrite the OSCAL JSON input with a DSSE envelope."""
+    private_key_path, _ = write_ed25519_key_pair(tmp_path)
+    input_path = tmp_path / 'catalog.json'
+    original_text = '{"a":1}'
+    input_path.write_text(original_text, encoding=const.FILE_ENCODING)
+    monkeypatch.setattr(
+        sys, 'argv', ['trestle', 'sign', '-f', str(input_path), '--key', str(private_key_path), '-o', str(input_path)]
+    )
+
+    assert Trestle().run() == CmdReturnCodes.COMMAND_ERROR.value
+    assert input_path.read_text(encoding=const.FILE_ENCODING) == original_text
+
+
+def test_verify_rejects_tampered_document(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
+    """Verify should fail if the OSCAL JSON changes after signing."""
+    private_key_path, public_key_path = write_ed25519_key_pair(tmp_path)
+    input_path = tmp_path / 'catalog.json'
+    envelope_path = tmp_path / 'catalog.json.dsse'
+    input_path.write_text('{"a":1}', encoding=const.FILE_ENCODING)
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['trestle', 'sign', '-f', str(input_path), '--key', str(private_key_path), '-o', str(envelope_path)],
+    )
+    assert Trestle().run() == CmdReturnCodes.SUCCESS.value
+
+    input_path.write_text('{"a":2}', encoding=const.FILE_ENCODING)
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['trestle', 'verify', '-f', str(input_path), '--signature', str(envelope_path), '--key', str(public_key_path)],
+    )
+    assert Trestle().run() == CmdReturnCodes.COMMAND_ERROR.value
+
+
+def test_verify_rejects_wrong_key(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
+    """Verify should fail if the public key does not match the signing key."""
+    private_key_path, _ = write_ed25519_key_pair(tmp_path, 'signing-key')
+    _, wrong_public_key_path = write_ed25519_key_pair(tmp_path, 'wrong-key')
+    input_path = tmp_path / 'catalog.json'
+    envelope_path = tmp_path / 'catalog.json.dsse'
+    input_path.write_text('{"a":1}', encoding=const.FILE_ENCODING)
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['trestle', 'sign', '-f', str(input_path), '--key', str(private_key_path), '-o', str(envelope_path)],
+    )
+    assert Trestle().run() == CmdReturnCodes.SUCCESS.value
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'trestle',
+            'verify',
+            '-f',
+            str(input_path),
+            '--signature',
+            str(envelope_path),
+            '--key',
+            str(wrong_public_key_path),
+        ],
+    )
+    assert Trestle().run() == CmdReturnCodes.COMMAND_ERROR.value
+
+
+def test_sign_rejects_duplicate_json_keys(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
+    """Sign should fail before signing ambiguous JSON."""
+    private_key_path, _ = write_ed25519_key_pair(tmp_path)
+    input_path = tmp_path / 'catalog.json'
+    envelope_path = tmp_path / 'catalog.json.dsse'
+    input_path.write_text('{"a":1,"a":2}', encoding=const.FILE_ENCODING)
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['trestle', 'sign', '-f', str(input_path), '--key', str(private_key_path), '-o', str(envelope_path)],
+    )
+
+    assert Trestle().run() == CmdReturnCodes.COMMAND_ERROR.value
+    assert not envelope_path.exists()
+
+
+def test_sign_rejects_non_json_input(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
+    """Sign should reject non-JSON file extensions."""
+    private_key_path, _ = write_ed25519_key_pair(tmp_path)
+    input_path = tmp_path / 'catalog.txt'
+    envelope_path = tmp_path / 'catalog.txt.dsse'
+    input_path.write_text('{"a":1}', encoding=const.FILE_ENCODING)
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['trestle', 'sign', '-f', str(input_path), '--key', str(private_key_path), '-o', str(envelope_path)],
+    )
+
+    assert Trestle().run() == CmdReturnCodes.COMMAND_ERROR.value
+    assert not envelope_path.exists()
+
+
+def test_verify_rejects_non_json_input(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
+    """Verify should reject non-JSON file extensions."""
+    private_key_path, public_key_path = write_ed25519_key_pair(tmp_path)
+    input_path = tmp_path / 'catalog.json'
+    non_json_input_path = tmp_path / 'catalog.txt'
+    envelope_path = tmp_path / 'catalog.json.dsse'
+    input_path.write_text('{"a":1}', encoding=const.FILE_ENCODING)
+    non_json_input_path.write_text('{"a":1}', encoding=const.FILE_ENCODING)
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['trestle', 'sign', '-f', str(input_path), '--key', str(private_key_path), '-o', str(envelope_path)],
+    )
+    assert Trestle().run() == CmdReturnCodes.SUCCESS.value
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'trestle',
+            'verify',
+            '-f',
+            str(non_json_input_path),
+            '--signature',
+            str(envelope_path),
+            '--key',
+            str(public_key_path),
+            '--subject-name',
+            input_path.name,
+        ],
+    )
+    assert Trestle().run() == CmdReturnCodes.COMMAND_ERROR.value

--- a/tests/trestle/core/commands/sign_verify_test.py
+++ b/tests/trestle/core/commands/sign_verify_test.py
@@ -20,6 +20,7 @@ import pathlib
 import sys
 from typing import Tuple
 
+import pytest
 from _pytest.monkeypatch import MonkeyPatch
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ed25519
@@ -31,16 +32,19 @@ from trestle.cli import Trestle
 from trestle.core.commands.common.return_codes import CmdReturnCodes
 
 
-def write_ed25519_key_pair(tmp_path: pathlib.Path, prefix: str = 'test-key') -> Tuple[pathlib.Path, pathlib.Path]:
+def write_ed25519_key_pair(
+    tmp_path: pathlib.Path, prefix: str = 'test-key', password: bytes = b''
+) -> Tuple[pathlib.Path, pathlib.Path]:
     """Write a temporary Ed25519 private/public key pair."""
     private_key = ed25519.Ed25519PrivateKey.generate()
     private_key_path = tmp_path / f'{prefix}.pem'
     public_key_path = tmp_path / f'{prefix}.pub.pem'
+    encryption_algorithm = serialization.BestAvailableEncryption(password) if password else serialization.NoEncryption()
     private_key_path.write_bytes(
         private_key.private_bytes(
             encoding=serialization.Encoding.PEM,
             format=serialization.PrivateFormat.PKCS8,
-            encryption_algorithm=serialization.NoEncryption(),
+            encryption_algorithm=encryption_algorithm,
         )
     )
     public_key_path.write_bytes(
@@ -99,8 +103,122 @@ def test_sign_and_verify_real_nist_800_53_catalog(tmp_path: pathlib.Path, monkey
     assert Trestle().run() == CmdReturnCodes.SUCCESS.value
 
 
+def test_verify_rejects_missing_custom_subject_name(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
+    """Verify should require the same custom subject name used during signing."""
+    private_key_path, public_key_path = write_ed25519_key_pair(tmp_path)
+    input_path = tmp_path / 'catalog.json'
+    envelope_path = tmp_path / 'catalog.json.dsse'
+    input_path.write_text('{"a":1}', encoding=const.FILE_ENCODING)
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'trestle',
+            'sign',
+            '-f',
+            str(input_path),
+            '--key',
+            str(private_key_path),
+            '-o',
+            str(envelope_path),
+            '--subject-name',
+            'custom/catalog.json',
+        ],
+    )
+    assert Trestle().run() == CmdReturnCodes.SUCCESS.value
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['trestle', 'verify', '-f', str(input_path), '--signature', str(envelope_path), '--key', str(public_key_path)],
+    )
+    assert Trestle().run() == CmdReturnCodes.COMMAND_ERROR.value
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'trestle',
+            'verify',
+            '-f',
+            str(input_path),
+            '--signature',
+            str(envelope_path),
+            '--key',
+            str(public_key_path),
+            '--subject-name',
+            'custom/catalog.json',
+        ],
+    )
+    assert Trestle().run() == CmdReturnCodes.SUCCESS.value
+
+
+def test_sign_supports_encrypted_private_key(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
+    """Sign should accept an encrypted PEM private key password from an environment variable."""
+    private_key_path, public_key_path = write_ed25519_key_pair(tmp_path, password=b'test-password')
+    input_path = tmp_path / 'catalog.json'
+    envelope_path = tmp_path / 'catalog.json.dsse'
+    input_path.write_text('{"a":1}', encoding=const.FILE_ENCODING)
+    monkeypatch.setenv('TRESTLE_KEY_PASSWORD', 'test-password')
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'trestle',
+            'sign',
+            '-f',
+            str(input_path),
+            '--key',
+            str(private_key_path),
+            '--key-password-env',
+            'TRESTLE_KEY_PASSWORD',
+            '-o',
+            str(envelope_path),
+        ],
+    )
+    assert Trestle().run() == CmdReturnCodes.SUCCESS.value
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['trestle', 'verify', '-f', str(input_path), '--signature', str(envelope_path), '--key', str(public_key_path)],
+    )
+    assert Trestle().run() == CmdReturnCodes.SUCCESS.value
+
+
+def test_sign_rejects_missing_key_password_env(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
+    """Sign should fail when the requested key password environment variable is unset."""
+    private_key_path, _ = write_ed25519_key_pair(tmp_path, password=b'test-password')
+    input_path = tmp_path / 'catalog.json'
+    envelope_path = tmp_path / 'catalog.json.dsse'
+    input_path.write_text('{"a":1}', encoding=const.FILE_ENCODING)
+    monkeypatch.delenv('TRESTLE_KEY_PASSWORD', raising=False)
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'trestle',
+            'sign',
+            '-f',
+            str(input_path),
+            '--key',
+            str(private_key_path),
+            '--key-password-env',
+            'TRESTLE_KEY_PASSWORD',
+            '-o',
+            str(envelope_path),
+        ],
+    )
+
+    assert Trestle().run() == CmdReturnCodes.COMMAND_ERROR.value
+    assert not envelope_path.exists()
+
+
 def test_sign_rejects_output_that_matches_input(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
-    """Sign should not overwrite the OSCAL JSON input with a DSSE envelope."""
+    """Sign should not overwrite the JSON input with a DSSE envelope."""
     private_key_path, _ = write_ed25519_key_pair(tmp_path)
     input_path = tmp_path / 'catalog.json'
     original_text = '{"a":1}'
@@ -113,8 +231,44 @@ def test_sign_rejects_output_that_matches_input(tmp_path: pathlib.Path, monkeypa
     assert input_path.read_text(encoding=const.FILE_ENCODING) == original_text
 
 
+def test_sign_rejects_output_that_matches_private_key(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
+    """Sign should not overwrite the private key with a DSSE envelope."""
+    private_key_path, _ = write_ed25519_key_pair(tmp_path)
+    original_key = private_key_path.read_bytes()
+    input_path = tmp_path / 'catalog.json'
+    input_path.write_text('{"a":1}', encoding=const.FILE_ENCODING)
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['trestle', 'sign', '-f', str(input_path), '--key', str(private_key_path), '-o', str(private_key_path)],
+    )
+
+    assert Trestle().run() == CmdReturnCodes.COMMAND_ERROR.value
+    assert private_key_path.read_bytes() == original_key
+
+
+def test_sign_rejects_output_symlink(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
+    """Sign should not follow output symlinks when writing a DSSE envelope."""
+    private_key_path, _ = write_ed25519_key_pair(tmp_path)
+    input_path = tmp_path / 'catalog.json'
+    target_path = tmp_path / 'target.dsse'
+    output_path = tmp_path / 'catalog.json.dsse'
+    input_path.write_text('{"a":1}', encoding=const.FILE_ENCODING)
+    try:
+        output_path.symlink_to(target_path)
+    except OSError as error:
+        pytest.skip(f'Symlinks are not available in this environment: {error}')
+
+    monkeypatch.setattr(
+        sys, 'argv', ['trestle', 'sign', '-f', str(input_path), '--key', str(private_key_path), '-o', str(output_path)]
+    )
+
+    assert Trestle().run() == CmdReturnCodes.COMMAND_ERROR.value
+    assert not target_path.exists()
+
+
 def test_verify_rejects_tampered_document(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
-    """Verify should fail if the OSCAL JSON changes after signing."""
+    """Verify should fail if the JSON changes after signing."""
     private_key_path, public_key_path = write_ed25519_key_pair(tmp_path)
     input_path = tmp_path / 'catalog.json'
     envelope_path = tmp_path / 'catalog.json.dsse'

--- a/tests/trestle/core/signing_test.py
+++ b/tests/trestle/core/signing_test.py
@@ -1,0 +1,245 @@
+# -*- mode:python; coding:utf-8 -*-
+
+# Copyright (c) 2026 The OSCAL Compass Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for OSCAL provenance signing helpers."""
+
+import base64
+import copy
+import json
+import pathlib
+from typing import Any, Dict, Tuple
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ed25519
+
+import trestle.common.const as const
+from trestle.common.err import TrestleError
+from trestle.core.canonicalization import sha256_digest_hex
+from trestle.core.signing import (
+    CANONICALIZATION_ALGORITHM,
+    DIGEST_ALGORITHM,
+    DSSE_PAYLOAD_TYPE,
+    IN_TOTO_STATEMENT_TYPE,
+    OSCAL_PREDICATE_TYPE,
+    build_in_toto_statement,
+    create_oscal_provenance_envelope,
+    dsse_pae,
+    load_dsse_envelope,
+    load_pem_private_key_signer,
+    load_pem_public_key,
+    sign_in_toto_statement,
+    verify_oscal_provenance_envelope,
+    write_dsse_envelope,
+)
+
+
+def write_ed25519_key_pair(tmp_path: pathlib.Path) -> Tuple[pathlib.Path, pathlib.Path]:
+    """Write a temporary Ed25519 private/public key pair."""
+    private_key = ed25519.Ed25519PrivateKey.generate()
+    private_key_path = tmp_path / 'test-key.pem'
+    public_key_path = tmp_path / 'test-key.pub.pem'
+    private_key_path.write_bytes(
+        private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+    )
+    public_key_path.write_bytes(
+        private_key.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM, format=serialization.PublicFormat.SubjectPublicKeyInfo
+        )
+    )
+    return private_key_path, public_key_path
+
+
+def sign_payload(payload: bytes, signer: Any) -> Dict[str, Any]:
+    """Sign arbitrary DSSE payload bytes for validation tests."""
+    signature = signer.sign(dsse_pae(DSSE_PAYLOAD_TYPE, payload))
+    return {
+        'payload': base64.b64encode(payload).decode('ascii'),
+        'payloadType': DSSE_PAYLOAD_TYPE,
+        'signatures': [
+            {'keyid': signature.keyid, 'sig': base64.b64encode(bytes.fromhex(signature.signature)).decode('ascii')}
+        ],
+    }
+
+
+def signing_context(tmp_path: pathlib.Path) -> Tuple[pathlib.Path, Any, Any, Dict[str, Any], Dict[str, Any]]:
+    """Create an input file, signer, public key, envelope, and Statement for validation tests."""
+    private_key_path, public_key_path = write_ed25519_key_pair(tmp_path)
+    input_path = tmp_path / 'catalog.json'
+    input_path.write_text('{"a":1}', encoding=const.FILE_ENCODING)
+    signer = load_pem_private_key_signer(private_key_path)
+    public_key = load_pem_public_key(public_key_path)
+    envelope = create_oscal_provenance_envelope(input_path, signer)
+    statement = build_in_toto_statement(input_path.name, sha256_digest_hex(b'{"a":1}'))
+    return input_path, signer, public_key, envelope, statement
+
+
+def test_dsse_pae_returns_expected_encoding() -> None:
+    """DSSE PAE should bind payload type and payload bytes."""
+    assert dsse_pae('test/type', b'payload') == b'DSSEv1 9 test/type 7 payload'
+
+
+def test_create_oscal_provenance_envelope_contains_in_toto_statement(tmp_path: pathlib.Path) -> None:
+    """Signing should create a DSSE envelope with an in-toto Statement payload."""
+    private_key_path, public_key_path = write_ed25519_key_pair(tmp_path)
+    input_path = tmp_path / 'catalog.json'
+    input_path.write_text('{"b":2,"a":1}', encoding=const.FILE_ENCODING)
+
+    signer = load_pem_private_key_signer(private_key_path)
+    envelope = create_oscal_provenance_envelope(input_path, signer)
+
+    assert envelope['payloadType'] == DSSE_PAYLOAD_TYPE
+    assert len(envelope['signatures']) == 1
+    statement = json.loads(base64.b64decode(envelope['payload']).decode(const.FILE_ENCODING))
+    assert statement['_type'] == IN_TOTO_STATEMENT_TYPE
+    assert statement['predicateType'] == OSCAL_PREDICATE_TYPE
+    assert statement['predicate']['canonicalization'] == CANONICALIZATION_ALGORITHM
+    assert statement['predicate']['digestAlgorithm'] == DIGEST_ALGORITHM
+    assert statement['subject'][0]['name'] == 'catalog.json'
+    assert statement['subject'][0]['digest']['sha256'] == sha256_digest_hex(b'{"a":1,"b":2}')
+
+    public_key = load_pem_public_key(public_key_path)
+    verify_oscal_provenance_envelope(input_path, envelope, public_key)
+
+
+def test_key_loaders_reject_invalid_pem(tmp_path: pathlib.Path) -> None:
+    """Key loaders should surface invalid PEM files as trestle errors."""
+    key_path = tmp_path / 'invalid.pem'
+    key_path.write_text('not a pem key', encoding=const.FILE_ENCODING)
+
+    with pytest.raises(TrestleError):
+        load_pem_private_key_signer(key_path)
+    with pytest.raises(TrestleError):
+        load_pem_public_key(key_path)
+
+
+def test_write_dsse_envelope_rejects_output_directory(tmp_path: pathlib.Path) -> None:
+    """DSSE envelope writing should reject directory output paths."""
+    with pytest.raises(TrestleError):
+        write_dsse_envelope({}, tmp_path)
+
+
+def test_load_dsse_envelope_rejects_invalid_json_and_non_object(tmp_path: pathlib.Path) -> None:
+    """DSSE envelope loading should require a JSON object."""
+    invalid_json_path = tmp_path / 'invalid.dsse'
+    invalid_json_path.write_text('{', encoding=const.FILE_ENCODING)
+    with pytest.raises(TrestleError):
+        load_dsse_envelope(invalid_json_path)
+
+    non_object_path = tmp_path / 'non-object.dsse'
+    non_object_path.write_text('[]', encoding=const.FILE_ENCODING)
+    with pytest.raises(TrestleError):
+        load_dsse_envelope(non_object_path)
+
+
+def test_load_dsse_envelope_rejects_duplicate_keys(tmp_path: pathlib.Path) -> None:
+    """DSSE envelope loading should reject duplicate JSON object keys."""
+    duplicate_key_path = tmp_path / 'duplicate-key.dsse'
+    duplicate_key_path.write_text('{"payload":"one","payload":"two"}', encoding=const.FILE_ENCODING)
+
+    with pytest.raises(TrestleError):
+        load_dsse_envelope(duplicate_key_path)
+
+
+def test_verify_rejects_malformed_dsse_fields(tmp_path: pathlib.Path) -> None:
+    """Verification should reject malformed DSSE envelope fields before accepting a payload."""
+    input_path, _, public_key, envelope, _ = signing_context(tmp_path)
+    bad_envelopes = []
+
+    unsupported_payload_type = copy.deepcopy(envelope)
+    unsupported_payload_type['payloadType'] = 'bad/type'
+    bad_envelopes.append(unsupported_payload_type)
+
+    no_signatures = copy.deepcopy(envelope)
+    no_signatures['signatures'] = []
+    bad_envelopes.append(no_signatures)
+
+    non_string_payload = copy.deepcopy(envelope)
+    non_string_payload['payload'] = 1
+    bad_envelopes.append(non_string_payload)
+
+    invalid_payload_base64 = copy.deepcopy(envelope)
+    invalid_payload_base64['payload'] = 'not base64!!'
+    bad_envelopes.append(invalid_payload_base64)
+
+    non_object_signature = copy.deepcopy(envelope)
+    non_object_signature['signatures'] = ['bad']
+    bad_envelopes.append(non_object_signature)
+
+    missing_keyid = copy.deepcopy(envelope)
+    del missing_keyid['signatures'][0]['keyid']
+    bad_envelopes.append(missing_keyid)
+
+    invalid_signature_base64 = copy.deepcopy(envelope)
+    invalid_signature_base64['signatures'][0]['sig'] = 'not base64!!'
+    bad_envelopes.append(invalid_signature_base64)
+
+    for bad_envelope in bad_envelopes:
+        with pytest.raises(TrestleError):
+            verify_oscal_provenance_envelope(input_path, bad_envelope, public_key)
+
+
+def test_verify_rejects_invalid_statement_payloads(tmp_path: pathlib.Path) -> None:
+    """Verification should reject signed payloads that are not JSON Statement objects."""
+    input_path, signer, public_key, _, _ = signing_context(tmp_path)
+    for payload in [b'\xff', b'{', b'[]', b'{"_type":"one","_type":"two"}']:
+        with pytest.raises(TrestleError):
+            verify_oscal_provenance_envelope(input_path, sign_payload(payload, signer), public_key)
+
+
+def test_verify_rejects_invalid_statement_fields(tmp_path: pathlib.Path) -> None:
+    """Verification should reject signed Statements with unsupported provenance fields."""
+    input_path, signer, public_key, _, statement = signing_context(tmp_path)
+    bad_statements = []
+
+    bad_type = copy.deepcopy(statement)
+    bad_type['_type'] = 'bad-type'
+    bad_statements.append(bad_type)
+
+    bad_predicate_type = copy.deepcopy(statement)
+    bad_predicate_type['predicateType'] = 'bad-predicate-type'
+    bad_statements.append(bad_predicate_type)
+
+    non_object_predicate = copy.deepcopy(statement)
+    non_object_predicate['predicate'] = []
+    bad_statements.append(non_object_predicate)
+
+    bad_canonicalization = copy.deepcopy(statement)
+    bad_canonicalization['predicate']['canonicalization'] = 'bad-canonicalization'
+    bad_statements.append(bad_canonicalization)
+
+    bad_digest_algorithm = copy.deepcopy(statement)
+    bad_digest_algorithm['predicate']['digestAlgorithm'] = 'sha512'
+    bad_statements.append(bad_digest_algorithm)
+
+    bad_digest_source = copy.deepcopy(statement)
+    bad_digest_source['predicate']['digestSource'] = 'original-file-bytes'
+    bad_statements.append(bad_digest_source)
+
+    non_array_subject = copy.deepcopy(statement)
+    non_array_subject['subject'] = {}
+    bad_statements.append(non_array_subject)
+
+    missing_subject = copy.deepcopy(statement)
+    missing_subject['subject'] = ['bad-subject']
+    bad_statements.append(missing_subject)
+
+    for bad_statement in bad_statements:
+        with pytest.raises(TrestleError):
+            verify_oscal_provenance_envelope(input_path, sign_in_toto_statement(bad_statement, signer), public_key)

--- a/tests/trestle/core/signing_test.py
+++ b/tests/trestle/core/signing_test.py
@@ -33,7 +33,9 @@ from trestle.core.signing import (
     DIGEST_ALGORITHM,
     DSSE_PAYLOAD_TYPE,
     IN_TOTO_STATEMENT_TYPE,
+    MAX_SIGNATURES,
     OSCAL_PREDICATE_TYPE,
+    _b64_decode,
     build_in_toto_statement,
     create_oscal_provenance_envelope,
     dsse_pae,
@@ -46,16 +48,17 @@ from trestle.core.signing import (
 )
 
 
-def write_ed25519_key_pair(tmp_path: pathlib.Path) -> Tuple[pathlib.Path, pathlib.Path]:
+def write_ed25519_key_pair(tmp_path: pathlib.Path, password: bytes = b'') -> Tuple[pathlib.Path, pathlib.Path]:
     """Write a temporary Ed25519 private/public key pair."""
     private_key = ed25519.Ed25519PrivateKey.generate()
     private_key_path = tmp_path / 'test-key.pem'
     public_key_path = tmp_path / 'test-key.pub.pem'
+    encryption_algorithm = serialization.BestAvailableEncryption(password) if password else serialization.NoEncryption()
     private_key_path.write_bytes(
         private_key.private_bytes(
             encoding=serialization.Encoding.PEM,
             format=serialization.PrivateFormat.PKCS8,
-            encryption_algorithm=serialization.NoEncryption(),
+            encryption_algorithm=encryption_algorithm,
         )
     )
     public_key_path.write_bytes(
@@ -129,10 +132,50 @@ def test_key_loaders_reject_invalid_pem(tmp_path: pathlib.Path) -> None:
         load_pem_public_key(key_path)
 
 
+def test_load_pem_private_key_signer_supports_encrypted_keys(tmp_path: pathlib.Path) -> None:
+    """Private key loading should support encrypted PEM keys when a password is provided."""
+    private_key_path, public_key_path = write_ed25519_key_pair(tmp_path, b'test-password')
+    input_path = tmp_path / 'catalog.json'
+    input_path.write_text('{"a":1}', encoding=const.FILE_ENCODING)
+
+    signer = load_pem_private_key_signer(private_key_path, 'test-password')
+    public_key = load_pem_public_key(public_key_path)
+    envelope = create_oscal_provenance_envelope(input_path, signer)
+
+    verify_oscal_provenance_envelope(input_path, envelope, public_key)
+
+
 def test_write_dsse_envelope_rejects_output_directory(tmp_path: pathlib.Path) -> None:
     """DSSE envelope writing should reject directory output paths."""
     with pytest.raises(TrestleError):
         write_dsse_envelope({}, tmp_path)
+
+
+def test_write_dsse_envelope_rejects_existing_output_file(tmp_path: pathlib.Path) -> None:
+    """DSSE envelope writing should not overwrite an existing output file."""
+    output_path = tmp_path / 'catalog.json.dsse'
+    output_path.write_text('existing file', encoding=const.FILE_ENCODING)
+
+    with pytest.raises(TrestleError):
+        write_dsse_envelope({}, output_path)
+
+    assert output_path.read_text(encoding=const.FILE_ENCODING) == 'existing file'
+
+
+def test_write_dsse_envelope_rejects_output_symlink(tmp_path: pathlib.Path) -> None:
+    """DSSE envelope writing should not follow output symlinks."""
+    target_path = tmp_path / 'target.txt'
+    target_path.write_text('target file', encoding=const.FILE_ENCODING)
+    output_path = tmp_path / 'catalog.json.dsse'
+    try:
+        output_path.symlink_to(target_path)
+    except OSError as error:
+        pytest.skip(f'Symlinks are not available in this environment: {error}')
+
+    with pytest.raises(TrestleError):
+        write_dsse_envelope({}, output_path)
+
+    assert target_path.read_text(encoding=const.FILE_ENCODING) == 'target file'
 
 
 def test_load_dsse_envelope_rejects_invalid_json_and_non_object(tmp_path: pathlib.Path) -> None:
@@ -182,9 +225,9 @@ def test_verify_rejects_malformed_dsse_fields(tmp_path: pathlib.Path) -> None:
     non_object_signature['signatures'] = ['bad']
     bad_envelopes.append(non_object_signature)
 
-    missing_keyid = copy.deepcopy(envelope)
-    del missing_keyid['signatures'][0]['keyid']
-    bad_envelopes.append(missing_keyid)
+    non_string_keyid = copy.deepcopy(envelope)
+    non_string_keyid['signatures'][0]['keyid'] = 1
+    bad_envelopes.append(non_string_keyid)
 
     invalid_signature_base64 = copy.deepcopy(envelope)
     invalid_signature_base64['signatures'][0]['sig'] = 'not base64!!'
@@ -193,6 +236,50 @@ def test_verify_rejects_malformed_dsse_fields(tmp_path: pathlib.Path) -> None:
     for bad_envelope in bad_envelopes:
         with pytest.raises(TrestleError):
             verify_oscal_provenance_envelope(input_path, bad_envelope, public_key)
+
+
+def test_verify_accepts_missing_signature_keyid(tmp_path: pathlib.Path) -> None:
+    """DSSE keyid is optional and should not be required for signature verification."""
+    input_path, _, public_key, envelope, _ = signing_context(tmp_path)
+    del envelope['signatures'][0]['keyid']
+
+    verify_oscal_provenance_envelope(input_path, envelope, public_key)
+
+
+def test_verify_accepts_empty_signature_keyid(tmp_path: pathlib.Path) -> None:
+    """DSSE keyid may be empty and should not be required for signature verification."""
+    input_path, _, public_key, envelope, _ = signing_context(tmp_path)
+    envelope['signatures'][0]['keyid'] = ''
+
+    verify_oscal_provenance_envelope(input_path, envelope, public_key)
+
+
+def test_verify_accepts_arbitrary_signature_keyid(tmp_path: pathlib.Path) -> None:
+    """Explicit-key verification should not depend on the DSSE keyid hint."""
+    input_path, _, public_key, envelope, _ = signing_context(tmp_path)
+    envelope['signatures'][0]['keyid'] = 'external-key-label'
+
+    verify_oscal_provenance_envelope(input_path, envelope, public_key)
+
+
+def test_verify_rejects_too_many_signatures(tmp_path: pathlib.Path) -> None:
+    """Verification should bound the number of signatures processed from one envelope."""
+    input_path, _, public_key, envelope, _ = signing_context(tmp_path)
+    envelope['signatures'] = envelope['signatures'] * (MAX_SIGNATURES + 1)
+
+    with pytest.raises(TrestleError):
+        verify_oscal_provenance_envelope(input_path, envelope, public_key)
+
+
+def test_b64_decode_accepts_urlsafe_base64() -> None:
+    """DSSE verification should accept URL-safe base64 as required by the DSSE spec."""
+    assert _b64_decode('--8=', 'payload') == b'\xfb\xef'
+
+
+def test_b64_decode_rejects_non_ascii_text() -> None:
+    """DSSE base64 fields should reject non-ASCII text."""
+    with pytest.raises(TrestleError):
+        _b64_decode('é', 'payload')
 
 
 def test_verify_rejects_invalid_statement_payloads(tmp_path: pathlib.Path) -> None:
@@ -240,6 +327,27 @@ def test_verify_rejects_invalid_statement_fields(tmp_path: pathlib.Path) -> None
     missing_subject['subject'] = ['bad-subject']
     bad_statements.append(missing_subject)
 
+    unnamed_subject = copy.deepcopy(statement)
+    unnamed_subject['subject'][0]['name'] = None
+    bad_statements.append(unnamed_subject)
+
+    non_object_digest = copy.deepcopy(statement)
+    non_object_digest['subject'][0]['digest'] = []
+    bad_statements.append(non_object_digest)
+
+    multiple_subjects = copy.deepcopy(statement)
+    multiple_subjects['subject'].append({'name': 'other.json', 'digest': {'sha256': 'bad-digest'}})
+    bad_statements.append(multiple_subjects)
+
     for bad_statement in bad_statements:
         with pytest.raises(TrestleError):
             verify_oscal_provenance_envelope(input_path, sign_in_toto_statement(bad_statement, signer), public_key)
+
+
+def test_verify_subject_name_mismatch_suggests_subject_name(tmp_path: pathlib.Path) -> None:
+    """Verification should explain how to match a custom signed subject name."""
+    input_path, signer, public_key, _, statement = signing_context(tmp_path)
+    statement['subject'][0]['name'] = 'custom/catalog.json'
+
+    with pytest.raises(TrestleError, match='--subject-name'):
+        verify_oscal_provenance_envelope(input_path, sign_in_toto_statement(statement, signer), public_key)

--- a/trestle/cli.py
+++ b/trestle/cli.py
@@ -34,9 +34,11 @@ from trestle.core.commands.merge import MergeCmd
 from trestle.core.commands.partial_object_validate import PartialObjectValidate
 from trestle.core.commands.remove import RemoveCmd
 from trestle.core.commands.replicate import ReplicateCmd
+from trestle.core.commands.sign import SignCmd
 from trestle.core.commands.split import SplitCmd
 from trestle.core.commands.task import TaskCmd
 from trestle.core.commands.validate import ValidateCmd
+from trestle.core.commands.verify import VerifyCmd
 from trestle.core.commands.version import VersionCmd
 from trestle.core.plugins import discovered_plugins
 
@@ -60,9 +62,11 @@ class Trestle(CommandBase):
         PartialObjectValidate,
         RemoveCmd,
         ReplicateCmd,
+        SignCmd,
         SplitCmd,
         TaskCmd,
         ValidateCmd,
+        VerifyCmd,
         VersionCmd,
     ]
 

--- a/trestle/core/beta_features.py
+++ b/trestle/core/beta_features.py
@@ -48,7 +48,18 @@ class BetaFeature:
     deprecation_version: Optional[str] = None
 
 
-BETA_FEATURES: Dict[str, BetaFeature] = {}
+BETA_FEATURES: Dict[str, BetaFeature] = {
+    'json-signing': BetaFeature(
+        name='json-signing',
+        description='Sign and verify JSON artifacts with detached DSSE envelopes.',
+        commands=['trestle sign', 'trestle verify'],
+        since_version='4.0.3',
+        stability='beta',
+        documentation_url='https://oscal-compass.github.io/compliance-trestle/tutorials/cli/#trestle-sign',
+        enabled_by_default=False,
+        deprecation_version=None,
+    )
+}
 
 
 def parse_feature_names(feature_names: str) -> Set[str]:

--- a/trestle/core/commands/sign.py
+++ b/trestle/core/commands/sign.py
@@ -17,6 +17,7 @@
 
 import argparse
 import logging
+import os
 import pathlib
 from typing import Optional
 
@@ -30,9 +31,9 @@ logger = logging.getLogger(__name__)
 
 
 class SignCmd(CommandBase):
-    """Sign an OSCAL JSON file as a detached DSSE provenance envelope.
+    """Sign a JSON file as a detached DSSE provenance envelope.
 
-    This command does not modify the input OSCAL file. It reads the JSON
+    This command does not modify the input JSON file. It reads the JSON
     bytes, canonicalizes them using RFC 8785, computes a SHA-256 digest over
     the canonical JSON, and records that digest in an in-toto Statement. The
     Statement is then signed as a DSSE payload using the provided PEM private
@@ -46,8 +47,13 @@ class SignCmd(CommandBase):
     name = 'sign'
 
     def _init_arguments(self) -> None:
-        self.add_argument('-f', '--file', help='Path to the OSCAL JSON file to sign.', required=True, type=pathlib.Path)
+        self.add_argument('-f', '--file', help='Path to the JSON file to sign.', required=True, type=pathlib.Path)
         self.add_argument('--key', help='Path to the PEM private key for signing.', required=True, type=pathlib.Path)
+        self.add_argument(
+            '--key-password-env',
+            help='Environment variable containing the password for an encrypted PEM private key.',
+            default=None,
+        )
         self.add_argument('-o', '--output', help='Output DSSE envelope file.', required=True, type=pathlib.Path)
         self.add_argument(
             '--subject-name',
@@ -56,13 +62,13 @@ class SignCmd(CommandBase):
         )
 
     def _run(self, args: argparse.Namespace) -> int:
-        """Sign an OSCAL JSON file."""
+        """Sign a JSON file."""
         try:
             log.set_log_level_from_args(args)
-            self.sign(args.file, args.key, args.output, args.subject_name)
+            self.sign(args.file, args.key, args.output, args.subject_name, args.key_password_env)
             return CmdReturnCodes.SUCCESS.value
         except Exception as e:  # pragma: no cover
-            return handle_generic_command_exception(e, logger, 'Error while signing OSCAL JSON')
+            return handle_generic_command_exception(e, logger, 'Error while signing JSON')
 
     @classmethod
     def sign(
@@ -71,13 +77,23 @@ class SignCmd(CommandBase):
         key_path: pathlib.Path,
         output_path: pathlib.Path,
         subject_name: Optional[str] = None,
+        key_password_env: Optional[str] = None,
     ) -> None:
-        """Write a detached DSSE provenance envelope for an OSCAL JSON file."""
+        """Write a detached DSSE provenance envelope for a JSON file."""
         input_path = input_path.resolve()
-        output_path = output_path.resolve()
-        if input_path == output_path:
-            raise TrestleError('DSSE output path must be different from input OSCAL JSON file.')
+        key_path = key_path.resolve()
+        resolved_output_path = output_path.resolve()
+        if input_path == resolved_output_path:
+            raise TrestleError('DSSE output path must be different from input JSON file.')
+        if key_path == resolved_output_path:
+            raise TrestleError('DSSE output path must be different from private key file.')
 
-        signer = load_pem_private_key_signer(key_path.resolve())
+        key_password = None
+        if key_password_env is not None:
+            if key_password_env not in os.environ:
+                raise TrestleError(f'Key password environment variable is not set: {key_password_env}')
+            key_password = os.environ[key_password_env]
+
+        signer = load_pem_private_key_signer(key_path, key_password)
         envelope = create_oscal_provenance_envelope(input_path, signer, subject_name)
         write_dsse_envelope(envelope, output_path)

--- a/trestle/core/commands/sign.py
+++ b/trestle/core/commands/sign.py
@@ -1,0 +1,83 @@
+# -*- mode:python; coding:utf-8 -*-
+
+# Copyright (c) 2026 The OSCAL Compass Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Trestle Sign Command."""
+
+import argparse
+import logging
+import pathlib
+from typing import Optional
+
+from trestle.common import log
+from trestle.common.err import TrestleError, handle_generic_command_exception
+from trestle.core.commands.command_docs import CommandBase
+from trestle.core.commands.common.return_codes import CmdReturnCodes
+from trestle.core.signing import create_oscal_provenance_envelope, load_pem_private_key_signer, write_dsse_envelope
+
+logger = logging.getLogger(__name__)
+
+
+class SignCmd(CommandBase):
+    """Sign an OSCAL JSON file as a detached DSSE provenance envelope.
+
+    This command does not modify the input OSCAL file. It reads the JSON
+    bytes, canonicalizes them using RFC 8785, computes a SHA-256 digest over
+    the canonical JSON, and records that digest in an in-toto Statement. The
+    Statement is then signed as a DSSE payload using the provided PEM private
+    key and written as a detached sidecar envelope.
+
+    The optional subject name is the name recorded in the in-toto Statement.
+    If it is omitted, the input file name is used. Verification must use the
+    same subject name when one was provided during signing.
+    """
+
+    name = 'sign'
+
+    def _init_arguments(self) -> None:
+        self.add_argument('-f', '--file', help='Path to the OSCAL JSON file to sign.', required=True, type=pathlib.Path)
+        self.add_argument('--key', help='Path to the PEM private key for signing.', required=True, type=pathlib.Path)
+        self.add_argument('-o', '--output', help='Output DSSE envelope file.', required=True, type=pathlib.Path)
+        self.add_argument(
+            '--subject-name',
+            help='Subject name to record in the in-toto Statement. Defaults to the input file name.',
+            default=None,
+        )
+
+    def _run(self, args: argparse.Namespace) -> int:
+        """Sign an OSCAL JSON file."""
+        try:
+            log.set_log_level_from_args(args)
+            self.sign(args.file, args.key, args.output, args.subject_name)
+            return CmdReturnCodes.SUCCESS.value
+        except Exception as e:  # pragma: no cover
+            return handle_generic_command_exception(e, logger, 'Error while signing OSCAL JSON')
+
+    @classmethod
+    def sign(
+        cls,
+        input_path: pathlib.Path,
+        key_path: pathlib.Path,
+        output_path: pathlib.Path,
+        subject_name: Optional[str] = None,
+    ) -> None:
+        """Write a detached DSSE provenance envelope for an OSCAL JSON file."""
+        input_path = input_path.resolve()
+        output_path = output_path.resolve()
+        if input_path == output_path:
+            raise TrestleError('DSSE output path must be different from input OSCAL JSON file.')
+
+        signer = load_pem_private_key_signer(key_path.resolve())
+        envelope = create_oscal_provenance_envelope(input_path, signer, subject_name)
+        write_dsse_envelope(envelope, output_path)

--- a/trestle/core/commands/sign.py
+++ b/trestle/core/commands/sign.py
@@ -23,6 +23,7 @@ from typing import Optional
 
 from trestle.common import log
 from trestle.common.err import TrestleError, handle_generic_command_exception
+from trestle.core.beta_features import beta_feature
 from trestle.core.commands.command_docs import CommandBase
 from trestle.core.commands.common.return_codes import CmdReturnCodes
 from trestle.core.signing import create_oscal_provenance_envelope, load_pem_private_key_signer, write_dsse_envelope
@@ -61,6 +62,7 @@ class SignCmd(CommandBase):
             default=None,
         )
 
+    @beta_feature('json-signing')
     def _run(self, args: argparse.Namespace) -> int:
         """Sign a JSON file."""
         try:

--- a/trestle/core/commands/verify.py
+++ b/trestle/core/commands/verify.py
@@ -22,6 +22,7 @@ from typing import Optional
 
 from trestle.common import log
 from trestle.common.err import handle_generic_command_exception
+from trestle.core.beta_features import beta_feature
 from trestle.core.commands.command_docs import CommandBase
 from trestle.core.commands.common.return_codes import CmdReturnCodes
 from trestle.core.signing import load_dsse_envelope, load_pem_public_key, verify_oscal_provenance_envelope
@@ -58,6 +59,7 @@ class VerifyCmd(CommandBase):
             default=None,
         )
 
+    @beta_feature('json-signing')
     def _run(self, args: argparse.Namespace) -> int:
         """Verify a JSON file."""
         try:

--- a/trestle/core/commands/verify.py
+++ b/trestle/core/commands/verify.py
@@ -30,12 +30,12 @@ logger = logging.getLogger(__name__)
 
 
 class VerifyCmd(CommandBase):
-    """Verify an OSCAL JSON file against a detached DSSE provenance envelope.
+    """Verify a JSON file against a detached DSSE provenance envelope.
 
     Verification performs two checks. First, it verifies the DSSE signature
     over the DSSE pre-authentication encoding for the in-toto Statement payload
-    using the provided PEM public key. Second, it canonicalizes the input OSCAL
-    JSON using RFC 8785, computes its SHA-256 digest, and confirms that the
+    using the provided PEM public key. Second, it canonicalizes the input JSON
+    using RFC 8785, computes its SHA-256 digest, and confirms that the
     digest matches the subject digest recorded in the signed Statement.
 
     Both checks are required: the digest proves the file matches the signed
@@ -47,9 +47,7 @@ class VerifyCmd(CommandBase):
     name = 'verify'
 
     def _init_arguments(self) -> None:
-        self.add_argument(
-            '-f', '--file', help='Path to the OSCAL JSON file to verify.', required=True, type=pathlib.Path
-        )
+        self.add_argument('-f', '--file', help='Path to the JSON file to verify.', required=True, type=pathlib.Path)
         self.add_argument('--signature', help='Path to the detached DSSE envelope.', required=True, type=pathlib.Path)
         self.add_argument(
             '--key', help='Path to the PEM public key for verification.', required=True, type=pathlib.Path
@@ -61,13 +59,13 @@ class VerifyCmd(CommandBase):
         )
 
     def _run(self, args: argparse.Namespace) -> int:
-        """Verify an OSCAL JSON file."""
+        """Verify a JSON file."""
         try:
             log.set_log_level_from_args(args)
             self.verify(args.file, args.signature, args.key, args.subject_name)
             return CmdReturnCodes.SUCCESS.value
         except Exception as e:  # pragma: no cover
-            return handle_generic_command_exception(e, logger, 'Error while verifying OSCAL JSON signature')
+            return handle_generic_command_exception(e, logger, 'Error while verifying JSON signature')
 
     @classmethod
     def verify(
@@ -77,7 +75,7 @@ class VerifyCmd(CommandBase):
         key_path: pathlib.Path,
         subject_name: Optional[str] = None,
     ) -> None:
-        """Verify a detached DSSE provenance envelope for an OSCAL JSON file."""
+        """Verify a detached DSSE provenance envelope for a JSON file."""
         public_key = load_pem_public_key(key_path.resolve())
         envelope = load_dsse_envelope(signature_path.resolve())
         verify_oscal_provenance_envelope(input_path.resolve(), envelope, public_key, subject_name)

--- a/trestle/core/commands/verify.py
+++ b/trestle/core/commands/verify.py
@@ -1,0 +1,83 @@
+# -*- mode:python; coding:utf-8 -*-
+
+# Copyright (c) 2026 The OSCAL Compass Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Trestle Verify Command."""
+
+import argparse
+import logging
+import pathlib
+from typing import Optional
+
+from trestle.common import log
+from trestle.common.err import handle_generic_command_exception
+from trestle.core.commands.command_docs import CommandBase
+from trestle.core.commands.common.return_codes import CmdReturnCodes
+from trestle.core.signing import load_dsse_envelope, load_pem_public_key, verify_oscal_provenance_envelope
+
+logger = logging.getLogger(__name__)
+
+
+class VerifyCmd(CommandBase):
+    """Verify an OSCAL JSON file against a detached DSSE provenance envelope.
+
+    Verification performs two checks. First, it verifies the DSSE signature
+    over the DSSE pre-authentication encoding for the in-toto Statement payload
+    using the provided PEM public key. Second, it canonicalizes the input OSCAL
+    JSON using RFC 8785, computes its SHA-256 digest, and confirms that the
+    digest matches the subject digest recorded in the signed Statement.
+
+    Both checks are required: the digest proves the file matches the signed
+    subject, and the DSSE signature proves the Statement was signed by the
+    corresponding private key. If the envelope was signed with a custom subject
+    name, pass that same value with --subject-name.
+    """
+
+    name = 'verify'
+
+    def _init_arguments(self) -> None:
+        self.add_argument(
+            '-f', '--file', help='Path to the OSCAL JSON file to verify.', required=True, type=pathlib.Path
+        )
+        self.add_argument('--signature', help='Path to the detached DSSE envelope.', required=True, type=pathlib.Path)
+        self.add_argument(
+            '--key', help='Path to the PEM public key for verification.', required=True, type=pathlib.Path
+        )
+        self.add_argument(
+            '--subject-name',
+            help='Subject name expected in the in-toto Statement. Defaults to the input file name.',
+            default=None,
+        )
+
+    def _run(self, args: argparse.Namespace) -> int:
+        """Verify an OSCAL JSON file."""
+        try:
+            log.set_log_level_from_args(args)
+            self.verify(args.file, args.signature, args.key, args.subject_name)
+            return CmdReturnCodes.SUCCESS.value
+        except Exception as e:  # pragma: no cover
+            return handle_generic_command_exception(e, logger, 'Error while verifying OSCAL JSON signature')
+
+    @classmethod
+    def verify(
+        cls,
+        input_path: pathlib.Path,
+        signature_path: pathlib.Path,
+        key_path: pathlib.Path,
+        subject_name: Optional[str] = None,
+    ) -> None:
+        """Verify a detached DSSE provenance envelope for an OSCAL JSON file."""
+        public_key = load_pem_public_key(key_path.resolve())
+        envelope = load_dsse_envelope(signature_path.resolve())
+        verify_oscal_provenance_envelope(input_path.resolve(), envelope, public_key, subject_name)

--- a/trestle/core/signing.py
+++ b/trestle/core/signing.py
@@ -13,11 +13,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Helpers for detached OSCAL JSON provenance signatures."""
+"""Helpers for detached JSON provenance signatures."""
 
 from __future__ import annotations
 
 import base64
+import hmac
 import json
 import pathlib
 from typing import Any, Dict, List, Optional
@@ -36,17 +37,19 @@ OSCAL_PREDICATE_TYPE = 'https://oscal-compass.github.io/compliance-trestle/predi
 CANONICALIZATION_ALGORITHM = 'RFC8785'
 DIGEST_ALGORITHM = 'sha256'
 DIGEST_SOURCE = 'canonical-json'
+MAX_SIGNATURES = 16
 
 
 def _validate_json_path(path: pathlib.Path) -> None:
     if path.suffix.lower() != '.json':
-        raise TrestleError('OSCAL signing is only supported for JSON files.')
+        raise TrestleError('Signing is only supported for JSON files.')
 
 
-def load_pem_private_key_signer(path: pathlib.Path) -> Signer:
+def load_pem_private_key_signer(path: pathlib.Path, password: Optional[str] = None) -> Signer:
     """Load a local PEM private key as a securesystemslib signer."""
+    password_bytes = password.encode(const.FILE_ENCODING) if password is not None else None
     try:
-        private_key = serialization.load_pem_private_key(path.read_bytes(), password=None)
+        private_key = serialization.load_pem_private_key(path.read_bytes(), password=password_bytes)
         return CryptoSigner(private_key)
     except Exception as error:
         raise TrestleError(f'Unable to load private key for signing: {path}') from error
@@ -62,7 +65,7 @@ def load_pem_public_key(path: pathlib.Path) -> Key:
 
 
 def build_in_toto_statement(subject_name: str, digest: str) -> Dict[str, Any]:
-    """Build the in-toto Statement payload for an OSCAL JSON artifact digest."""
+    """Build the in-toto Statement payload for a JSON artifact digest."""
     return {
         '_type': IN_TOTO_STATEMENT_TYPE,
         'subject': [{'name': subject_name, 'digest': {DIGEST_ALGORITHM: digest}}],
@@ -93,7 +96,7 @@ def dsse_pae(payload_type: str, payload: bytes) -> bytes:
 def create_oscal_provenance_envelope(
     input_path: pathlib.Path, signer: Signer, subject_name: Optional[str] = None
 ) -> Dict[str, Any]:
-    """Create a DSSE envelope whose payload is an in-toto Statement for an OSCAL JSON file."""
+    """Create a DSSE envelope whose payload is an in-toto Statement for a JSON file."""
     _validate_json_path(input_path)
     _, canonical_bytes = load_canonical_json_file(input_path)
     digest = sha256_digest_hex(canonical_bytes)
@@ -114,11 +117,15 @@ def sign_in_toto_statement(statement: Dict[str, Any], signer: Signer) -> Dict[st
 
 def write_dsse_envelope(envelope: Dict[str, Any], output_path: pathlib.Path) -> None:
     """Write a DSSE envelope as JSON."""
-    output_path = output_path.resolve()
-    if output_path.exists() and output_path.is_dir():
-        raise TrestleError(f'DSSE output path is a directory: {output_path}')
+    if output_path.is_symlink():
+        raise TrestleError(f'DSSE output path must not be a symlink: {output_path}')
+    if output_path.exists():
+        if output_path.is_dir():
+            raise TrestleError(f'DSSE output path is a directory: {output_path}')
+        raise TrestleError(f'DSSE output path already exists: {output_path}')
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(json.dumps(envelope, indent=2, sort_keys=True) + '\n', encoding=const.FILE_ENCODING)
+    with output_path.open('x', encoding=const.FILE_ENCODING) as write_file:
+        write_file.write(json.dumps(envelope, indent=2, sort_keys=True) + '\n')
 
 
 def load_dsse_envelope(envelope_path: pathlib.Path) -> Dict[str, Any]:
@@ -133,7 +140,7 @@ def load_dsse_envelope(envelope_path: pathlib.Path) -> Dict[str, Any]:
 def verify_oscal_provenance_envelope(
     input_path: pathlib.Path, envelope: Dict[str, Any], public_key: Key, subject_name: Optional[str] = None
 ) -> Dict[str, Any]:
-    """Verify a DSSE in-toto Statement envelope against an OSCAL JSON file."""
+    """Verify a DSSE in-toto Statement envelope against a JSON file."""
     _validate_json_path(input_path)
     _, canonical_bytes = load_canonical_json_file(input_path)
     expected_digest = sha256_digest_hex(canonical_bytes)
@@ -153,11 +160,13 @@ def _verified_payload(envelope: Dict[str, Any], public_key: Key) -> bytes:
     signatures = envelope.get('signatures')
     if not isinstance(signatures, list) or not signatures:
         raise TrestleError('DSSE envelope must contain at least one signature.')
+    if len(signatures) > MAX_SIGNATURES:
+        raise TrestleError(f'DSSE envelope contains more than {MAX_SIGNATURES} signatures.')
 
     verification_errors: List[str] = []
     for signature_entry in signatures:
         try:
-            signature = _signature_from_dsse(signature_entry)
+            signature = _signature_from_dsse(signature_entry, public_key.keyid)
             public_key.verify_signature(signature, pae)
             return payload
         except (TrestleError, UnverifiedSignatureError, VerificationError) as error:
@@ -196,16 +205,30 @@ def _validate_statement(statement: Dict[str, Any], subject_name: str, expected_d
     subjects = statement.get('subject')
     if not isinstance(subjects, list):
         raise TrestleError('in-toto Statement subject must be an array.')
-    for subject in subjects:
-        if not isinstance(subject, dict):
-            continue
-        digest = subject.get('digest')
-        if subject.get('name') == subject_name and isinstance(digest, dict):
-            if digest.get(DIGEST_ALGORITHM) == expected_digest:
-                return
-            raise TrestleError(f'in-toto Statement digest does not match OSCAL JSON: {subject_name}')
+    if len(subjects) != 1:
+        raise TrestleError('in-toto Statement must contain exactly one subject for JSON signing.')
 
-    raise TrestleError(f'in-toto Statement does not contain expected subject: {subject_name}')
+    subject = subjects[0]
+    if not isinstance(subject, dict):
+        raise TrestleError(f'in-toto Statement does not contain expected subject: {subject_name}')
+
+    actual_subject_name = subject.get('name')
+    if actual_subject_name != subject_name:
+        if isinstance(actual_subject_name, str):
+            raise TrestleError(
+                f'in-toto Statement does not contain expected subject: {subject_name}. '
+                f'Found subject: {actual_subject_name}. '
+                'If signing used --subject-name, pass the same value during verification.'
+            )
+        raise TrestleError(f'in-toto Statement does not contain expected subject: {subject_name}')
+
+    digest = subject.get('digest')
+    if not isinstance(digest, dict):
+        raise TrestleError(f'in-toto Statement subject does not contain a digest for: {subject_name}')
+    if hmac.compare_digest(str(digest.get(DIGEST_ALGORITHM)), expected_digest):
+        return
+
+    raise TrestleError(f'in-toto Statement digest does not match JSON file: {subject_name}')
 
 
 def _json_bytes(value: Dict[str, Any]) -> bytes:
@@ -216,13 +239,12 @@ def _dsse_signature(signature: Signature) -> Dict[str, str]:
     return {'keyid': signature.keyid, 'sig': _b64_encode(bytes.fromhex(signature.signature))}
 
 
-def _signature_from_dsse(signature_entry: Any) -> Signature:
+def _signature_from_dsse(signature_entry: Any, verification_keyid: str = '') -> Signature:
     if not isinstance(signature_entry, dict):
         raise TrestleError('DSSE signature entry must be a JSON object.')
-    keyid = signature_entry.get('keyid')
-    if not isinstance(keyid, str) or not keyid:
-        raise TrestleError('DSSE signature entry must contain a keyid.')
-    return Signature(keyid, _b64_decode(signature_entry.get('sig'), 'signature sig').hex())
+    if 'keyid' in signature_entry and not isinstance(signature_entry['keyid'], str):
+        raise TrestleError('DSSE signature entry keyid must be a string.')
+    return Signature(verification_keyid, _b64_decode(signature_entry.get('sig'), 'signature sig').hex())
 
 
 def _b64_encode(data: bytes) -> str:
@@ -233,6 +255,14 @@ def _b64_decode(value: Any, field_name: str) -> bytes:
     if not isinstance(value, str):
         raise TrestleError(f'DSSE {field_name} must be a base64 string.')
     try:
-        return base64.b64decode(value.encode('ascii'), validate=True)
-    except Exception as error:
+        encoded = value.encode('ascii')
+    except UnicodeEncodeError as error:
         raise TrestleError(f'DSSE {field_name} is not valid base64.') from error
+
+    try:
+        return base64.b64decode(encoded, validate=True)
+    except Exception:
+        try:
+            return base64.b64decode(encoded, altchars=b'-_', validate=True)
+        except Exception as error:
+            raise TrestleError(f'DSSE {field_name} is not valid base64.') from error

--- a/trestle/core/signing.py
+++ b/trestle/core/signing.py
@@ -1,0 +1,238 @@
+# -*- mode:python; coding:utf-8 -*-
+
+# Copyright (c) 2026 The OSCAL Compass Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Helpers for detached OSCAL JSON provenance signatures."""
+
+from __future__ import annotations
+
+import base64
+import json
+import pathlib
+from typing import Any, Dict, List, Optional
+
+from cryptography.hazmat.primitives import serialization
+from securesystemslib.exceptions import UnverifiedSignatureError, VerificationError
+from securesystemslib.signer import CryptoSigner, Key, SSlibKey, Signature, Signer
+
+from trestle.common import const
+from trestle.common.err import TrestleError
+from trestle.core.canonicalization import canonicalize_json_text, load_canonical_json_file, sha256_digest_hex
+
+DSSE_PAYLOAD_TYPE = 'application/vnd.in-toto+json'
+IN_TOTO_STATEMENT_TYPE = 'https://in-toto.io/Statement/v1'
+OSCAL_PREDICATE_TYPE = 'https://oscal-compass.github.io/compliance-trestle/predicates/oscal-signing/v1'
+CANONICALIZATION_ALGORITHM = 'RFC8785'
+DIGEST_ALGORITHM = 'sha256'
+DIGEST_SOURCE = 'canonical-json'
+
+
+def _validate_json_path(path: pathlib.Path) -> None:
+    if path.suffix.lower() != '.json':
+        raise TrestleError('OSCAL signing is only supported for JSON files.')
+
+
+def load_pem_private_key_signer(path: pathlib.Path) -> Signer:
+    """Load a local PEM private key as a securesystemslib signer."""
+    try:
+        private_key = serialization.load_pem_private_key(path.read_bytes(), password=None)
+        return CryptoSigner(private_key)
+    except Exception as error:
+        raise TrestleError(f'Unable to load private key for signing: {path}') from error
+
+
+def load_pem_public_key(path: pathlib.Path) -> Key:
+    """Load a local PEM public key as a securesystemslib key."""
+    try:
+        public_key = serialization.load_pem_public_key(path.read_bytes())
+        return SSlibKey.from_crypto(public_key)
+    except Exception as error:
+        raise TrestleError(f'Unable to load public key for verification: {path}') from error
+
+
+def build_in_toto_statement(subject_name: str, digest: str) -> Dict[str, Any]:
+    """Build the in-toto Statement payload for an OSCAL JSON artifact digest."""
+    return {
+        '_type': IN_TOTO_STATEMENT_TYPE,
+        'subject': [{'name': subject_name, 'digest': {DIGEST_ALGORITHM: digest}}],
+        'predicateType': OSCAL_PREDICATE_TYPE,
+        'predicate': {
+            'canonicalization': CANONICALIZATION_ALGORITHM,
+            'digestAlgorithm': DIGEST_ALGORITHM,
+            'digestSource': DIGEST_SOURCE,
+            'tool': 'compliance-trestle',
+        },
+    }
+
+
+def dsse_pae(payload_type: str, payload: bytes) -> bytes:
+    """Return DSSE pre-authentication encoding for a payload type and payload."""
+    payload_type_bytes = payload_type.encode(const.FILE_ENCODING)
+    return b' '.join(
+        [
+            b'DSSEv1',
+            str(len(payload_type_bytes)).encode(const.FILE_ENCODING),
+            payload_type_bytes,
+            str(len(payload)).encode(const.FILE_ENCODING),
+            payload,
+        ]
+    )
+
+
+def create_oscal_provenance_envelope(
+    input_path: pathlib.Path, signer: Signer, subject_name: Optional[str] = None
+) -> Dict[str, Any]:
+    """Create a DSSE envelope whose payload is an in-toto Statement for an OSCAL JSON file."""
+    _validate_json_path(input_path)
+    _, canonical_bytes = load_canonical_json_file(input_path)
+    digest = sha256_digest_hex(canonical_bytes)
+    statement = build_in_toto_statement(subject_name or input_path.name, digest)
+    return sign_in_toto_statement(statement, signer)
+
+
+def sign_in_toto_statement(statement: Dict[str, Any], signer: Signer) -> Dict[str, Any]:
+    """Sign an in-toto Statement as a DSSE envelope."""
+    payload = _json_bytes(statement)
+    signature = signer.sign(dsse_pae(DSSE_PAYLOAD_TYPE, payload))
+    return {
+        'payload': _b64_encode(payload),
+        'payloadType': DSSE_PAYLOAD_TYPE,
+        'signatures': [_dsse_signature(signature)],
+    }
+
+
+def write_dsse_envelope(envelope: Dict[str, Any], output_path: pathlib.Path) -> None:
+    """Write a DSSE envelope as JSON."""
+    output_path = output_path.resolve()
+    if output_path.exists() and output_path.is_dir():
+        raise TrestleError(f'DSSE output path is a directory: {output_path}')
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(envelope, indent=2, sort_keys=True) + '\n', encoding=const.FILE_ENCODING)
+
+
+def load_dsse_envelope(envelope_path: pathlib.Path) -> Dict[str, Any]:
+    """Load a DSSE envelope from JSON."""
+    envelope, _ = canonicalize_json_text(envelope_path.read_text(encoding=const.FILE_ENCODING))
+
+    if not isinstance(envelope, dict):
+        raise TrestleError('DSSE envelope must be a JSON object.')
+    return envelope
+
+
+def verify_oscal_provenance_envelope(
+    input_path: pathlib.Path, envelope: Dict[str, Any], public_key: Key, subject_name: Optional[str] = None
+) -> Dict[str, Any]:
+    """Verify a DSSE in-toto Statement envelope against an OSCAL JSON file."""
+    _validate_json_path(input_path)
+    _, canonical_bytes = load_canonical_json_file(input_path)
+    expected_digest = sha256_digest_hex(canonical_bytes)
+    payload = _verified_payload(envelope, public_key)
+    statement = _load_statement(payload)
+    _validate_statement(statement, subject_name or input_path.name, expected_digest)
+    return statement
+
+
+def _verified_payload(envelope: Dict[str, Any], public_key: Key) -> bytes:
+    payload_type = envelope.get('payloadType')
+    if payload_type != DSSE_PAYLOAD_TYPE:
+        raise TrestleError(f'Unsupported DSSE payload type: {payload_type}')
+
+    payload = _b64_decode(envelope.get('payload'), 'payload')
+    pae = dsse_pae(payload_type, payload)
+    signatures = envelope.get('signatures')
+    if not isinstance(signatures, list) or not signatures:
+        raise TrestleError('DSSE envelope must contain at least one signature.')
+
+    verification_errors: List[str] = []
+    for signature_entry in signatures:
+        try:
+            signature = _signature_from_dsse(signature_entry)
+            public_key.verify_signature(signature, pae)
+            return payload
+        except (TrestleError, UnverifiedSignatureError, VerificationError) as error:
+            verification_errors.append(str(error))
+
+    raise TrestleError(f'DSSE envelope signature could not be verified: {"; ".join(verification_errors)}')
+
+
+def _load_statement(payload: bytes) -> Dict[str, Any]:
+    try:
+        statement, _ = canonicalize_json_text(payload.decode(const.FILE_ENCODING))
+    except UnicodeDecodeError as error:
+        raise TrestleError(f'DSSE payload is not a valid JSON in-toto Statement: {error}') from error
+
+    if not isinstance(statement, dict):
+        raise TrestleError('DSSE payload must be a JSON in-toto Statement object.')
+    return statement
+
+
+def _validate_statement(statement: Dict[str, Any], subject_name: str, expected_digest: str) -> None:
+    if statement.get('_type') != IN_TOTO_STATEMENT_TYPE:
+        raise TrestleError('DSSE payload is not an in-toto Statement v1.')
+    if statement.get('predicateType') != OSCAL_PREDICATE_TYPE:
+        raise TrestleError(f'Unsupported in-toto predicate type: {statement.get("predicateType")}')
+
+    predicate = statement.get('predicate')
+    if not isinstance(predicate, dict):
+        raise TrestleError('in-toto Statement predicate must be a JSON object.')
+    if predicate.get('canonicalization') != CANONICALIZATION_ALGORITHM:
+        raise TrestleError('in-toto Statement does not describe RFC 8785 canonicalization.')
+    if predicate.get('digestAlgorithm') != DIGEST_ALGORITHM:
+        raise TrestleError('in-toto Statement does not describe a SHA-256 digest.')
+    if predicate.get('digestSource') != DIGEST_SOURCE:
+        raise TrestleError('in-toto Statement does not describe a canonical JSON digest source.')
+
+    subjects = statement.get('subject')
+    if not isinstance(subjects, list):
+        raise TrestleError('in-toto Statement subject must be an array.')
+    for subject in subjects:
+        if not isinstance(subject, dict):
+            continue
+        digest = subject.get('digest')
+        if subject.get('name') == subject_name and isinstance(digest, dict):
+            if digest.get(DIGEST_ALGORITHM) == expected_digest:
+                return
+            raise TrestleError(f'in-toto Statement digest does not match OSCAL JSON: {subject_name}')
+
+    raise TrestleError(f'in-toto Statement does not contain expected subject: {subject_name}')
+
+
+def _json_bytes(value: Dict[str, Any]) -> bytes:
+    return json.dumps(value, separators=(',', ':'), sort_keys=True).encode(const.FILE_ENCODING)
+
+
+def _dsse_signature(signature: Signature) -> Dict[str, str]:
+    return {'keyid': signature.keyid, 'sig': _b64_encode(bytes.fromhex(signature.signature))}
+
+
+def _signature_from_dsse(signature_entry: Any) -> Signature:
+    if not isinstance(signature_entry, dict):
+        raise TrestleError('DSSE signature entry must be a JSON object.')
+    keyid = signature_entry.get('keyid')
+    if not isinstance(keyid, str) or not keyid:
+        raise TrestleError('DSSE signature entry must contain a keyid.')
+    return Signature(keyid, _b64_decode(signature_entry.get('sig'), 'signature sig').hex())
+
+
+def _b64_encode(data: bytes) -> str:
+    return base64.b64encode(data).decode('ascii')
+
+
+def _b64_decode(value: Any, field_name: str) -> bytes:
+    if not isinstance(value, str):
+        raise TrestleError(f'DSSE {field_name} must be a base64 string.')
+    try:
+        return base64.b64decode(value.encode('ascii'), validate=True)
+    except Exception as error:
+        raise TrestleError(f'DSSE {field_name} is not valid base64.') from error


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

<!--- Uncomment below if changes are for GitHub Actions -->

<!--
### How To Test

If using [act](https://github.com/nektos/act), fill in below:

**act version**  

**act command**
```bash
```
-->

## Summary
Adds a basic detached signing and verification flow for OSCAL JSON artifacts.

This PR introduces trestle sign and trestle verify. Signing canonicalizes the input JSON with RFC 8785, computes a SHA-256 digest, records that digest in an in-toto Statement, signs the Statement as a DSSE payload, and writes a detached DSSE envelope. Verification checks the DSSE signature, validates the Statement predicate, canonicalizes the input OSCAL JSON, and compares the computed digest with the signed subject digest.
## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)
- Closes https://github.com/oscal-compass/compliance-trestle/issues/2240
- Part of https://github.com/oscal-compass/compliance-trestle/issues/2037

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
