### PR TITLE
fix: raise minimum pydantic version to 2.11.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "paramiko==5.0.0",
     "ruamel.yaml",
     "furl",
-    "pydantic[email]>=2.0.0",
+    "pydantic[email]>=2.11.0",
     "python-dotenv>=0.10.4",
     "python-frontmatter",
     "pywin32 >= 1.0;platform_system=='Windows'",


### PR DESCRIPTION
Fix #2339

Raise the minimum supported pydantic version from `>=2.0.0` to `>=2.11.0`
in `pyproject.toml`. `by_alias`, `by_name` and `extra` were added to
`BaseModel.model_validate` in pydantic 2.11.0 (released 2025-03-27), and
`TrestleBaseModel.model_validate` forwards them to `super()`. With the lower
bound at 2.11.0 the forwarded keyword arguments are always supported.