### PR TITLE
fix: nolog

### DIFF
--- a/trestle/core/catalog/catalog_interface.py
+++ b/trestle/core/catalog/catalog_interface.py
@@ -124,7 +124,8 @@ class CatalogInterface:
         """Generate sequential group ids."""
         group_id = f'trestle_group_{self._generate_group_index:04d}'
         self._generate_group_index += 1
-        logger.warning(f'Group titled "{group.title}" has no id and has been assigned id: {group_id}')
+        safe_title = str(group.title).replace('\n', '\\n').replace('\r', '\\r') if group.title else ''
+        logger.warning(f'Group titled "{safe_title}" has no id and has been assigned id: {group_id}')
         return group_id
 
     def _add_params_to_map(self, control: cat.Control) -> None:


### PR DESCRIPTION
The fix is in trestle/core/catalog/catalog_interface.py:127.

What was wrong: group.title is user-controlled data (sourced from a catalog file). Logging it directly is vulnerable to log injection — a malicious title containing newlines (\n, \r) could forge additional log entries or corrupt log output (CWE-117 / SonarQube S5145).

What was changed: The user-controlled value is sanitized before logging by:

Calling str() to ensure it's a string.
Replacing \n and \r with their literal escape sequences, which neutralises any newline-injection attempt.
Handling the None case (empty string fallback) to avoid NoneType errors.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [ ] My code follows the code style of this project.
- [ ] Documentation for my change is up to date?
- [ ] My PR meets testing requirements.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

<!--- Uncomment below if changes are for GitHub Actions -->

<!--
### How To Test

If using [act](https://github.com/nektos/act), fill in below:

**act version**  

**act command**
```bash
```
-->

## Summary

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
