### PR TITLE
fix: is_ordered_sublist matching substrings across list items

### DIFF
--- a/tests/trestle/utils/list_utils_test.py
+++ b/tests/trestle/utils/list_utils_test.py
@@ -24,6 +24,13 @@ def test_is_ordered_sublist() -> None:
     assert list_utils.is_ordered_sublist(['a', 'b', 'c'], ['x', 'a', 'b', 'c', 'y', 'z']) is True
     assert list_utils.is_ordered_sublist(['a', 'b', 'c'], ['x', 'a', 'c', 'b', 'y', 'z']) is False
     assert list_utils.is_ordered_sublist(['a', 'b', 'c'], ['x', 'a', 'b', 'y', 'c', 'z']) is False
+    # a needle item must match a whole haystack item, not a substring of one
+    assert list_utils.is_ordered_sublist(['b'], ['abc']) is False
+    assert list_utils.is_ordered_sublist(['a', 'b'], ['xa', 'by']) is False
+    # a needle longer than the haystack cannot be contained in it
+    assert list_utils.is_ordered_sublist(['a', 'b'], ['a']) is False
+    # exact whole-list match still holds
+    assert list_utils.is_ordered_sublist(['a', 'b'], ['a', 'b']) is True
 
 
 def test_join_key_to_list_dicts() -> None:

--- a/trestle/common/list_utils.py
+++ b/trestle/common/list_utils.py
@@ -84,10 +84,7 @@ def is_ordered_sublist(needle: List[str], haystack: List[str]) -> bool:
     # an empty needle is trivially contained; a needle longer than the haystack cannot be
     if n_items == 0:
         return True
-    for start in range(len(haystack) - n_items + 1):
-        if haystack[start:start + n_items] == needle:
-            return True
-    return False
+    return any(haystack[start:start + n_items] == needle for start in range(len(haystack) - n_items + 1))
 
 
 def join_key_to_list_dicts(dict1: Dict[str, List[Any]], dict2: Dict[str, List[Any]]) -> Dict[str, List[Any]]:

--- a/trestle/common/list_utils.py
+++ b/trestle/common/list_utils.py
@@ -80,7 +80,14 @@ def is_ordered_sublist(needle: List[str], haystack: List[str]) -> bool:
     needle=['a','b','c'], haystack=['x','y','a','b','c','z'], result = True
     needle=['a','b','c'], haystack=['x','y','a','b','z','c'], result = False
     """
-    return ' '.join(needle) in ' '.join(haystack)
+    n_items = len(needle)
+    # an empty needle is trivially contained; a needle longer than the haystack cannot be
+    if n_items == 0:
+        return True
+    for start in range(len(haystack) - n_items + 1):
+        if haystack[start:start + n_items] == needle:
+            return True
+    return False
 
 
 def join_key_to_list_dicts(dict1: Dict[str, List[Any]], dict2: Dict[str, List[Any]]) -> Dict[str, List[Any]]:

--- a/trestle/common/list_utils.py
+++ b/trestle/common/list_utils.py
@@ -84,7 +84,7 @@ def is_ordered_sublist(needle: List[str], haystack: List[str]) -> bool:
     # an empty needle is trivially contained; a needle longer than the haystack cannot be
     if n_items == 0:
         return True
-    return any(haystack[start:start + n_items] == needle for start in range(len(haystack) - n_items + 1))
+    return any(haystack[start : start + n_items] == needle for start in range(len(haystack) - n_items + 1))
 
 
 def join_key_to_list_dicts(dict1: Dict[str, List[Any]], dict2: Dict[str, List[Any]]) -> Dict[str, List[Any]]:


### PR DESCRIPTION
## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Summary

While reading through `trestle/common/list_utils.py` I noticed `is_ordered_sublist` joins both lists with spaces and then does a plain substring test. That lets a needle item match part of a haystack item rather than a whole item, so `is_ordered_sublist(['b'], ['abc'])` returns True and `is_ordered_sublist(['a', 'b'], ['xa', 'by'])` does too. The docstring and its examples describe an item-wise contiguous match, so these are false positives. This function is used in the xlsx component-definition task (`xlsx_helper.py`) to detect the NIST mappings column from header tokens, where a partial-token match could pick the wrong column.

The fix compares the items directly as a contiguous run instead of using string containment. I added a few cases to the existing test covering the substring situations and a needle longer than the haystack. The updated `list_utils` tests and the `xlsx_to_oscal_cd` task tests both pass locally.

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)