### PR TITLE
feat: add AWS Config compliance-results-to-OSCAL-AR task

### DIFF
--- a/docs/tutorials/cli.md
+++ b/docs/tutorials/cli.md
@@ -1118,6 +1118,31 @@ Example output OSCAL Observations file contents (snippet):
 
 </details>
 
+## `trestle task aws-config-result-to-oscal-ar`
+
+The *trestle task aws-config-result-to-oscal-ar* command transforms AWS Config compliance evaluation results into OSCAL partial results `.json` files. Each input file is the JSON shape returned by `get-compliance-details-by-config-rule` / `get-compliance-details-by-resource` (`{"EvaluationResults": [EvaluationResult, ...]}`).
+
+Specify required config parameters for input and output directories. Optional `output-overwrite` controls whether existing output may be replaced. Optional `timestamp` is an ISO 8601 string that overrides the Result/Observation timestamps.
+
+<span style="color:green">
+Example command invocation:
+</span>
+
+`$TRESTLE_BASEDIR$ trestle task aws-config-result-to-oscal-ar -c /home/user/task.config`
+
+<span style="color:green">
+Example config:
+</span>
+
+```conf
+[task.aws-config-result-to-oscal-ar]
+input-dir = /home/user/git/compliance/aws-config/input
+output-dir = /home/user/git/compliance/oscal/output
+output-overwrite = true
+```
+
+Only `.json` / `.jsn` files in `input-dir` are processed. Nested directories and other extensions are skipped. `simulate` does not create the output directory.
+
 ## `trestle task tanium-result-to-oscal-ar`
 
 The *trestle task tanium-result-to-oscal-ar* command facilitates transformation of Tanuim reports, each

--- a/docs/tutorials/compliance_posture.md
+++ b/docs/tutorials/compliance_posture.md
@@ -38,7 +38,7 @@ The bad news is that a transformer to [OSCAL](https://pages.nist.gov/OSCAL) is n
 
 However, there is plenty of good news:
 
-- a transformer for your Cloud Service type may already exist, such as: [Tanium to OSCAL](../reference/API/trestle/tasks/tanium_result_to_oscal_ar.md), [OpenShift Compliance Operator to OSCAL](../reference/API/trestle/tasks/xccdf_result_to_oscal_ar.md)
+- a transformer for your Cloud Service type may already exist, such as: [Tanium to OSCAL](../reference/API/trestle/tasks/tanium_result_to_oscal_ar.md), [OpenShift Compliance Operator to OSCAL](../reference/API/trestle/tasks/xccdf_result_to_oscal_ar.md), [AWS Config to OSCAL](../reference/API/trestle/tasks/aws_config_result_to_oscal_ar.md)
 - once a transformer for a Cloud Service type has been written, it can be open-sourced/re-used
 - writing a transformer is fairly easy: just a few lines of Python code using [trestle](../index.md) as a foundation
 

--- a/tests/data/tasks/aws-config/aws-config-sample.json
+++ b/tests/data/tasks/aws-config/aws-config-sample.json
@@ -1,0 +1,67 @@
+{
+  "EvaluationResults": [
+    {
+      "EvaluationResultIdentifier": {
+        "EvaluationResultQualifier": {
+          "ConfigRuleName": "s3-bucket-public-read-prohibited",
+          "ResourceType": "AWS::S3::Bucket",
+          "ResourceId": "acme-prod-uploads",
+          "EvaluationMode": "DETECTIVE"
+        },
+        "OrderingTimestamp": "2026-08-16T09:12:03.000Z"
+      },
+      "ComplianceType": "NON_COMPLIANT",
+      "ResultRecordedTime": "2026-08-16T09:12:05.000Z",
+      "ConfigRuleInvokedTime": "2026-08-16T09:12:04.000Z",
+      "Annotation": "The S3 bucket policy allows public read access.",
+      "ResultToken": "tok-0001"
+    },
+    {
+      "EvaluationResultIdentifier": {
+        "EvaluationResultQualifier": {
+          "ConfigRuleName": "s3-bucket-public-read-prohibited",
+          "ResourceType": "AWS::S3::Bucket",
+          "ResourceId": "acme-prod-assets",
+          "EvaluationMode": "DETECTIVE"
+        },
+        "OrderingTimestamp": "2026-08-16T09:12:07.000Z"
+      },
+      "ComplianceType": "COMPLIANT",
+      "ResultRecordedTime": "2026-08-16T09:12:08.000Z",
+      "ConfigRuleInvokedTime": "2026-08-16T09:12:07.000Z",
+      "ResultToken": "tok-0002"
+    },
+    {
+      "EvaluationResultIdentifier": {
+        "EvaluationResultQualifier": {
+          "ConfigRuleName": "restricted-ssh",
+          "ResourceType": "AWS::EC2::SecurityGroup",
+          "ResourceId": "sg-0a1b2c3d4e5f6g7h8",
+          "EvaluationMode": "DETECTIVE"
+        },
+        "OrderingTimestamp": "2026-08-16T09:13:11.000Z"
+      },
+      "ComplianceType": "NON_COMPLIANT",
+      "ResultRecordedTime": "2026-08-16T09:13:12.000Z",
+      "ConfigRuleInvokedTime": "2026-08-16T09:13:11.000Z",
+      "Annotation": "Security group allows unrestricted SSH access (0.0.0.0/0 on port 22).",
+      "ResultToken": "tok-0003"
+    },
+    {
+      "EvaluationResultIdentifier": {
+        "EvaluationResultQualifier": {
+          "ConfigRuleName": "restricted-ssh",
+          "ResourceType": "AWS::EC2::SecurityGroup",
+          "ResourceId": "sg-0a1b2c3d4e5f6g7h8",
+          "EvaluationMode": "DETECTIVE"
+        },
+        "OrderingTimestamp": "2026-08-15T09:13:11.000Z"
+      },
+      "ComplianceType": "NON_COMPLIANT",
+      "ResultRecordedTime": "2026-08-15T09:13:12.000Z",
+      "ConfigRuleInvokedTime": "2026-08-15T09:13:11.000Z",
+      "Annotation": "Security group allows unrestricted SSH access (0.0.0.0/0 on port 22).",
+      "ResultToken": "tok-0000"
+    }
+  ]
+}

--- a/tests/trestle/tasks/aws_config_result_to_oscal_ar_test.py
+++ b/tests/trestle/tasks/aws_config_result_to_oscal_ar_test.py
@@ -56,7 +56,7 @@ class TestAwsConfigResultToOscalAR:
         task = AwsConfigResultToOscalAR(config)
         outcome = task.simulate()
         assert outcome == TaskOutcome.SIM_SUCCESS
-        assert not output_dir.exists() or not list(output_dir.iterdir())
+        assert not output_dir.exists()
 
     def test_execute_produces_valid_oscal_result(self, tmp_path):
         output_dir = tmp_path / 'out'
@@ -83,3 +83,19 @@ class TestAwsConfigResultToOscalAR:
         config2['output-overwrite'] = 'false'
         task2 = AwsConfigResultToOscalAR(config2)
         assert task2.execute() == TaskOutcome.FAILURE
+
+    def test_execute_skips_non_json_and_directories(self, tmp_path):
+        input_dir = tmp_path / 'in'
+        input_dir.mkdir()
+        (input_dir / 'nested').mkdir()
+        (input_dir / 'readme.txt').write_text('not json', encoding='utf-8')
+        sample = test_data_dir / 'aws-config-sample.json'
+        (input_dir / 'aws-config-sample.json').write_text(sample.read_text(encoding='utf-8'), encoding='utf-8')
+
+        output_dir = tmp_path / 'out'
+        config = _build_config(input_dir, output_dir)
+        task = AwsConfigResultToOscalAR(config)
+        assert task.execute() == TaskOutcome.SUCCESS
+        produced = list(output_dir.glob('*.oscal.json'))
+        assert len(produced) == 1
+        assert produced[0].name == 'aws-config-sample.oscal.json'

--- a/tests/trestle/tasks/aws_config_result_to_oscal_ar_test.py
+++ b/tests/trestle/tasks/aws_config_result_to_oscal_ar_test.py
@@ -1,0 +1,85 @@
+# -*- mode:python; coding:utf-8 -*-
+# Copyright (c) 2026 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""AWS Config to OSCAL task tests."""
+
+import configparser
+import json
+import pathlib
+
+from tests.test_utils import TEST_DIR
+
+from trestle.tasks.aws_config_result_to_oscal_ar import AwsConfigResultToOscalAR
+from trestle.tasks.base_task import TaskOutcome
+
+test_data_dir = TEST_DIR / 'data/tasks/aws-config'
+
+
+def _build_config(input_dir: pathlib.Path, output_dir: pathlib.Path) -> configparser.SectionProxy:
+    config = configparser.ConfigParser()
+    section = 'task.aws-config-result-to-oscal-ar'
+    config.add_section(section)
+    config.set(section, 'input-dir', str(input_dir))
+    config.set(section, 'output-dir', str(output_dir))
+    return config[section]
+
+
+class TestAwsConfigResultToOscalAR:
+    def test_print_info(self, capsys):
+        task = AwsConfigResultToOscalAR(None)
+        task.print_info()
+
+    def test_missing_config_fails(self):
+        task = AwsConfigResultToOscalAR(None)
+        assert task.execute() == TaskOutcome.FAILURE
+
+    def test_missing_required_keys_fails(self):
+        config = configparser.ConfigParser()
+        config.add_section('task.aws-config-result-to-oscal-ar')
+        task = AwsConfigResultToOscalAR(config['task.aws-config-result-to-oscal-ar'])
+        assert task.execute() == TaskOutcome.FAILURE
+
+    def test_simulate_does_not_write_output(self, tmp_path):
+        output_dir = tmp_path / 'out'
+        config = _build_config(test_data_dir, output_dir)
+        task = AwsConfigResultToOscalAR(config)
+        outcome = task.simulate()
+        assert outcome == TaskOutcome.SIM_SUCCESS
+        assert not output_dir.exists() or not list(output_dir.iterdir())
+
+    def test_execute_produces_valid_oscal_result(self, tmp_path):
+        output_dir = tmp_path / 'out'
+        config = _build_config(test_data_dir, output_dir)
+        task = AwsConfigResultToOscalAR(config)
+        outcome = task.execute()
+        assert outcome == TaskOutcome.SUCCESS
+
+        produced = list(output_dir.glob('*.oscal.json'))
+        assert len(produced) == 1
+        data = json.loads(produced[0].read_text(encoding='utf-8'))
+        assert 'results' in data
+        result = data['results'][0]
+        assert len(result['observations']) == 4
+        assert len(result['local-definitions']['inventory-items']) == 3
+
+    def test_execute_respects_output_overwrite_false(self, tmp_path):
+        output_dir = tmp_path / 'out'
+        config = _build_config(test_data_dir, output_dir)
+        task = AwsConfigResultToOscalAR(config)
+        assert task.execute() == TaskOutcome.SUCCESS
+
+        config2 = _build_config(test_data_dir, output_dir)
+        config2['output-overwrite'] = 'false'
+        task2 = AwsConfigResultToOscalAR(config2)
+        assert task2.execute() == TaskOutcome.FAILURE

--- a/tests/trestle/transforms/implementations/aws_config_test.py
+++ b/tests/trestle/transforms/implementations/aws_config_test.py
@@ -1,0 +1,144 @@
+# -*- mode:python; coding:utf-8 -*-
+# Copyright (c) 2026 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for AwsConfigResultToOscalARTransformer.
+
+The fixture (tests/data/tasks/aws-config/aws-config-sample.json) is
+hand-constructed to match AWS Config's documented EvaluationResult schema
+field-for-field (EvaluationResultIdentifier / EvaluationResultQualifier /
+ComplianceType / ResultRecordedTime / ConfigRuleInvokedTime / Annotation /
+ResultToken), verified against
+https://docs.aws.amazon.com/config/latest/APIReference/API_EvaluationResult.html
+and API_EvaluationResultQualifier.html -- it is not a captured real AWS API
+response (no AWS account was used), but every field name and shape is real.
+"""
+import pathlib
+
+import pytest
+
+from trestle.transforms.implementations.aws_config import AwsConfigResultToOscalARTransformer
+
+test_data_dir = pathlib.Path('tests/data/tasks/aws-config').resolve()
+
+
+@pytest.fixture
+def sample_blob() -> str:
+    return (test_data_dir / 'aws-config-sample.json').read_text(encoding='utf-8')
+
+
+class TestTransform:
+    def test_produces_one_result_with_all_observations(self, sample_blob):
+        transformer = AwsConfigResultToOscalARTransformer()
+        results = transformer.transform(sample_blob)
+        assert len(results.root) == 1
+        result = results.root[0]
+        # 4 EvaluationResults in the fixture -> 4 Observations (one per evaluation, even
+        # when the same resource is evaluated more than once).
+        assert len(result.observations) == 4
+
+    def test_inventory_deduplicated_by_resource(self, sample_blob):
+        """The same security group appears in 2 EvaluationResults -> 1 inventory item."""
+        transformer = AwsConfigResultToOscalARTransformer()
+        results = transformer.transform(sample_blob)
+        result = results.root[0]
+        inventory_items = result.local_definitions.inventory_items
+        # 3 distinct resources: 2 S3 buckets + 1 security group (evaluated twice).
+        assert len(inventory_items) == 3
+        descriptions = {i.description for i in inventory_items}
+        assert descriptions == {
+            'AWS::S3::Bucket acme-prod-uploads',
+            'AWS::S3::Bucket acme-prod-assets',
+            'AWS::EC2::SecurityGroup sg-0a1b2c3d4e5f6g7h8',
+        }
+
+    def test_observation_subjects_reference_the_correct_inventory_item(self, sample_blob):
+        transformer = AwsConfigResultToOscalARTransformer()
+        results = transformer.transform(sample_blob)
+        result = results.root[0]
+        sg_item_uuid = next(
+            i.uuid for i in result.local_definitions.inventory_items
+            if 'sg-0a1b2c3d4e5f6g7h8' in i.description
+        )
+        sg_observations = [o for o in result.observations if 'restricted-ssh' in o.description]
+        assert len(sg_observations) == 2
+        for obs in sg_observations:
+            assert obs.subjects[0].subject_uuid == sg_item_uuid
+            assert obs.subjects[0].type.root == 'inventory-item'
+
+    def test_compliance_type_and_annotation_carried_in_props(self, sample_blob):
+        transformer = AwsConfigResultToOscalARTransformer()
+        results = transformer.transform(sample_blob)
+        result = results.root[0]
+        non_compliant = [
+            o for o in result.observations
+            if any(p.name == 'compliance-type' and p.value == 'NON_COMPLIANT' for p in o.props)
+        ]
+        # 3 of the 4 fixture entries are NON_COMPLIANT.
+        assert len(non_compliant) == 3
+        s3_obs = next(o for o in result.observations if 'acme-prod-uploads' in o.description)
+        assert 'public read access' in s3_obs.description
+        assert 'AWS::S3::Bucket' in s3_obs.description
+
+    def test_compliant_entry_has_no_annotation_but_valid_description(self, sample_blob):
+        transformer = AwsConfigResultToOscalARTransformer()
+        results = transformer.transform(sample_blob)
+        result = results.root[0]
+        compliant_obs = next(o for o in result.observations if 'acme-prod-assets' in o.description)
+        assert compliant_obs.description == 's3-bucket-public-read-prohibited (AWS::S3::Bucket acme-prod-assets)'
+
+    def test_methods_and_collected_are_set(self, sample_blob):
+        transformer = AwsConfigResultToOscalARTransformer()
+        results = transformer.transform(sample_blob)
+        result = results.root[0]
+        for obs in result.observations:
+            assert obs.methods == ['TEST-AUTOMATED']
+            assert obs.collected is not None
+
+    def test_reviewed_controls_present(self, sample_blob):
+        transformer = AwsConfigResultToOscalARTransformer()
+        results = transformer.transform(sample_blob)
+        result = results.root[0]
+        assert result.reviewed_controls is not None
+        assert result.reviewed_controls.control_selections is not None
+
+    def test_analysis_reports_correct_counts(self, sample_blob):
+        transformer = AwsConfigResultToOscalARTransformer()
+        results = transformer.transform(sample_blob)
+        assert results.root  # ensure transform ran before checking analysis
+        assert 'inventory: 3' in transformer.analysis
+        assert 'observations: 4' in transformer.analysis
+
+    def test_empty_evaluation_results_produces_result_with_no_observations(self):
+        transformer = AwsConfigResultToOscalARTransformer()
+        results = transformer.transform('{"EvaluationResults": []}')
+        assert len(results.root) == 1
+        assert results.root[0].observations is None
+
+    def test_missing_optional_fields_do_not_raise(self):
+        """A minimal, spec-legal EvaluationResult (all fields optional per AWS docs)."""
+        blob = '{"EvaluationResults": [{}]}'
+        transformer = AwsConfigResultToOscalARTransformer()
+        results = transformer.transform(blob)
+        result = results.root[0]
+        assert len(result.observations) == 1
+        assert result.observations[0].description == 'Unknown (Unknown Unknown)'
+
+    def test_result_round_trips_through_oscal_serialization(self, sample_blob):
+        """The Result must be genuinely OSCAL-schema-valid, not just pydantic-constructible."""
+        transformer = AwsConfigResultToOscalARTransformer()
+        results = transformer.transform(sample_blob)
+        serialized = results.oscal_serialize_json_bytes(pretty=True)
+        assert b'"aws-config-result"' not in serialized  # sanity: not leaking internal names
+        assert b'observations' in serialized
+        assert b'restricted-ssh' in serialized

--- a/tests/trestle/transforms/implementations/aws_config_test.py
+++ b/tests/trestle/transforms/implementations/aws_config_test.py
@@ -23,6 +23,7 @@ https://docs.aws.amazon.com/config/latest/APIReference/API_EvaluationResult.html
 and API_EvaluationResultQualifier.html -- it is not a captured real AWS API
 response (no AWS account was used), but every field name and shape is real.
 """
+
 import pathlib
 
 import pytest
@@ -67,8 +68,7 @@ class TestTransform:
         results = transformer.transform(sample_blob)
         result = results.root[0]
         sg_item_uuid = next(
-            i.uuid for i in result.local_definitions.inventory_items
-            if 'sg-0a1b2c3d4e5f6g7h8' in i.description
+            i.uuid for i in result.local_definitions.inventory_items if 'sg-0a1b2c3d4e5f6g7h8' in i.description
         )
         sg_observations = [o for o in result.observations if 'restricted-ssh' in o.description]
         assert len(sg_observations) == 2
@@ -81,7 +81,8 @@ class TestTransform:
         results = transformer.transform(sample_blob)
         result = results.root[0]
         non_compliant = [
-            o for o in result.observations
+            o
+            for o in result.observations
             if any(p.name == 'compliance-type' and p.value == 'NON_COMPLIANT' for p in o.props)
         ]
         # 3 of the 4 fixture entries are NON_COMPLIANT.

--- a/trestle/tasks/aws_config_result_to_oscal_ar.py
+++ b/trestle/tasks/aws_config_result_to_oscal_ar.py
@@ -130,10 +130,11 @@ class AwsConfigResultToOscalAR(TaskBase):
             except Exception:
                 logger.warning('config invalid "timestamp"')
                 return TaskOutcome(mode + 'failure')
-        # ensure output dir exists
-        opth.mkdir(exist_ok=True, parents=True)
-        # process
+        if not self._simulate:
+            opth.mkdir(exist_ok=True, parents=True)
         for ifile in sorted(ipth.iterdir()):
+            if not ifile.is_file() or ifile.suffix not in ['.json', '.jsn']:
+                continue
             blob = self._read_file(ifile)
             transformer = AwsConfigResultToOscalARTransformer()
             results = transformer.transform(blob)

--- a/trestle/tasks/aws_config_result_to_oscal_ar.py
+++ b/trestle/tasks/aws_config_result_to_oscal_ar.py
@@ -1,0 +1,168 @@
+# -*- mode:python; coding:utf-8 -*-
+# Copyright (c) 2026 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""OSCAL transformation tasks."""
+
+import configparser
+import logging
+import pathlib
+import traceback
+from typing import Optional
+
+from trestle.common import const
+from trestle.tasks.base_task import TaskBase
+from trestle.tasks.base_task import TaskOutcome
+from trestle.transforms.implementations.aws_config import AwsConfigResultToOscalARTransformer
+
+logger = logging.getLogger(__name__)
+
+
+class AwsConfigResultToOscalAR(TaskBase):
+    """
+    Task to convert AWS Config compliance evaluation results to OSCAL json.
+
+    Attributes:
+        name: Name of the task.
+    """
+
+    name = 'aws-config-result-to-oscal-ar'
+
+    def __init__(self, config_object: Optional[configparser.SectionProxy]) -> None:
+        """
+        Initialize trestle task aws-config-result-to-oscal-ar.
+
+        Args:
+            config_object: Config section associated with the task.
+        """
+        super().__init__(config_object)
+
+    def print_info(self) -> None:
+        """Print the help string."""
+        logger.info(f'Help information for {self.name} task.')
+        logger.info('')
+        logger.info(
+            'Purpose: Transform AWS Config compliance evaluation result files into Open Security Controls '
+            + 'Assessment Language (OSCAL) results objects and serialize to a file.'
+        )
+        logger.info('')
+        logger.info('Configuration flags sit under [task.aws-config-result-to-oscal-ar]:')
+        logger.info(
+            '  input-dir = (required) the path of the input directory comprising AWS Config compliance '
+            + 'evaluation result files. Each file is the json output of the AWS Config '
+            + '"get-compliance-details-by-config-rule" or "get-compliance-details-by-resource" API/CLI call, '
+            + 'i.e. a top-level "EvaluationResults" list of EvaluationResult objects.'
+        )
+        logger.info(
+            '  output-dir = (required) the path of the output directory comprising synthesized OSCAL .json files.'
+        )
+        logger.info('  output-overwrite = (optional) true [default] or false; replace existing output when true.')
+        logger.info(
+            '  quiet = (optional) true or false [default]; display file creations and results analysis when false.'
+        )
+        logger.info(
+            '  timestamp = (optional) timestamp for the Result/Observations in ISO 8601 format, such as '
+            + '2026-01-04T00:05:23+04:00 for example; if not specified the current time is used.'
+        )
+        logger.info('')
+        logger.info(
+            'Operation: A transformation is performed on one or more AWS Config compliance evaluation result '
+            + 'files to produce output in OSCAL partial results format.'
+        )
+
+    def simulate(self) -> TaskOutcome:
+        """Provide a simulated outcome."""
+        self._simulate = True
+        return self._transform()
+
+    def execute(self) -> TaskOutcome:
+        """Provide an actual outcome."""
+        self._simulate = False
+        return self._transform()
+
+    def _transform(self) -> TaskOutcome:
+        """Perform transformation."""
+        try:
+            return self._transform_work()
+        except Exception:
+            logger.info(traceback.format_exc())
+            mode = 'simulated-' if self._simulate else ''
+            return TaskOutcome(mode + 'failure')
+
+    def _transform_work(self) -> TaskOutcome:
+        """
+        Perform the transformation work.
+
+        Transformation work steps: read input, process, write output, display analysis.
+        """
+        mode = 'simulated-' if self._simulate else ''
+        if not self._config:
+            logger.warning('Config missing')
+            return TaskOutcome(mode + 'failure')
+        # config required input & output dirs
+        try:
+            idir = self._config['input-dir']
+            ipth = pathlib.Path(idir)
+            odir = self._config['output-dir']
+            opth = pathlib.Path(odir)
+        except KeyError as e:
+            logger.debug(f'key {e.args[0]} missing')
+            return TaskOutcome(mode + 'failure')
+        # config optional overwrite & quiet
+        self._overwrite = self._config.getboolean('output-overwrite', True)
+        quiet = self._config.get('quiet', False)
+        self._verbose = not self._simulate and not quiet
+        # config optional timestamp
+        timestamp = self._config.get('timestamp')
+        if timestamp is not None:
+            try:
+                AwsConfigResultToOscalARTransformer.set_timestamp(timestamp)
+            except Exception:
+                logger.warning('config invalid "timestamp"')
+                return TaskOutcome(mode + 'failure')
+        # ensure output dir exists
+        opth.mkdir(exist_ok=True, parents=True)
+        # process
+        for ifile in sorted(ipth.iterdir()):
+            blob = self._read_file(ifile)
+            transformer = AwsConfigResultToOscalARTransformer()
+            results = transformer.transform(blob)
+            oname = ifile.stem + '.oscal' + '.json'
+            ofile = opth / oname
+            if not self._overwrite and pathlib.Path(ofile).exists():
+                logger.warning(f'output: {ofile} already exists')
+                return TaskOutcome(mode + 'failure')
+            self._write_file(results, ofile)
+            self._show_analysis(transformer)
+        return TaskOutcome(mode + 'success')
+
+    def _read_file(self, ifile: str) -> str:
+        """Read raw input file."""
+        if not self._simulate and self._verbose:
+            logger.info(f'input: {ifile}')
+        with open(ifile, 'r', encoding=const.FILE_ENCODING) as fp:
+            blob = fp.read()
+        return blob
+
+    def _write_file(self, result: str, ofile: str) -> None:
+        """Write oscal results file."""
+        if not self._simulate:
+            if self._verbose:
+                logger.info(f'output: {ofile}')
+            result.oscal_write(pathlib.Path(ofile))
+
+    def _show_analysis(self, transformer: AwsConfigResultToOscalARTransformer) -> None:
+        """Show analysis."""
+        if not self._simulate and self._verbose:
+            for line in transformer.analysis:
+                logger.info(line)

--- a/trestle/transforms/implementations/aws_config.py
+++ b/trestle/transforms/implementations/aws_config.py
@@ -1,0 +1,228 @@
+# -*- mode:python; coding:utf-8 -*-
+# Copyright (c) 2026 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Facilitate OSCAL-AWS Config transformation.
+
+Transforms AWS Config compliance evaluation results (the JSON shape returned
+by the AWS Config ``get-compliance-details-by-config-rule`` /
+``get-compliance-details-by-resource`` APIs: a top-level ``EvaluationResults``
+list of ``EvaluationResult`` objects, see
+https://docs.aws.amazon.com/config/latest/APIReference/API_EvaluationResult.html)
+into OSCAL Assessment Results, following the same
+Task + ResultsTransformer + private results-factory shape used by
+``osco.py`` / ``tanium.py`` in this package.
+"""
+import json
+import logging
+import uuid
+from typing import Any, Dict, List, ValuesView
+
+from pydantic import AnyUrl
+
+from trestle.oscal.assessment_results import LocalDefinitions1, Observation, Result
+from trestle.oscal.common import (
+    ControlSelectionsAll,
+    IncludeAll,
+    InventoryItem,
+    Property,
+    ReviewedControls,
+    SubjectReference,
+)
+from trestle.transforms.results import Results
+from trestle.transforms.transformer_factory import ResultsTransformer
+
+logger = logging.getLogger(__name__)
+
+_COMPLIANCE_TYPES = {'COMPLIANT', 'NON_COMPLIANT', 'NOT_APPLICABLE', 'INSUFFICIENT_DATA'}
+
+
+class AwsConfigResultToOscalARTransformer(ResultsTransformer):
+    """Interface for AWS Config transformer."""
+
+    def __init__(self) -> None:
+        """Initialize."""
+        self._modes: Dict[str, Any] = {}
+
+    def set_modes(self, modes: Dict[str, Any]) -> None:
+        """Set the transformation modes."""
+        if modes is not None:
+            self._modes = modes
+
+    @property
+    def analysis(self) -> List[str]:
+        """Return statistics."""
+        return self._results_factory.analysis if hasattr(self, '_results_factory') else []
+
+    def transform(self, blob: str) -> Results:
+        """
+        Transform AWS Config evaluation results into OSCAL results.
+
+        Args:
+            blob: text (json) blob containing AWS Config evaluation results,
+                shaped as ``{"EvaluationResults": [EvaluationResult, ...]}``.
+
+        Returns:
+            Results containing a single OSCAL Result with one Observation
+            per input EvaluationResult.
+        """
+        self._results_factory = _OscalResultsFactory(self.get_timestamp())
+        data = json.loads(blob)
+        for evaluation_result in data.get('EvaluationResults', []):
+            self._results_factory.ingest(evaluation_result)
+        results = Results.model_construct(root=[])
+        results.root.append(self._results_factory.result)
+        return results
+
+
+class _OscalResultsFactory:
+    """Build OSCAL entities from AWS Config EvaluationResult objects."""
+
+    default_timestamp = ResultsTransformer.get_timestamp()
+
+    def __init__(self, timestamp: str = default_timestamp) -> None:
+        """Initialize."""
+        self._timestamp = timestamp
+        self._observation_list: List[Observation] = []
+        self._inventory_map: Dict[str, InventoryItem] = {}
+        self._ns = AnyUrl('https://oscal-compass.github.io/compliance-trestle/schemas/oscal/ar/aws-config')
+
+    @property
+    def inventory(self) -> ValuesView[InventoryItem]:
+        """OSCAL inventory."""
+        return self._inventory_map.values()
+
+    @property
+    def local_definitions(self) -> LocalDefinitions1:
+        """OSCAL local definitions."""
+        local_def_data = {'inventory-items': list(self.inventory)}
+        return LocalDefinitions1.model_validate(local_def_data)
+
+    @property
+    def observations(self) -> List[Observation]:
+        """OSCAL observations."""
+        return self._observation_list
+
+    @property
+    def reviewed_controls(self) -> ReviewedControls:
+        """OSCAL reviewed controls.
+
+        AWS Config rules are not, by default, mapped to a specific OSCAL
+        catalog's control identifiers -- that mapping is organization- and
+        catalog-specific. Following the same approach as the OSCO
+        transformer for the analogous case, an include-all control
+        selection is emitted here; downstream tooling that has the
+        rule-to-control mapping can refine this.
+        """
+        include_all = IncludeAll()
+        control_sel_all = ControlSelectionsAll.model_validate({'include-all': include_all})
+        reviewed_controls_data = {'control-selections': [control_sel_all]}
+        return ReviewedControls.model_validate(reviewed_controls_data)
+
+    @property
+    def result(self) -> Result:
+        """OSCAL result."""
+        result_data = {
+            'uuid': str(uuid.uuid4()),
+            'title': 'AWS Config Compliance Evaluation',
+            'description': 'AWS Config Rule Compliance Evaluation Results',
+            'start': self._timestamp,
+            'end': self._timestamp,
+            'reviewed-controls': self.reviewed_controls,
+        }
+        if self.inventory:
+            result_data['local-definitions'] = self.local_definitions
+        if self.observations:
+            result_data['observations'] = self.observations
+        return Result.model_validate(result_data)
+
+    @property
+    def analysis(self) -> List[str]:
+        """OSCAL statistics."""
+        return [f'inventory: {len(self.inventory)}', f'observations: {len(self.observations)}']
+
+    def _inventory_key(self, resource_type: str, resource_id: str) -> str:
+        return f'{resource_type}::{resource_id}'
+
+    def _inventory_extract(self, resource_type: str, resource_id: str) -> str:
+        """Get (or create) the inventory-item uuid for an AWS resource, returning its uuid."""
+        key = self._inventory_key(resource_type, resource_id)
+        if key not in self._inventory_map:
+            props = [
+                Property.model_construct(name='resource-type', value=resource_type, ns=self._ns),
+                Property.model_construct(name='resource-id', value=resource_id, ns=self._ns),
+            ]
+            item = InventoryItem.model_validate(
+                {
+                    'uuid': str(uuid.uuid4()),
+                    'description': f'{resource_type} {resource_id}',
+                    'props': props,
+                }
+            )
+            self._inventory_map[key] = item
+        return self._inventory_map[key].uuid
+
+    def _observation_properties(self, evaluation_result: Dict[str, Any]) -> List[Property]:
+        """Build the props list for one EvaluationResult."""
+        props = []
+        qualifier = evaluation_result.get('EvaluationResultIdentifier', {}).get('EvaluationResultQualifier', {})
+        compliance_type = evaluation_result.get('ComplianceType')
+        if compliance_type is not None and compliance_type not in _COMPLIANCE_TYPES:
+            logger.warning(f'unexpected ComplianceType {compliance_type!r}')
+        for name, value in (
+            ('config-rule-name', qualifier.get('ConfigRuleName')),
+            ('evaluation-mode', qualifier.get('EvaluationMode')),
+            ('compliance-type', compliance_type),
+            ('config-rule-invoked-time', evaluation_result.get('ConfigRuleInvokedTime')),
+            ('result-token', evaluation_result.get('ResultToken')),
+        ):
+            if value is not None:
+                class_ = 'aws_config_compliance' if name == 'compliance-type' else None
+                if class_:
+                    props.append(Property.model_construct(name=name, value=str(value), ns=self._ns, class_=class_))
+                else:
+                    props.append(Property.model_construct(name=name, value=str(value), ns=self._ns))
+        return props
+
+    def ingest(self, evaluation_result: Dict[str, Any]) -> None:
+        """Ingest one AWS Config EvaluationResult, producing an Observation."""
+        qualifier = evaluation_result.get('EvaluationResultIdentifier', {}).get('EvaluationResultQualifier', {})
+        resource_type = qualifier.get('ResourceType', 'Unknown')
+        resource_id = qualifier.get('ResourceId', 'Unknown')
+        rule_name = qualifier.get('ConfigRuleName', 'Unknown')
+        inventory_ref = self._inventory_extract(resource_type, resource_id)
+
+        subject_reference = SubjectReference.model_validate(
+            {'subject-uuid': inventory_ref, 'type': 'inventory-item'}
+        )
+        annotation = evaluation_result.get('Annotation')
+        description = f'{rule_name} ({resource_type} {resource_id})'
+        if annotation:
+            description = f'{description}: {annotation}'
+        collected = (
+            evaluation_result.get('ResultRecordedTime')
+            or evaluation_result.get('ConfigRuleInvokedTime')
+            or self._timestamp
+        )
+        observation_data = {
+            'uuid': str(uuid.uuid4()),
+            'description': description,
+            'methods': ['TEST-AUTOMATED'],
+            'collected': collected,
+            'subjects': [subject_reference],
+        }
+        props = self._observation_properties(evaluation_result)
+        if props:
+            observation_data['props'] = props
+        observation = Observation.model_validate(observation_data)
+        self._observation_list.append(observation)

--- a/trestle/transforms/implementations/aws_config.py
+++ b/trestle/transforms/implementations/aws_config.py
@@ -23,6 +23,7 @@ into OSCAL Assessment Results, following the same
 Task + ResultsTransformer + private results-factory shape used by
 ``osco.py`` / ``tanium.py`` in this package.
 """
+
 import json
 import logging
 import uuid
@@ -88,11 +89,9 @@ class AwsConfigResultToOscalARTransformer(ResultsTransformer):
 class _OscalResultsFactory:
     """Build OSCAL entities from AWS Config EvaluationResult objects."""
 
-    default_timestamp = ResultsTransformer.get_timestamp()
-
-    def __init__(self, timestamp: str = default_timestamp) -> None:
+    def __init__(self, timestamp: str | None = None) -> None:
         """Initialize."""
-        self._timestamp = timestamp
+        self._timestamp = timestamp if timestamp is not None else ResultsTransformer.get_timestamp()
         self._observation_list: List[Observation] = []
         self._inventory_map: Dict[str, InventoryItem] = {}
         self._ns = AnyUrl('https://oscal-compass.github.io/compliance-trestle/schemas/oscal/ar/aws-config')
@@ -163,11 +162,7 @@ class _OscalResultsFactory:
                 Property.model_construct(name='resource-id', value=resource_id, ns=self._ns),
             ]
             item = InventoryItem.model_validate(
-                {
-                    'uuid': str(uuid.uuid4()),
-                    'description': f'{resource_type} {resource_id}',
-                    'props': props,
-                }
+                {'uuid': str(uuid.uuid4()), 'description': f'{resource_type} {resource_id}', 'props': props}
             )
             self._inventory_map[key] = item
         return self._inventory_map[key].uuid
@@ -187,6 +182,10 @@ class _OscalResultsFactory:
             ('result-token', evaluation_result.get('ResultToken')),
         ):
             if value is not None:
+                # Only compliance-type is classed for downstream filtering,
+                # matching osco.py's scc_result pattern. Prop names stay
+                # hyphenated (OSCAL); class_ uses the underscored identifier
+                # style of osco's scc_* values.
                 class_ = 'aws_config_compliance' if name == 'compliance-type' else None
                 if class_:
                     props.append(Property.model_construct(name=name, value=str(value), ns=self._ns, class_=class_))
@@ -202,9 +201,7 @@ class _OscalResultsFactory:
         rule_name = qualifier.get('ConfigRuleName', 'Unknown')
         inventory_ref = self._inventory_extract(resource_type, resource_id)
 
-        subject_reference = SubjectReference.model_validate(
-            {'subject-uuid': inventory_ref, 'type': 'inventory-item'}
-        )
+        subject_reference = SubjectReference.model_validate({'subject-uuid': inventory_ref, 'type': 'inventory-item'})
         annotation = evaluation_result.get('Annotation')
         description = f'{rule_name} ({resource_type} {resource_id})'
         if annotation:

--- a/trestle/transforms/transformer_singleton.py
+++ b/trestle/transforms/transformer_singleton.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """Create the singleton transformer factory here."""
 
+from trestle.transforms.implementations.aws_config import AwsConfigResultToOscalARTransformer
 from trestle.transforms.implementations.osco import OscalProfileToOscoProfileTransformer
 from trestle.transforms.implementations.osco import OscoResultToOscalARTransformer
 from trestle.transforms.implementations.tanium import TaniumResultToOscalARTransformer
@@ -24,5 +25,6 @@ transformer_factory = TransformerFactory()
 # results
 transformer_factory.register_transformer('osco', OscoResultToOscalARTransformer)
 transformer_factory.register_transformer('tanium', TaniumResultToOscalARTransformer)
+transformer_factory.register_transformer('aws-config', AwsConfigResultToOscalARTransformer)
 # profiles
 transformer_factory.register_transformer('oscal-profile-to-osco-profile', OscalProfileToOscoProfileTransformer)


### PR DESCRIPTION
## What this adds

A new `aws-config-result-to-oscal-ar` task + `AwsConfigResultToOscalARTransformer`, converting AWS Config compliance evaluation results into OSCAL Assessment Results — following the same Task + `ResultsTransformer` + private results-factory shape as the existing `tanium`/`osco` AR tasks (closest analogues I found and mirrored).

**Input**: the JSON shape returned by AWS Config's `get-compliance-details-by-config-rule` / `get-compliance-details-by-resource` APIs (`{"EvaluationResults": [EvaluationResult, ...]}`). Every field name was verified against AWS's own API reference rather than assumed:
- https://docs.aws.amazon.com/config/latest/APIReference/API_EvaluationResult.html
- https://docs.aws.amazon.com/config/latest/APIReference/API_EvaluationResultQualifier.html

**Output**: one `Result` per input file, one `Observation` per `EvaluationResult` (`methods: ['TEST-AUTOMATED']`), an `InventoryItem` per distinct AWS resource — de-duplicated when the same resource is evaluated more than once — and `compliance-type` / `config-rule-name` / `evaluation-mode` / `config-rule-invoked-time` / `result-token` carried as `props`.

Control mapping is intentionally `include-all`: AWS Config rules aren't mapped to specific catalog controls out of the box (that mapping is org/catalog-specific), so I followed the same approach OSCO takes for the analogous case rather than fabricate a mapping.

## Testing

Editable-installed the real package (Python 3.12) and ran everything against it, not just against my own code:

- **11 transformer-level tests** (`tests/trestle/transforms/implementations/aws_config_test.py`) against a fixture (`tests/data/tasks/aws-config/aws-config-sample.json`) hand-built to match AWS's documented schema field-for-field — covering inventory de-duplication, subject→inventory-item linkage, compliance-type/annotation props, missing-optional-fields handling, and a full `oscal_serialize_json_bytes()` round-trip.
- **6 task-level tests** (`tests/trestle/tasks/aws_config_result_to_oscal_ar_test.py`) exercising the real `TaskBase.execute()`/`simulate()` path with actual file I/O, `output-overwrite` handling, and the missing-config failure mode.
- Ran the task through `execute()` directly against a temp workspace and inspected the written file — genuine, valid OSCAL JSON.
- Confirmed `trestle task -l` (in an initialized trestle workspace) lists `aws-config-result-to-oscal-ar` correctly alongside `osco-result-to-oscal-ar` and `tanium-result-to-oscal-ar`.
- `flake8` clean on both new source files.

```
17 passed in 2.60s
```

**Two real bugs caught and fixed by this testing before submission** (leaving them in the commit message for transparency): my first draft gave `InventoryItem` a `status` field, which doesn't exist on that model (I'd confused it with `SystemComponent`'s field) — pydantic rejected it immediately. Second, OSCAL's `Observation.props` requires `min_length=1` when present, so an empty list has to be omitted from the payload entirely rather than passed as `[]`.

## Known gap — please advise

Same as the transformer/task pattern in `osco.py`, `content-type` handling for compressed/paginated AWS Config exports isn't handled — this covers the single-file JSON case. Happy to extend if there's a preferred shape for larger exports (e.g. AWS Config's S3 delivery channel snapshots, which paginate differently than the CLI's direct API output).

Also open to feedback on whether `ReviewedControls` should stay `include-all` or whether there's a preferred convention for AWS Config → OSCAL catalog control mapping I should follow instead.