### PR TITLE
feat: add signed package manifest flow

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ Trestle provides tooling to help orchestrate the compliance process across a num
 - Tooling manage authoring and governance of markdown and drawio files withn a repository.
 - Support within trestle to streamline management within a managed git environment.
 - An underlying object model that supports developers interacting with OSCAL artefacts.
-- Detached signing and verification for JSON artifacts. See the [`trestle sign` and `trestle verify` CLI documentation](tutorials/cli.md#trestle-sign).
+- Detached signing and verification for JSON artifacts and JSON package manifests. See the [`trestle sign`](tutorials/cli.md#trestle-sign) and [`trestle sign-manifest`](tutorials/cli.md#trestle-sign-manifest) CLI documentation.
 
 ## Important Note:
 

--- a/docs/predicates/oscal-package/manifest-v1.schema.json
+++ b/docs/predicates/oscal-package/manifest-v1.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://oscal-compass.github.io/compliance-trestle/predicates/oscal-package/manifest-v1.schema.json",
+  "title": "OSCAL Package Manifest v1",
+  "description": "A package manifest listing related local JSON artifacts for detached DSSE signing.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "primaryArtifact",
+    "artifacts"
+  ],
+  "properties": {
+    "primaryArtifact": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The name of the primary artifact in the artifacts array."
+    },
+    "artifacts": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/artifact"
+      }
+    }
+  },
+  "$defs": {
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "uri",
+        "mediaType"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "uri": {
+          "type": "string",
+          "minLength": 1,
+          "description": "A relative local path resolved from the manifest directory."
+        },
+        "mediaType": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/docs/predicates/oscal-package/v1.md
+++ b/docs/predicates/oscal-package/v1.md
@@ -1,0 +1,81 @@
+---
+title: OSCAL Package Predicate v1
+description: Predicate type used by compliance-trestle detached JSON package signatures
+---
+
+# OSCAL Package Predicate v1
+
+Trestle uses this predicate type in the in-toto Statement created by `trestle sign-manifest`:
+
+```text
+https://oscal-compass.github.io/compliance-trestle/predicates/oscal-package/v1
+```
+
+The predicate records the validated fields from the JSON package manifest. The predicate type URI is recorded in the signed Statement and is not fetched during verification.
+
+For command usage, see the [`trestle sign-manifest` and `trestle verify-manifest` CLI documentation](../../tutorials/cli.md#trestle-sign-manifest).
+
+The package manifest format is defined by the [OSCAL Package Manifest v1 JSON Schema](manifest-v1.schema.json).
+
+## What is signed
+
+`trestle sign-manifest` creates a detached DSSE envelope. The envelope payload is an in-toto Statement that records:
+
+- the artifact names listed in the package manifest
+- the SHA-256 digest of each artifact's RFC 8785 canonical JSON bytes
+- the package predicate type and predicate fields described below
+
+The DSSE signature is made over the DSSE pre-authentication encoding of the Statement payload. The package manifest and listed JSON artifacts are not modified.
+
+The raw manifest bytes are not signed directly. Trestle validates the manifest, copies its package metadata into the predicate, records the digest of each listed artifact as a subject, and signs the resulting Statement. Verification reconstructs those values from the supplied manifest and artifacts and requires them to match the signed Statement.
+
+## Statement
+
+The DSSE payload is a base64-encoded in-toto Statement with one subject for each package artifact:
+
+```json
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "subject": [
+    {
+      "name": "ssp.json",
+      "digest": {
+        "sha256": "..."
+      }
+    },
+    {
+      "name": "profile.json",
+      "digest": {
+        "sha256": "..."
+      }
+    }
+  ],
+  "predicateType": "https://oscal-compass.github.io/compliance-trestle/predicates/oscal-package/v1",
+  "predicate": {
+    "tool": "compliance-trestle",
+    "manifestVersion": "v1",
+    "primaryArtifact": "ssp.json",
+    "artifacts": [
+      {
+        "name": "ssp.json",
+        "uri": "ssp/ssp.json",
+        "mediaType": "application/oscal+json"
+      },
+      {
+        "name": "profile.json",
+        "uri": "profiles/profile.json",
+        "mediaType": "application/oscal+json"
+      }
+    ]
+  }
+}
+```
+
+## Predicate fields
+
+| Field             | Description                                                                                                   |
+| ----------------- | ------------------------------------------------------------------------------------------------------------- |
+| `tool`            | The producer of the predicate. Trestle writes `compliance-trestle`.                                           |
+| `manifestVersion` | The package manifest predicate version. Trestle writes `v1`.                                                  |
+| `primaryArtifact` | The manifest artifact name treated as the primary artifact for the package.                                   |
+| `artifacts`       | The ordered artifact list from the JSON package manifest. Each entry contains `name`, `uri`, and `mediaType`. |

--- a/docs/tutorials/cli.md
+++ b/docs/tutorials/cli.md
@@ -651,10 +651,75 @@ Trestle verify checks a JSON file against a detached DSSE envelope and a PEM pub
 trestle verify \
   -f catalog.json \
   --signature catalog.json.dsse \
-  --key public.pem
+  --public-key public.pem
 ```
 
 If signing used `--subject-name`, pass the same value during verification.
+
+## `trestle sign-manifest`
+
+Trestle sign-manifest writes a detached DSSE envelope for a JSON package manifest. The manifest lists related JSON artifacts. Trestle canonicalizes each artifact using RFC 8785, records each SHA-256 digest in an in-toto Statement, and signs the package Statement with a PEM private key.
+
+The sign-manifest and verify-manifest commands are beta features. Enable them before use:
+
+```bash
+trestle beta enable json-manifest-signing
+```
+
+Example package manifest:
+
+```json
+{
+  "primaryArtifact": "ssp.json",
+  "artifacts": [
+    {
+      "name": "ssp.json",
+      "uri": "ssp/ssp.json",
+      "mediaType": "application/oscal+json"
+    },
+    {
+      "name": "profile.json",
+      "uri": "profiles/profile.json",
+      "mediaType": "application/oscal+json"
+    },
+    {
+      "name": "catalog.json",
+      "uri": "catalogs/catalog.json",
+      "mediaType": "application/oscal+json"
+    }
+  ]
+}
+```
+
+The manifest format is defined by the [OSCAL Package Manifest v1 JSON Schema](../predicates/oscal-package/manifest-v1.schema.json).
+
+Trestle also requires `primaryArtifact` to name one listed artifact, artifact names to be unique, and each `uri` to identify an existing local JSON file within the manifest directory. Invalid JSON and duplicate JSON keys are rejected.
+
+Sign the package manifest:
+
+```bash
+trestle sign-manifest \
+  --manifest package.json \
+  --key private.pem \
+  -o package.dsse
+```
+
+For an encrypted private key, use `--key-password-env` as with `trestle sign`.
+
+The signed package Statement uses the [OSCAL package predicate](../predicates/oscal-package/v1.md).
+
+## `trestle verify-manifest`
+
+Trestle verify-manifest checks a JSON package manifest against a detached DSSE envelope and a PEM public key. Verification checks the package DSSE signature, requires the manifest metadata and artifact set to match the signed package Statement, and confirms that each current JSON artifact digest matches its signed digest.
+
+```bash
+trestle verify-manifest \
+  --manifest package.json \
+  --signature package.dsse \
+  --public-key public.pem
+```
+
+This first manifest signing flow verifies package digests only. Per-document signature requirements are expected to be added in a later workflow.
 
 ## `trestle tasks`
 

--- a/tests/trestle/core/commands/sign_manifest_verify_manifest_test.py
+++ b/tests/trestle/core/commands/sign_manifest_verify_manifest_test.py
@@ -1,0 +1,416 @@
+# -*- mode:python; coding:utf-8 -*-
+
+# Copyright (c) 2026 The OSCAL Compass Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for trestle sign-manifest and verify-manifest commands."""
+
+import base64
+import json
+import pathlib
+import sys
+from typing import Tuple
+
+import pytest
+from _pytest.monkeypatch import MonkeyPatch
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ed25519
+
+import trestle.common.const as const
+from trestle.common.err import TrestleError
+from trestle.cli import Trestle
+from trestle.core.commands.common.return_codes import CmdReturnCodes
+from trestle.core.commands.sign_manifest import SignManifestCmd
+
+
+def write_ed25519_key_pair(
+    tmp_path: pathlib.Path, prefix: str = 'test-key', password: bytes = b''
+) -> Tuple[pathlib.Path, pathlib.Path]:
+    """Write a temporary Ed25519 private/public key pair."""
+    private_key = ed25519.Ed25519PrivateKey.generate()
+    private_key_path = tmp_path / f'{prefix}.pem'
+    public_key_path = tmp_path / f'{prefix}.pub.pem'
+    encryption_algorithm = serialization.BestAvailableEncryption(password) if password else serialization.NoEncryption()
+    private_key_path.write_bytes(
+        private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=encryption_algorithm,
+        )
+    )
+    public_key_path.write_bytes(
+        private_key.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM, format=serialization.PublicFormat.SubjectPublicKeyInfo
+        )
+    )
+    return private_key_path, public_key_path
+
+
+@pytest.fixture(autouse=True)
+def enable_json_manifest_signing_beta(monkeypatch: MonkeyPatch) -> None:
+    """Enable the manifest signing beta feature for command tests."""
+    monkeypatch.setenv('TRESTLE_BETA_FEATURES', 'json-manifest-signing')
+
+
+def write_package_manifest(tmp_path: pathlib.Path) -> pathlib.Path:
+    """Write a sample package manifest and JSON artifacts."""
+    (tmp_path / 'ssp').mkdir()
+    (tmp_path / 'profiles').mkdir()
+    (tmp_path / 'catalogs').mkdir()
+    (tmp_path / 'ssp/ssp.json').write_text('{"ssp":{"b":2,"a":1}}', encoding=const.FILE_ENCODING)
+    (tmp_path / 'profiles/profile.json').write_text('{"profile":{"id":"test-profile"}}', encoding=const.FILE_ENCODING)
+    (tmp_path / 'catalogs/catalog.json').write_text('{"catalog":{"id":"test-catalog"}}', encoding=const.FILE_ENCODING)
+    manifest_path = tmp_path / 'package.json'
+    manifest_path.write_text(
+        json.dumps(
+            {
+                'primaryArtifact': 'ssp.json',
+                'artifacts': [
+                    {'name': 'ssp.json', 'uri': 'ssp/ssp.json', 'mediaType': 'application/oscal+json'},
+                    {'name': 'profile.json', 'uri': 'profiles/profile.json', 'mediaType': 'application/oscal+json'},
+                    {'name': 'catalog.json', 'uri': 'catalogs/catalog.json', 'mediaType': 'application/oscal+json'},
+                ],
+            }
+        ),
+        encoding=const.FILE_ENCODING,
+    )
+    return manifest_path
+
+
+def test_sign_manifest_and_verify_manifest_require_beta_feature(
+    tmp_path: pathlib.Path, monkeypatch: MonkeyPatch
+) -> None:
+    """Manifest sign and verify commands should be blocked unless the beta feature is enabled."""
+    monkeypatch.delenv('TRESTLE_BETA_FEATURES', raising=False)
+    monkeypatch.setenv('XDG_CONFIG_HOME', str(tmp_path / 'xdg-config'))
+    manifest_path = tmp_path / 'package.json'
+    key_path = tmp_path / 'key.pem'
+    envelope_path = tmp_path / 'package.dsse'
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'trestle',
+            'sign-manifest',
+            '--manifest',
+            str(manifest_path),
+            '--key',
+            str(key_path),
+            '-o',
+            str(envelope_path),
+        ],
+    )
+    assert Trestle().run() == CmdReturnCodes.COMMAND_ERROR.value
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'trestle',
+            'verify-manifest',
+            '--manifest',
+            str(manifest_path),
+            '--signature',
+            str(envelope_path),
+            '--public-key',
+            str(key_path),
+        ],
+    )
+    assert Trestle().run() == CmdReturnCodes.COMMAND_ERROR.value
+
+
+def test_sign_manifest_and_verify_manifest_accept_one_time_beta_flag(
+    tmp_path: pathlib.Path, monkeypatch: MonkeyPatch
+) -> None:
+    """Manifest commands should run with --beta without persisting beta config."""
+    monkeypatch.delenv('TRESTLE_BETA_FEATURES', raising=False)
+    monkeypatch.setenv('XDG_CONFIG_HOME', str(tmp_path / 'xdg-config'))
+    private_key_path, public_key_path = write_ed25519_key_pair(tmp_path)
+    manifest_path = write_package_manifest(tmp_path)
+    envelope_path = tmp_path / 'package.dsse'
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'trestle',
+            'sign-manifest',
+            '--beta',
+            '--manifest',
+            str(manifest_path),
+            '--key',
+            str(private_key_path),
+            '-o',
+            str(envelope_path),
+        ],
+    )
+    assert Trestle().run() == CmdReturnCodes.SUCCESS.value
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'trestle',
+            'verify-manifest',
+            '--beta',
+            '--manifest',
+            str(manifest_path),
+            '--signature',
+            str(envelope_path),
+            '--public-key',
+            str(public_key_path),
+        ],
+    )
+    assert Trestle().run() == CmdReturnCodes.SUCCESS.value
+    assert not (tmp_path / 'xdg-config').exists()
+
+
+def test_sign_manifest_and_verify_manifest_round_trip(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
+    """Sign-manifest should write a DSSE envelope that verify-manifest accepts."""
+    private_key_path, public_key_path = write_ed25519_key_pair(tmp_path)
+    manifest_path = write_package_manifest(tmp_path)
+    envelope_path = tmp_path / 'package.dsse'
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'trestle',
+            'sign-manifest',
+            '--manifest',
+            str(manifest_path),
+            '--key',
+            str(private_key_path),
+            '-o',
+            str(envelope_path),
+        ],
+    )
+    assert Trestle().run() == CmdReturnCodes.SUCCESS.value
+    assert envelope_path.exists()
+
+    envelope = json.loads(envelope_path.read_text(encoding=const.FILE_ENCODING))
+    statement = json.loads(base64.b64decode(envelope['payload']).decode(const.FILE_ENCODING))
+    assert envelope['payloadType'] == 'application/vnd.in-toto+json'
+    assert (
+        statement['predicateType'] == 'https://oscal-compass.github.io/compliance-trestle/predicates/oscal-package/v1'
+    )
+    assert {subject['name'] for subject in statement['subject']} == {'ssp.json', 'profile.json', 'catalog.json'}
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'trestle',
+            'verify-manifest',
+            '--manifest',
+            str(manifest_path),
+            '--signature',
+            str(envelope_path),
+            '--public-key',
+            str(public_key_path),
+        ],
+    )
+    assert Trestle().run() == CmdReturnCodes.SUCCESS.value
+
+
+def test_sign_manifest_supports_encrypted_private_key(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
+    """Sign-manifest should accept an encrypted PEM private key password from an environment variable."""
+    private_key_path, public_key_path = write_ed25519_key_pair(tmp_path, password=b'test-password')
+    manifest_path = write_package_manifest(tmp_path)
+    envelope_path = tmp_path / 'package.dsse'
+    monkeypatch.setenv('TRESTLE_KEY_PASSWORD', 'test-password')
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'trestle',
+            'sign-manifest',
+            '--manifest',
+            str(manifest_path),
+            '--key',
+            str(private_key_path),
+            '--key-password-env',
+            'TRESTLE_KEY_PASSWORD',
+            '-o',
+            str(envelope_path),
+        ],
+    )
+    assert Trestle().run() == CmdReturnCodes.SUCCESS.value
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'trestle',
+            'verify-manifest',
+            '--manifest',
+            str(manifest_path),
+            '--signature',
+            str(envelope_path),
+            '--public-key',
+            str(public_key_path),
+        ],
+    )
+    assert Trestle().run() == CmdReturnCodes.SUCCESS.value
+
+
+@pytest.mark.parametrize(
+    'output_target, expected_error',
+    [('manifest', 'different from package manifest'), ('key', 'different from private key')],
+)
+def test_sign_manifest_rejects_unsafe_output_paths(
+    tmp_path: pathlib.Path, output_target: str, expected_error: str
+) -> None:
+    """Sign-manifest should reject output paths that would overwrite important inputs."""
+    private_key_path, _ = write_ed25519_key_pair(tmp_path)
+    manifest_path = write_package_manifest(tmp_path)
+    output_path = manifest_path if output_target == 'manifest' else private_key_path
+
+    with pytest.raises(TrestleError, match=expected_error):
+        SignManifestCmd.sign_manifest(manifest_path, private_key_path, output_path)
+
+
+def test_sign_manifest_rejects_missing_key_password_env(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
+    """Sign-manifest should fail before writing output when the password env var is missing."""
+    private_key_path, _ = write_ed25519_key_pair(tmp_path)
+    manifest_path = write_package_manifest(tmp_path)
+    monkeypatch.delenv('MISSING_TRESTLE_KEY_PASSWORD', raising=False)
+
+    with pytest.raises(TrestleError, match='Key password environment variable is not set'):
+        SignManifestCmd.sign_manifest(
+            manifest_path, private_key_path, tmp_path / 'package.dsse', 'MISSING_TRESTLE_KEY_PASSWORD'
+        )
+
+
+def test_verify_manifest_rejects_changed_artifact(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
+    """Verify-manifest should fail if a package artifact changes after signing."""
+    private_key_path, public_key_path = write_ed25519_key_pair(tmp_path)
+    manifest_path = write_package_manifest(tmp_path)
+    envelope_path = tmp_path / 'package.dsse'
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'trestle',
+            'sign-manifest',
+            '--manifest',
+            str(manifest_path),
+            '--key',
+            str(private_key_path),
+            '-o',
+            str(envelope_path),
+        ],
+    )
+    assert Trestle().run() == CmdReturnCodes.SUCCESS.value
+    (tmp_path / 'ssp/ssp.json').write_text('{"ssp":{"changed":true}}', encoding=const.FILE_ENCODING)
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'trestle',
+            'verify-manifest',
+            '--manifest',
+            str(manifest_path),
+            '--signature',
+            str(envelope_path),
+            '--public-key',
+            str(public_key_path),
+        ],
+    )
+    assert Trestle().run() == CmdReturnCodes.COMMAND_ERROR.value
+
+
+def test_verify_manifest_rejects_wrong_public_key(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
+    """Verify-manifest should fail if the public key does not match the signing key."""
+    private_key_path, _ = write_ed25519_key_pair(tmp_path, 'signing-key')
+    _, wrong_public_key_path = write_ed25519_key_pair(tmp_path, 'wrong-key')
+    manifest_path = write_package_manifest(tmp_path)
+    envelope_path = tmp_path / 'package.dsse'
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'trestle',
+            'sign-manifest',
+            '--manifest',
+            str(manifest_path),
+            '--key',
+            str(private_key_path),
+            '-o',
+            str(envelope_path),
+        ],
+    )
+    assert Trestle().run() == CmdReturnCodes.SUCCESS.value
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'trestle',
+            'verify-manifest',
+            '--manifest',
+            str(manifest_path),
+            '--signature',
+            str(envelope_path),
+            '--public-key',
+            str(wrong_public_key_path),
+        ],
+    )
+    assert Trestle().run() == CmdReturnCodes.COMMAND_ERROR.value
+
+
+def test_verify_manifest_rejects_tampered_envelope(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
+    """Verify-manifest should fail when the package DSSE envelope is tampered."""
+    private_key_path, public_key_path = write_ed25519_key_pair(tmp_path)
+    manifest_path = write_package_manifest(tmp_path)
+    envelope_path = tmp_path / 'package.dsse'
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'trestle',
+            'sign-manifest',
+            '--manifest',
+            str(manifest_path),
+            '--key',
+            str(private_key_path),
+            '-o',
+            str(envelope_path),
+        ],
+    )
+    assert Trestle().run() == CmdReturnCodes.SUCCESS.value
+    envelope = json.loads(envelope_path.read_text(encoding=const.FILE_ENCODING))
+    envelope['payload'] = base64.b64encode(b'{"tampered":true}').decode('ascii')
+    envelope_path.write_text(json.dumps(envelope), encoding=const.FILE_ENCODING)
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'trestle',
+            'verify-manifest',
+            '--manifest',
+            str(manifest_path),
+            '--signature',
+            str(envelope_path),
+            '--public-key',
+            str(public_key_path),
+        ],
+    )
+    assert Trestle().run() == CmdReturnCodes.COMMAND_ERROR.value

--- a/tests/trestle/core/commands/sign_verify_test.py
+++ b/tests/trestle/core/commands/sign_verify_test.py
@@ -77,7 +77,7 @@ def test_sign_and_verify_require_beta_feature(tmp_path: pathlib.Path, monkeypatc
     monkeypatch.setattr(
         sys,
         'argv',
-        ['trestle', 'verify', '-f', str(input_path), '--signature', str(envelope_path), '--key', str(key_path)],
+        ['trestle', 'verify', '-f', str(input_path), '--signature', str(envelope_path), '--public-key', str(key_path)],
     )
     assert Trestle().run() == CmdReturnCodes.COMMAND_ERROR.value
 
@@ -109,7 +109,7 @@ def test_sign_and_verify_accept_one_time_beta_flag(tmp_path: pathlib.Path, monke
             str(input_path),
             '--signature',
             str(envelope_path),
-            '--key',
+            '--public-key',
             str(public_key_path),
         ],
     )
@@ -138,7 +138,16 @@ def test_sign_and_verify_round_trip(tmp_path: pathlib.Path, monkeypatch: MonkeyP
     monkeypatch.setattr(
         sys,
         'argv',
-        ['trestle', 'verify', '-f', str(input_path), '--signature', str(envelope_path), '--key', str(public_key_path)],
+        [
+            'trestle',
+            'verify',
+            '-f',
+            str(input_path),
+            '--signature',
+            str(envelope_path),
+            '--public-key',
+            str(public_key_path),
+        ],
     )
     assert Trestle().run() == CmdReturnCodes.SUCCESS.value
 
@@ -160,7 +169,16 @@ def test_sign_and_verify_real_nist_800_53_catalog(tmp_path: pathlib.Path, monkey
     monkeypatch.setattr(
         sys,
         'argv',
-        ['trestle', 'verify', '-f', str(input_path), '--signature', str(envelope_path), '--key', str(public_key_path)],
+        [
+            'trestle',
+            'verify',
+            '-f',
+            str(input_path),
+            '--signature',
+            str(envelope_path),
+            '--public-key',
+            str(public_key_path),
+        ],
     )
     assert Trestle().run() == CmdReturnCodes.SUCCESS.value
 
@@ -193,7 +211,16 @@ def test_verify_rejects_missing_custom_subject_name(tmp_path: pathlib.Path, monk
     monkeypatch.setattr(
         sys,
         'argv',
-        ['trestle', 'verify', '-f', str(input_path), '--signature', str(envelope_path), '--key', str(public_key_path)],
+        [
+            'trestle',
+            'verify',
+            '-f',
+            str(input_path),
+            '--signature',
+            str(envelope_path),
+            '--public-key',
+            str(public_key_path),
+        ],
     )
     assert Trestle().run() == CmdReturnCodes.COMMAND_ERROR.value
 
@@ -207,7 +234,7 @@ def test_verify_rejects_missing_custom_subject_name(tmp_path: pathlib.Path, monk
             str(input_path),
             '--signature',
             str(envelope_path),
-            '--key',
+            '--public-key',
             str(public_key_path),
             '--subject-name',
             'custom/catalog.json',
@@ -245,7 +272,16 @@ def test_sign_supports_encrypted_private_key(tmp_path: pathlib.Path, monkeypatch
     monkeypatch.setattr(
         sys,
         'argv',
-        ['trestle', 'verify', '-f', str(input_path), '--signature', str(envelope_path), '--key', str(public_key_path)],
+        [
+            'trestle',
+            'verify',
+            '-f',
+            str(input_path),
+            '--signature',
+            str(envelope_path),
+            '--public-key',
+            str(public_key_path),
+        ],
     )
     assert Trestle().run() == CmdReturnCodes.SUCCESS.value
 
@@ -346,7 +382,16 @@ def test_verify_rejects_tampered_document(tmp_path: pathlib.Path, monkeypatch: M
     monkeypatch.setattr(
         sys,
         'argv',
-        ['trestle', 'verify', '-f', str(input_path), '--signature', str(envelope_path), '--key', str(public_key_path)],
+        [
+            'trestle',
+            'verify',
+            '-f',
+            str(input_path),
+            '--signature',
+            str(envelope_path),
+            '--public-key',
+            str(public_key_path),
+        ],
     )
     assert Trestle().run() == CmdReturnCodes.COMMAND_ERROR.value
 
@@ -375,7 +420,7 @@ def test_verify_rejects_wrong_key(tmp_path: pathlib.Path, monkeypatch: MonkeyPat
             str(input_path),
             '--signature',
             str(envelope_path),
-            '--key',
+            '--public-key',
             str(wrong_public_key_path),
         ],
     )
@@ -439,7 +484,7 @@ def test_verify_rejects_non_json_input(tmp_path: pathlib.Path, monkeypatch: Monk
             str(non_json_input_path),
             '--signature',
             str(envelope_path),
-            '--key',
+            '--public-key',
             str(public_key_path),
             '--subject-name',
             input_path.name,

--- a/tests/trestle/core/signing_manifest_test.py
+++ b/tests/trestle/core/signing_manifest_test.py
@@ -1,0 +1,319 @@
+# -*- mode:python; coding:utf-8 -*-
+
+# Copyright (c) 2026 The OSCAL Compass Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for signed package manifest helpers."""
+
+import base64
+import json
+import pathlib
+from typing import Any, Callable, Dict, Optional, Tuple
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ed25519
+
+import trestle.common.const as const
+from trestle.common.err import TrestleError
+from trestle.core.signing import (
+    DIGEST_ALGORITHM,
+    IN_TOTO_STATEMENT_TYPE,
+    load_pem_private_key_signer,
+    load_pem_public_key,
+    sign_in_toto_statement,
+)
+from trestle.core.signing_manifest import (
+    MANIFEST_VERSION,
+    PACKAGE_PREDICATE_TYPE,
+    PACKAGE_TOOL,
+    build_manifest_statement,
+    create_manifest_envelope,
+    load_signing_manifest,
+    verify_manifest_envelope,
+)
+
+
+def write_ed25519_key_pair(tmp_path: pathlib.Path) -> Tuple[pathlib.Path, pathlib.Path]:
+    """Write a temporary Ed25519 private/public key pair."""
+    private_key = ed25519.Ed25519PrivateKey.generate()
+    private_key_path = tmp_path / 'test-key.pem'
+    public_key_path = tmp_path / 'test-key.pub.pem'
+    private_key_path.write_bytes(
+        private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+    )
+    public_key_path.write_bytes(
+        private_key.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM, format=serialization.PublicFormat.SubjectPublicKeyInfo
+        )
+    )
+    return private_key_path, public_key_path
+
+
+def write_package_manifest(tmp_path: pathlib.Path) -> pathlib.Path:
+    """Write a sample package manifest and its JSON artifacts."""
+    (tmp_path / 'ssp').mkdir()
+    (tmp_path / 'profiles').mkdir()
+    (tmp_path / 'catalogs').mkdir()
+    (tmp_path / 'ssp/ssp.json').write_text('{"ssp":{"b":2,"a":1}}', encoding=const.FILE_ENCODING)
+    (tmp_path / 'profiles/profile.json').write_text('{"profile":{"id":"test-profile"}}', encoding=const.FILE_ENCODING)
+    (tmp_path / 'catalogs/catalog.json').write_text('{"catalog":{"id":"test-catalog"}}', encoding=const.FILE_ENCODING)
+    manifest_path = tmp_path / 'package.json'
+    manifest_path.write_text(
+        json.dumps(
+            {
+                'primaryArtifact': 'ssp.json',
+                'artifacts': [
+                    {'name': 'ssp.json', 'uri': 'ssp/ssp.json', 'mediaType': 'application/oscal+json'},
+                    {'name': 'profile.json', 'uri': 'profiles/profile.json', 'mediaType': 'application/oscal+json'},
+                    {'name': 'catalog.json', 'uri': 'catalogs/catalog.json', 'mediaType': 'application/oscal+json'},
+                ],
+            }
+        ),
+        encoding=const.FILE_ENCODING,
+    )
+    return manifest_path
+
+
+def test_create_manifest_envelope_contains_package_statement(tmp_path: pathlib.Path) -> None:
+    """Manifest signing should create a package Statement with all artifact subjects."""
+    private_key_path, public_key_path = write_ed25519_key_pair(tmp_path)
+    manifest = load_signing_manifest(write_package_manifest(tmp_path))
+    signer = load_pem_private_key_signer(private_key_path)
+
+    envelope = create_manifest_envelope(manifest, signer)
+    statement = json.loads(base64.b64decode(envelope['payload']).decode(const.FILE_ENCODING))
+
+    assert statement['_type'] == IN_TOTO_STATEMENT_TYPE
+    assert statement['predicateType'] == PACKAGE_PREDICATE_TYPE
+    assert statement['predicate'] == {
+        'tool': PACKAGE_TOOL,
+        'manifestVersion': MANIFEST_VERSION,
+        'primaryArtifact': 'ssp.json',
+        'artifacts': [
+            {'name': 'ssp.json', 'uri': 'ssp/ssp.json', 'mediaType': 'application/oscal+json'},
+            {'name': 'profile.json', 'uri': 'profiles/profile.json', 'mediaType': 'application/oscal+json'},
+            {'name': 'catalog.json', 'uri': 'catalogs/catalog.json', 'mediaType': 'application/oscal+json'},
+        ],
+    }
+    assert {subject['name'] for subject in statement['subject']} == {'ssp.json', 'profile.json', 'catalog.json'}
+    assert all(DIGEST_ALGORITHM in subject['digest'] for subject in statement['subject'])
+
+    public_key = load_pem_public_key(public_key_path)
+    verify_manifest_envelope(manifest, envelope, public_key)
+
+
+def test_build_manifest_statement_matches_create_manifest_payload(tmp_path: pathlib.Path) -> None:
+    """The explicit builder should produce the same Statement payload shape used by signing."""
+    manifest = load_signing_manifest(write_package_manifest(tmp_path))
+
+    statement = build_manifest_statement(manifest)
+
+    assert statement['predicateType'] == PACKAGE_PREDICATE_TYPE
+    assert statement['predicate']['primaryArtifact'] == 'ssp.json'
+    assert len(statement['subject']) == 3
+
+
+@pytest.mark.parametrize(
+    'manifest_name, manifest_text, expected_error',
+    [
+        ('package.yml', '{}', 'JSON file'),
+        ('missing.json', None, 'does not exist'),
+        ('package.json', '{"artifacts": [', 'Unable to load signing manifest JSON'),
+        (
+            'package.json',
+            '{"artifacts":["ssp.json"],"primaryArtifact":"ssp.json"}',
+            'artifact at index 0 must be a mapping',
+        ),
+        (
+            'package.json',
+            '{"artifacts":[{"uri":"ssp/ssp.json","mediaType":"application/oscal+json"}],"primaryArtifact":"ssp.json"}',
+            'requires a non-empty string field: name',
+        ),
+        (
+            'package.json',
+            '{"primaryArtifact":"ssp.json","primaryArtifact":"other.json","artifacts":[]}',
+            'Duplicate JSON object key',
+        ),
+    ],
+)
+def test_load_signing_manifest_rejects_manifest_file_and_artifact_errors(
+    tmp_path: pathlib.Path, manifest_name: str, manifest_text: Optional[str], expected_error: str
+) -> None:
+    """Manifest loading should reject malformed paths, JSON, and artifact entries."""
+    (tmp_path / 'ssp').mkdir()
+    (tmp_path / 'ssp/ssp.json').write_text('{"ssp":{}}', encoding=const.FILE_ENCODING)
+    manifest_path = tmp_path / manifest_name
+    if manifest_text is not None:
+        manifest_path.write_text(manifest_text, encoding=const.FILE_ENCODING)
+
+    with pytest.raises(TrestleError, match=expected_error):
+        load_signing_manifest(manifest_path)
+
+
+def test_verify_manifest_rejects_changed_artifact(tmp_path: pathlib.Path) -> None:
+    """Verification should fail when any signed artifact digest changes."""
+    private_key_path, public_key_path = write_ed25519_key_pair(tmp_path)
+    manifest_path = write_package_manifest(tmp_path)
+    manifest = load_signing_manifest(manifest_path)
+    envelope = create_manifest_envelope(manifest, load_pem_private_key_signer(private_key_path))
+    (tmp_path / 'profiles/profile.json').write_text('{"profile":{"id":"changed"}}', encoding=const.FILE_ENCODING)
+
+    with pytest.raises(TrestleError, match='digest does not match artifact'):
+        verify_manifest_envelope(load_signing_manifest(manifest_path), envelope, load_pem_public_key(public_key_path))
+
+
+def test_verify_manifest_rejects_changed_manifest(tmp_path: pathlib.Path) -> None:
+    """Verification should fail when the manifest metadata no longer matches the signed predicate."""
+    private_key_path, public_key_path = write_ed25519_key_pair(tmp_path)
+    manifest_path = write_package_manifest(tmp_path)
+    manifest = load_signing_manifest(manifest_path)
+    envelope = create_manifest_envelope(manifest, load_pem_private_key_signer(private_key_path))
+    manifest_path.write_text(
+        manifest_path.read_text(encoding=const.FILE_ENCODING).replace('application/oscal+json', 'application/json', 1),
+        encoding=const.FILE_ENCODING,
+    )
+
+    with pytest.raises(TrestleError, match='predicate does not match'):
+        verify_manifest_envelope(load_signing_manifest(manifest_path), envelope, load_pem_public_key(public_key_path))
+
+
+@pytest.mark.parametrize(
+    'statement_update, expected_error',
+    [
+        (lambda statement: statement.update({'_type': 'wrong-type'}), 'not an in-toto Statement'),
+        (
+            lambda statement: statement.update({'predicateType': 'wrong-predicate'}),
+            'Unsupported in-toto package predicate',
+        ),
+        (lambda statement: statement.update({'predicate': []}), 'predicate must be a JSON object'),
+        (lambda statement: statement.update({'subject': {}}), 'subject must be an array'),
+        (lambda statement: statement.update({'subject': ['ssp.json']}), 'subject entries must be JSON objects'),
+        (lambda statement: statement['subject'][0].update({'name': 10}), 'subject name must be a string'),
+        (lambda statement: statement['subject'].append(statement['subject'][0]), 'duplicate subject'),
+        (
+            lambda statement: statement['subject'][0].update({'digest': {'sha512': 'missing-sha256'}}),
+            'does not contain a SHA-256 digest',
+        ),
+        (lambda statement: statement['subject'].pop(), 'subjects do not match'),
+    ],
+)
+def test_verify_manifest_rejects_malformed_package_statements(
+    tmp_path: pathlib.Path, statement_update: Callable[[Dict[str, Any]], None], expected_error: str
+) -> None:
+    """Package Statement validation should reject malformed or inconsistent signed payloads."""
+    private_key_path, public_key_path = write_ed25519_key_pair(tmp_path)
+    manifest = load_signing_manifest(write_package_manifest(tmp_path))
+    statement = build_manifest_statement(manifest)
+    statement_update(statement)
+    envelope = sign_in_toto_statement(statement, load_pem_private_key_signer(private_key_path))
+
+    with pytest.raises(TrestleError, match=expected_error):
+        verify_manifest_envelope(manifest, envelope, load_pem_public_key(public_key_path))
+
+
+@pytest.mark.parametrize(
+    'manifest_text, expected_error',
+    [
+        ('[]', 'JSON object'),
+        ('{"primaryArtifact":"ssp.json","artifacts":[]}', 'non-empty list'),
+        (
+            '{"primaryArtifact":"missing.json","artifacts":['
+            '{"name":"ssp.json","uri":"ssp/ssp.json","mediaType":"application/oscal+json"}]}',
+            'primaryArtifact is not listed',
+        ),
+        (
+            '{"primaryArtifact":"ssp.json","artifacts":['
+            '{"name":"ssp.json","uri":"ssp/ssp.json","mediaType":"application/oscal+json"},'
+            '{"name":"ssp.json","uri":"ssp/other.json","mediaType":"application/oscal+json"}]}',
+            'duplicate artifact name',
+        ),
+        (
+            '{"primaryArtifact":"ssp.json","artifacts":['
+            '{"name":"ssp.json","uri":"ssp/ssp.json","mediaType":"application/oscal+json"}],'
+            '"policy":"strict"}',
+            'unsupported field',
+        ),
+        (
+            '{"primaryArtifact":"ssp.json","artifacts":['
+            '{"name":"ssp.json","uri":"ssp/ssp.json","mediaType":"application/oscal+json",'
+            '"signatureRequired":true}]}',
+            'unsupported field',
+        ),
+        (
+            '{"primaryArtifact":"ssp.json","artifacts":['
+            '{"name":"ssp.json","uri":"ssp/ssp.json","mediaType":"application/oscal+json"}],'
+            '"1":"unexpected"}',
+            'unsupported field',
+        ),
+    ],
+)
+def test_load_signing_manifest_rejects_invalid_shapes(
+    tmp_path: pathlib.Path, manifest_text: str, expected_error: str
+) -> None:
+    """Manifest loading should reject invalid JSON shape and identifiers."""
+    (tmp_path / 'ssp').mkdir()
+    (tmp_path / 'ssp/ssp.json').write_text('{"ssp":{}}', encoding=const.FILE_ENCODING)
+    (tmp_path / 'ssp/other.json').write_text('{"ssp":{}}', encoding=const.FILE_ENCODING)
+    manifest_path = tmp_path / 'package.json'
+    manifest_path.write_text(manifest_text, encoding=const.FILE_ENCODING)
+
+    with pytest.raises(TrestleError, match=expected_error):
+        load_signing_manifest(manifest_path)
+
+
+@pytest.mark.parametrize(
+    'uri, expected_error',
+    [
+        ('ssp/ssp.txt', 'JSON files'),
+        ('ssp/missing.json', 'does not exist'),
+        ('https://example.com/ssp.json', 'relative local path'),
+        ('../outside.json', 'within the manifest directory'),
+    ],
+)
+def test_load_signing_manifest_rejects_unsupported_artifact_paths(
+    tmp_path: pathlib.Path, uri: str, expected_error: str
+) -> None:
+    """Manifest loading should reject unsupported or unavailable artifact paths."""
+    (tmp_path / 'ssp').mkdir()
+    (tmp_path / 'ssp/ssp.txt').write_text('not json', encoding=const.FILE_ENCODING)
+    (tmp_path.parent / 'outside.json').write_text('{"outside":true}', encoding=const.FILE_ENCODING)
+    manifest_path = tmp_path / 'package.json'
+    manifest_path.write_text(
+        json.dumps(
+            {'primaryArtifact': 'ssp.json', 'artifacts': [{'name': 'ssp.json', 'uri': uri, 'mediaType': 'text/plain'}]}
+        ),
+        encoding=const.FILE_ENCODING,
+    )
+
+    with pytest.raises(TrestleError, match=expected_error):
+        load_signing_manifest(manifest_path)
+
+
+@pytest.mark.parametrize(
+    'artifact_text, expected_error', [('{', 'Input is not valid JSON'), ('{"a":1,"a":2}', 'Duplicate JSON object key')]
+)
+def test_create_manifest_envelope_rejects_invalid_json_artifacts(
+    tmp_path: pathlib.Path, artifact_text: str, expected_error: str
+) -> None:
+    """Manifest signing should fail before signing invalid or ambiguous JSON artifacts."""
+    private_key_path, _ = write_ed25519_key_pair(tmp_path)
+    manifest_path = write_package_manifest(tmp_path)
+    (tmp_path / 'ssp/ssp.json').write_text(artifact_text, encoding=const.FILE_ENCODING)
+
+    with pytest.raises(TrestleError, match=expected_error):
+        create_manifest_envelope(load_signing_manifest(manifest_path), load_pem_private_key_signer(private_key_path))

--- a/trestle/cli.py
+++ b/trestle/cli.py
@@ -35,10 +35,12 @@ from trestle.core.commands.partial_object_validate import PartialObjectValidate
 from trestle.core.commands.remove import RemoveCmd
 from trestle.core.commands.replicate import ReplicateCmd
 from trestle.core.commands.sign import SignCmd
+from trestle.core.commands.sign_manifest import SignManifestCmd
 from trestle.core.commands.split import SplitCmd
 from trestle.core.commands.task import TaskCmd
 from trestle.core.commands.validate import ValidateCmd
 from trestle.core.commands.verify import VerifyCmd
+from trestle.core.commands.verify_manifest import VerifyManifestCmd
 from trestle.core.commands.version import VersionCmd
 from trestle.core.plugins import discovered_plugins
 
@@ -63,10 +65,12 @@ class Trestle(CommandBase):
         RemoveCmd,
         ReplicateCmd,
         SignCmd,
+        SignManifestCmd,
         SplitCmd,
         TaskCmd,
         ValidateCmd,
         VerifyCmd,
+        VerifyManifestCmd,
         VersionCmd,
     ]
 

--- a/trestle/core/beta_features.py
+++ b/trestle/core/beta_features.py
@@ -58,7 +58,17 @@ BETA_FEATURES: Dict[str, BetaFeature] = {
         documentation_url='https://oscal-compass.github.io/compliance-trestle/tutorials/cli/#trestle-sign',
         enabled_by_default=False,
         deprecation_version=None,
-    )
+    ),
+    'json-manifest-signing': BetaFeature(
+        name='json-manifest-signing',
+        description='Sign and verify JSON package manifests for JSON artifacts with detached DSSE envelopes.',
+        commands=['trestle sign-manifest', 'trestle verify-manifest'],
+        since_version='4.0.3',
+        stability='beta',
+        documentation_url='https://oscal-compass.github.io/compliance-trestle/tutorials/cli/#trestle-sign-manifest',
+        enabled_by_default=False,
+        deprecation_version=None,
+    ),
 }
 
 

--- a/trestle/core/commands/sign_manifest.py
+++ b/trestle/core/commands/sign_manifest.py
@@ -1,0 +1,94 @@
+# -*- mode:python; coding:utf-8 -*-
+
+# Copyright (c) 2026 The OSCAL Compass Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Trestle Sign Manifest Command."""
+
+import argparse
+import logging
+import os
+import pathlib
+from typing import Optional
+
+from trestle.common import log
+from trestle.common.err import TrestleError, handle_generic_command_exception
+from trestle.core.beta_features import beta_feature
+from trestle.core.commands.command_docs import CommandBase
+from trestle.core.commands.common.return_codes import CmdReturnCodes
+from trestle.core.signing import load_pem_private_key_signer, write_dsse_envelope
+from trestle.core.signing_manifest import create_manifest_envelope, load_signing_manifest
+
+logger = logging.getLogger(__name__)
+
+
+class SignManifestCmd(CommandBase):
+    """Sign a JSON package manifest as a detached DSSE envelope.
+
+    The manifest lists local JSON artifacts that belong to a package. This
+    command canonicalizes each listed JSON artifact with RFC 8785, records each
+    SHA-256 digest in an in-toto Statement, signs the Statement using the
+    provided PEM private key, and writes the detached package envelope.
+    """
+
+    name = 'sign-manifest'
+
+    def _init_arguments(self) -> None:
+        self.add_argument(
+            '--manifest', help='Path to the JSON package manifest to sign.', required=True, type=pathlib.Path
+        )
+        self.add_argument('--key', help='Path to the PEM private key for signing.', required=True, type=pathlib.Path)
+        self.add_argument(
+            '--key-password-env',
+            help='Environment variable containing the password for an encrypted PEM private key.',
+            default=None,
+        )
+        self.add_argument('-o', '--output', help='Output DSSE package envelope file.', required=True, type=pathlib.Path)
+
+    @beta_feature('json-manifest-signing')
+    def _run(self, args: argparse.Namespace) -> int:
+        """Sign a JSON package manifest."""
+        try:
+            log.set_log_level_from_args(args)
+            self.sign_manifest(args.manifest, args.key, args.output, args.key_password_env)
+            return CmdReturnCodes.SUCCESS.value
+        except Exception as e:  # pragma: no cover
+            return handle_generic_command_exception(e, logger, 'Error while signing package manifest')
+
+    @classmethod
+    def sign_manifest(
+        cls,
+        manifest_path: pathlib.Path,
+        key_path: pathlib.Path,
+        output_path: pathlib.Path,
+        key_password_env: Optional[str] = None,
+    ) -> None:
+        """Write a detached DSSE envelope for a JSON package manifest."""
+        manifest_path = manifest_path.resolve()
+        key_path = key_path.resolve()
+        resolved_output_path = output_path.resolve()
+        if manifest_path == resolved_output_path:
+            raise TrestleError('DSSE output path must be different from package manifest file.')
+        if key_path == resolved_output_path:
+            raise TrestleError('DSSE output path must be different from private key file.')
+
+        key_password = None
+        if key_password_env is not None:
+            if key_password_env not in os.environ:
+                raise TrestleError(f'Key password environment variable is not set: {key_password_env}')
+            key_password = os.environ[key_password_env]
+
+        signer = load_pem_private_key_signer(key_path, key_password)
+        manifest = load_signing_manifest(manifest_path)
+        envelope = create_manifest_envelope(manifest, signer)
+        write_dsse_envelope(envelope, output_path)

--- a/trestle/core/commands/verify.py
+++ b/trestle/core/commands/verify.py
@@ -51,7 +51,7 @@ class VerifyCmd(CommandBase):
         self.add_argument('-f', '--file', help='Path to the JSON file to verify.', required=True, type=pathlib.Path)
         self.add_argument('--signature', help='Path to the detached DSSE envelope.', required=True, type=pathlib.Path)
         self.add_argument(
-            '--key', help='Path to the PEM public key for verification.', required=True, type=pathlib.Path
+            '--public-key', help='Path to the PEM public key for verification.', required=True, type=pathlib.Path
         )
         self.add_argument(
             '--subject-name',
@@ -64,7 +64,7 @@ class VerifyCmd(CommandBase):
         """Verify a JSON file."""
         try:
             log.set_log_level_from_args(args)
-            self.verify(args.file, args.signature, args.key, args.subject_name)
+            self.verify(args.file, args.signature, args.public_key, args.subject_name)
             return CmdReturnCodes.SUCCESS.value
         except Exception as e:  # pragma: no cover
             return handle_generic_command_exception(e, logger, 'Error while verifying JSON signature')
@@ -74,10 +74,10 @@ class VerifyCmd(CommandBase):
         cls,
         input_path: pathlib.Path,
         signature_path: pathlib.Path,
-        key_path: pathlib.Path,
+        public_key_path: pathlib.Path,
         subject_name: Optional[str] = None,
     ) -> None:
         """Verify a detached DSSE provenance envelope for a JSON file."""
-        public_key = load_pem_public_key(key_path.resolve())
+        public_key = load_pem_public_key(public_key_path.resolve())
         envelope = load_dsse_envelope(signature_path.resolve())
         verify_oscal_provenance_envelope(input_path.resolve(), envelope, public_key, subject_name)

--- a/trestle/core/commands/verify_manifest.py
+++ b/trestle/core/commands/verify_manifest.py
@@ -1,0 +1,72 @@
+# -*- mode:python; coding:utf-8 -*-
+
+# Copyright (c) 2026 The OSCAL Compass Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Trestle Verify Manifest Command."""
+
+import argparse
+import logging
+import pathlib
+
+from trestle.common import log
+from trestle.common.err import handle_generic_command_exception
+from trestle.core.beta_features import beta_feature
+from trestle.core.commands.command_docs import CommandBase
+from trestle.core.commands.common.return_codes import CmdReturnCodes
+from trestle.core.signing import load_dsse_envelope, load_pem_public_key
+from trestle.core.signing_manifest import load_signing_manifest, verify_manifest_envelope
+
+logger = logging.getLogger(__name__)
+
+
+class VerifyManifestCmd(CommandBase):
+    """Verify a JSON package manifest against a detached DSSE envelope.
+
+    Verification checks the package DSSE signature, validates the signed
+    in-toto package Statement, and confirms every current JSON artifact digest
+    matches the digest recorded in the signed manifest envelope.
+    """
+
+    name = 'verify-manifest'
+
+    def _init_arguments(self) -> None:
+        self.add_argument(
+            '--manifest', help='Path to the JSON package manifest to verify.', required=True, type=pathlib.Path
+        )
+        self.add_argument(
+            '--signature', help='Path to the detached DSSE package envelope.', required=True, type=pathlib.Path
+        )
+        self.add_argument(
+            '--public-key', help='Path to the PEM public key for verification.', required=True, type=pathlib.Path
+        )
+
+    @beta_feature('json-manifest-signing')
+    def _run(self, args: argparse.Namespace) -> int:
+        """Verify a JSON package manifest."""
+        try:
+            log.set_log_level_from_args(args)
+            self.verify_manifest(args.manifest, args.signature, args.public_key)
+            return CmdReturnCodes.SUCCESS.value
+        except Exception as e:  # pragma: no cover
+            return handle_generic_command_exception(e, logger, 'Error while verifying package manifest signature')
+
+    @classmethod
+    def verify_manifest(
+        cls, manifest_path: pathlib.Path, signature_path: pathlib.Path, public_key_path: pathlib.Path
+    ) -> None:
+        """Verify a detached DSSE envelope for a JSON package manifest."""
+        manifest = load_signing_manifest(manifest_path.resolve())
+        public_key = load_pem_public_key(public_key_path.resolve())
+        envelope = load_dsse_envelope(signature_path.resolve())
+        verify_manifest_envelope(manifest, envelope, public_key)

--- a/trestle/core/signing.py
+++ b/trestle/core/signing.py
@@ -150,6 +150,16 @@ def verify_oscal_provenance_envelope(
     return statement
 
 
+def verify_dsse_payload(envelope: Dict[str, Any], public_key: Key) -> bytes:
+    """Verify a DSSE envelope signature and return its payload bytes."""
+    return _verified_payload(envelope, public_key)
+
+
+def load_in_toto_statement(payload: bytes) -> Dict[str, Any]:
+    """Load a verified DSSE payload as an in-toto Statement object."""
+    return _load_statement(payload)
+
+
 def _verified_payload(envelope: Dict[str, Any], public_key: Key) -> bytes:
     payload_type = envelope.get('payloadType')
     if payload_type != DSSE_PAYLOAD_TYPE:

--- a/trestle/core/signing_manifest.py
+++ b/trestle/core/signing_manifest.py
@@ -1,0 +1,236 @@
+# -*- mode:python; coding:utf-8 -*-
+
+# Copyright (c) 2026 The OSCAL Compass Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Helpers for signed JSON package manifests."""
+
+from __future__ import annotations
+
+import hmac
+import pathlib
+from dataclasses import dataclass
+from typing import Any, Dict, List, Set
+from urllib.parse import urlparse
+
+from securesystemslib.signer import Key, Signer
+
+from trestle.common.err import TrestleError
+from trestle.core.canonicalization import load_canonical_json_file, sha256_digest_hex
+from trestle.core.signing import (
+    DIGEST_ALGORITHM,
+    IN_TOTO_STATEMENT_TYPE,
+    load_in_toto_statement,
+    sign_in_toto_statement,
+    verify_dsse_payload,
+)
+
+PACKAGE_PREDICATE_TYPE = 'https://oscal-compass.github.io/compliance-trestle/predicates/oscal-package/v1'
+MANIFEST_VERSION = 'v1'
+PACKAGE_TOOL = 'compliance-trestle'
+MANIFEST_FIELDS = {'primaryArtifact', 'artifacts'}
+ARTIFACT_FIELDS = {'name', 'uri', 'mediaType'}
+
+
+@dataclass(frozen=True)
+class ManifestArtifact:
+    """An artifact listed in a package manifest."""
+
+    name: str
+    uri: str
+    media_type: str
+    path: pathlib.Path
+
+    def to_predicate(self) -> Dict[str, str]:
+        """Return the stable predicate representation for the artifact."""
+        return {'name': self.name, 'uri': self.uri, 'mediaType': self.media_type}
+
+
+@dataclass(frozen=True)
+class SigningManifest:
+    """A validated JSON signing manifest."""
+
+    path: pathlib.Path
+    primary_artifact: str
+    artifacts: List[ManifestArtifact]
+
+    def predicate_artifacts(self) -> List[Dict[str, str]]:
+        """Return the stable predicate artifact list."""
+        return [artifact.to_predicate() for artifact in self.artifacts]
+
+
+def load_signing_manifest(manifest_path: pathlib.Path) -> SigningManifest:
+    """Load and validate a JSON signing manifest."""
+    manifest_path = manifest_path.resolve()
+    if manifest_path.suffix.lower() != '.json':
+        raise TrestleError(f'Signing manifest must be a JSON file: {manifest_path}')
+    if not manifest_path.exists() or not manifest_path.is_file():
+        raise TrestleError(f'Signing manifest path does not exist or is not a file: {manifest_path}')
+
+    try:
+        manifest_data, _ = load_canonical_json_file(manifest_path)
+    except TrestleError as error:
+        raise TrestleError(f'Unable to load signing manifest JSON: {manifest_path}: {error}') from error
+
+    if not isinstance(manifest_data, dict):
+        raise TrestleError('Signing manifest must be a JSON object.')
+
+    _reject_unknown_fields(manifest_data, MANIFEST_FIELDS, 'Signing manifest')
+    primary_artifact = _required_string(manifest_data, 'primaryArtifact', 'Signing manifest')
+    artifacts_data = manifest_data.get('artifacts')
+    if not isinstance(artifacts_data, list) or not artifacts_data:
+        raise TrestleError('Signing manifest artifacts must be a non-empty list.')
+
+    artifacts: List[ManifestArtifact] = []
+    artifact_names = set()
+    for index, artifact_data in enumerate(artifacts_data):
+        if not isinstance(artifact_data, dict):
+            raise TrestleError(f'Signing manifest artifact at index {index} must be a mapping.')
+        _reject_unknown_fields(artifact_data, ARTIFACT_FIELDS, f'Signing manifest artifact at index {index}')
+        name = _required_string(artifact_data, 'name', f'Signing manifest artifact at index {index}')
+        uri = _required_string(artifact_data, 'uri', f'Signing manifest artifact {name}')
+        media_type = _required_string(artifact_data, 'mediaType', f'Signing manifest artifact {name}')
+        if name in artifact_names:
+            raise TrestleError(f'Signing manifest contains a duplicate artifact name: {name}')
+        artifact_names.add(name)
+        artifact_path = _artifact_path(manifest_path.parent, uri)
+        _validate_artifact_path(artifact_path)
+        artifacts.append(ManifestArtifact(name, uri, media_type, artifact_path))
+
+    if primary_artifact not in artifact_names:
+        raise TrestleError(f'Signing manifest primaryArtifact is not listed in artifacts: {primary_artifact}')
+
+    return SigningManifest(manifest_path, primary_artifact, artifacts)
+
+
+def create_manifest_envelope(manifest: SigningManifest, signer: Signer) -> Dict[str, Any]:
+    """Create a DSSE envelope for a validated signing manifest."""
+    return sign_in_toto_statement(build_manifest_statement(manifest), signer)
+
+
+def build_manifest_statement(manifest: SigningManifest) -> Dict[str, Any]:
+    """Build the in-toto Statement payload for a signing manifest."""
+    return {
+        '_type': IN_TOTO_STATEMENT_TYPE,
+        'subject': _manifest_subjects(manifest),
+        'predicateType': PACKAGE_PREDICATE_TYPE,
+        'predicate': {
+            'tool': PACKAGE_TOOL,
+            'manifestVersion': MANIFEST_VERSION,
+            'primaryArtifact': manifest.primary_artifact,
+            'artifacts': manifest.predicate_artifacts(),
+        },
+    }
+
+
+def verify_manifest_envelope(manifest: SigningManifest, envelope: Dict[str, Any], public_key: Key) -> Dict[str, Any]:
+    """Verify a DSSE package Statement envelope against a signing manifest."""
+    payload = verify_dsse_payload(envelope, public_key)
+    statement = load_in_toto_statement(payload)
+    _validate_manifest_statement(statement, manifest)
+    return statement
+
+
+def _validate_manifest_statement(statement: Dict[str, Any], manifest: SigningManifest) -> None:
+    if statement.get('_type') != IN_TOTO_STATEMENT_TYPE:
+        raise TrestleError('DSSE payload is not an in-toto Statement v1.')
+    if statement.get('predicateType') != PACKAGE_PREDICATE_TYPE:
+        raise TrestleError(f'Unsupported in-toto package predicate type: {statement.get("predicateType")}')
+
+    predicate = statement.get('predicate')
+    if not isinstance(predicate, dict):
+        raise TrestleError('in-toto package Statement predicate must be a JSON object.')
+    expected_predicate = {
+        'tool': PACKAGE_TOOL,
+        'manifestVersion': MANIFEST_VERSION,
+        'primaryArtifact': manifest.primary_artifact,
+        'artifacts': manifest.predicate_artifacts(),
+    }
+    if predicate != expected_predicate:
+        raise TrestleError('in-toto package Statement predicate does not match the signing manifest.')
+
+    _validate_manifest_subjects(statement.get('subject'), manifest)
+
+
+def _validate_manifest_subjects(subjects: Any, manifest: SigningManifest) -> None:
+    if not isinstance(subjects, list):
+        raise TrestleError('in-toto package Statement subject must be an array.')
+
+    expected_subjects = {
+        subject['name']: subject['digest'][DIGEST_ALGORITHM] for subject in _manifest_subjects(manifest)
+    }
+    actual_subjects: Dict[str, str] = {}
+    for subject in subjects:
+        if not isinstance(subject, dict):
+            raise TrestleError('in-toto package Statement subject entries must be JSON objects.')
+        name = subject.get('name')
+        if not isinstance(name, str):
+            raise TrestleError('in-toto package Statement subject name must be a string.')
+        if name in actual_subjects:
+            raise TrestleError(f'in-toto package Statement contains a duplicate subject: {name}')
+        digest = subject.get('digest')
+        if not isinstance(digest, dict) or not isinstance(digest.get(DIGEST_ALGORITHM), str):
+            raise TrestleError(f'in-toto package Statement subject does not contain a SHA-256 digest: {name}')
+        actual_subjects[name] = digest[DIGEST_ALGORITHM]
+
+    if set(actual_subjects) != set(expected_subjects):
+        raise TrestleError('in-toto package Statement subjects do not match the signing manifest artifacts.')
+
+    for name, expected_digest in expected_subjects.items():
+        if not hmac.compare_digest(actual_subjects[name], expected_digest):
+            raise TrestleError(f'in-toto package Statement digest does not match artifact: {name}')
+
+
+def _manifest_subjects(manifest: SigningManifest) -> List[Dict[str, Any]]:
+    return [
+        {'name': artifact.name, 'digest': {DIGEST_ALGORITHM: _artifact_digest(artifact.path)}}
+        for artifact in manifest.artifacts
+    ]
+
+
+def _artifact_digest(path: pathlib.Path) -> str:
+    _, canonical_bytes = load_canonical_json_file(path)
+    return sha256_digest_hex(canonical_bytes)
+
+
+def _required_string(data: Dict[str, Any], key: str, context: str) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value:
+        raise TrestleError(f'{context} requires a non-empty string field: {key}')
+    return value
+
+
+def _reject_unknown_fields(data: Dict[str, Any], allowed_fields: Set[str], context: str) -> None:
+    unknown_fields = sorted(str(field) for field in set(data) - allowed_fields)
+    if unknown_fields:
+        raise TrestleError(f'{context} contains unsupported field(s): {", ".join(unknown_fields)}')
+
+
+def _artifact_path(manifest_dir: pathlib.Path, uri: str) -> pathlib.Path:
+    manifest_dir = manifest_dir.resolve()
+    parsed_uri = urlparse(uri)
+    if parsed_uri.scheme or pathlib.Path(uri).is_absolute():
+        raise TrestleError(f'Signing manifest artifact uri must be a relative local path: {uri}')
+    artifact_path = (manifest_dir / uri).resolve()
+    try:
+        artifact_path.relative_to(manifest_dir)
+    except ValueError:
+        raise TrestleError(f'Signing manifest artifact uri must stay within the manifest directory: {uri}')
+    return artifact_path
+
+
+def _validate_artifact_path(path: pathlib.Path) -> None:
+    if path.suffix.lower() != '.json':
+        raise TrestleError(f'Signing manifest artifacts must be JSON files: {path}')
+    if not path.exists() or not path.is_file():
+        raise TrestleError(f'Signing manifest artifact path does not exist or is not a file: {path}')


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

<!--- Uncomment below if changes are for GitHub Actions -->

<!--
### How To Test

If using [act](https://github.com/nektos/act), fill in below:

**act version**  

**act command**
```bash
```
-->

## Summary
Adds beta support for signing and verifying YAML-defined JSON package manifests.

This introduces trestle `sign-manifest` and trestle `verify-manifest`. The manifest explicitly lists package artifacts, trestle canonicalizes each listed JSON file, computes SHA-256 digests, builds an in-toto Statement containing all artifact subjects, and signs that Statement as a detached DSSE envelope.

This PR is digest-only package verification. It does not auto-discover OSCAL dependencies, enforce per-document .dsse signatures.

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)
- part of https://github.com/oscal-compass/compliance-trestle/issues/2037

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
