### PR TITLE
feat: add digest algorithm agility to signing

### DIFF
--- a/docs/predicates/oscal-package/v1.md
+++ b/docs/predicates/oscal-package/v1.md
@@ -22,7 +22,7 @@ The package manifest format is defined by the [OSCAL Package Manifest v1 JSON Sc
 `trestle sign-manifest` creates a detached DSSE envelope. The envelope payload is an in-toto Statement that records:
 
 - the artifact names listed in the package manifest
-- the SHA-256 digest of each artifact's RFC 8785 canonical JSON bytes
+- the selected digest of each artifact's RFC 8785 canonical JSON bytes (SHA-256 by default)
 - the package predicate type and predicate fields described below
 
 The DSSE signature is made over the DSSE pre-authentication encoding of the Statement payload. The package manifest and listed JSON artifacts are not modified.
@@ -31,7 +31,7 @@ The raw manifest bytes are not signed directly. Trestle validates the manifest, 
 
 ## Statement
 
-The DSSE payload is a base64-encoded in-toto Statement with one subject for each package artifact:
+The DSSE payload is a base64-encoded in-toto Statement with one subject for each package artifact. This example uses the default SHA-256 algorithm:
 
 ```json
 {
@@ -72,6 +72,10 @@ The DSSE payload is a base64-encoded in-toto Statement with one subject for each
 ```
 
 ## Predicate fields
+
+The selected digest algorithm is recorded in each subject's `digest` key, not in the package predicate or input manifest. Signing uses the same algorithm for every artifact. After verifying the DSSE signature, verification automatically detects the algorithm, requiring exactly one digest per subject and the same supported algorithm across all subjects. An explicit `--digest-algorithm` instead requires that algorithm for every subject, including when a subject contains multiple digests, without falling back to another digest. Existing SHA-256 package envelopes retain their format.
+
+Supported digest keys are `sha224`, `sha256`, `sha384`, `sha512`, `sha3_224`, `sha3_256`, `sha3_384`, and `sha3_512`. See [Digest algorithms](../../tutorials/cli.md#digest-algorithms) for CLI selection.
 
 | Field             | Description                                                                                                   |
 | ----------------- | ------------------------------------------------------------------------------------------------------------- |

--- a/docs/predicates/oscal-signing/v1.md
+++ b/docs/predicates/oscal-signing/v1.md
@@ -22,7 +22,7 @@ For command usage, see the [`trestle sign` and `trestle verify` CLI documentatio
 `trestle sign` creates a detached DSSE envelope. The envelope payload is an in-toto Statement that records:
 
 - the subject file name
-- the SHA-256 digest of the RFC 8785 canonical JSON bytes
+- the selected digest of the RFC 8785 canonical JSON bytes (SHA-256 by default)
 - the predicate type and predicate fields described below
 
 The DSSE signature is made over the DSSE pre-authentication encoding of the
@@ -30,7 +30,7 @@ Statement payload. The original JSON file is not modified.
 
 ## Statement
 
-The DSSE payload is a base64-encoded in-toto Statement with exactly one subject:
+The DSSE payload is a base64-encoded in-toto Statement with exactly one subject. This example uses the default SHA-256 algorithm:
 
 ```json
 {
@@ -58,6 +58,10 @@ The DSSE payload is a base64-encoded in-toto Statement with exactly one subject:
 | Field              | Description                                                                                                                                     |
 | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
 | `canonicalization` | The canonicalization algorithm applied before hashing. Trestle uses `RFC8785`.                                                                  |
-| `digestAlgorithm`  | The digest algorithm used over the canonical JSON bytes. Trestle uses `sha256`.                                                                 |
+| `digestAlgorithm`  | The selected digest algorithm in in-toto notation, such as `sha256`, `sha384`, or `sha3_256`. Defaults to `sha256`.                             |
 | `digestSource`     | The bytes that were hashed. `canonical-json` means the digest was computed over the RFC 8785 canonical JSON bytes, not the original file bytes. |
 | `tool`             | The producer of the predicate. Trestle writes `compliance-trestle`.                                                                             |
+
+Supported digest names are `sha224`, `sha256`, `sha384`, `sha512`, `sha3_224`, `sha3_256`, `sha3_384`, and `sha3_512`. After verifying the DSSE signature, verification detects the algorithm from the authenticated predicate's `digestAlgorithm` and checks the corresponding subject digest. An explicit `--digest-algorithm` additionally requires the predicate to identify that algorithm. The algorithm metadata is covered by the DSSE signature.
+
+See [Digest algorithms](../../tutorials/cli.md#digest-algorithms) for CLI selection and compatibility with existing SHA-256 envelopes.

--- a/docs/tutorials/cli.md
+++ b/docs/tutorials/cli.md
@@ -604,7 +604,7 @@ references to links, and corresponding links in the backmatter.
 
 ## `trestle sign`
 
-Trestle sign writes a detached DSSE envelope for a JSON file. It canonicalizes the JSON using RFC 8785, computes a SHA-256 digest, records that digest in an in-toto Statement, and signs the Statement with a PEM private key.
+Trestle sign writes a detached DSSE envelope for a JSON file. It canonicalizes the JSON using RFC 8785, computes an artifact digest (SHA-256 by default), records that digest in an in-toto Statement, and signs the Statement with a PEM private key.
 
 The sign and verify commands are beta features. Enable them before use:
 
@@ -653,9 +653,26 @@ The `--subject-name` option records a subject name other than the input file nam
 
 The signed Statement uses the [OSCAL signing predicate](../predicates/oscal-signing/v1.md).
 
+### Digest algorithms
+
+The `sign`, `verify`, `sign-manifest`, and `verify-manifest` commands accept `--digest-algorithm`. The supported names come from OSCAL's `Algorithm` enum: `SHA-224`, `SHA-256`, `SHA-384`, `SHA-512`, `SHA3-224`, `SHA3-256`, `SHA3-384`, and `SHA3-512`.
+
+Signing defaults to SHA-256. Verification automatically detects the algorithm from the authenticated Statement after verifying its DSSE signature. Existing SHA-256 envelopes and commands without the new option remain compatible. To sign with another algorithm:
+
+```bash
+trestle sign -f catalog.json --private-key private.pem \
+  --digest-algorithm SHA-384 -o catalog.sha384.dsse
+trestle verify -f catalog.json --signature catalog.sha384.dsse \
+  --public-key public.pem
+```
+
+On either verification command, optionally pass `--digest-algorithm SHA-384` to require that specific algorithm instead of automatic detection. Unsupported algorithms, a mismatch with an explicit restriction, or a changed artifact cause failure. Older Trestle versions that only support SHA-256 cannot verify envelopes using other digests.
+
+This option selects the artifact hash, not the private key's signature algorithm. RFC 8785 canonicalization is unchanged. Statements use in-toto digest names such as `sha384` and `sha3_256`.
+
 ## `trestle verify`
 
-Trestle verify checks a JSON file against a detached DSSE envelope and a PEM public key. Verification checks the DSSE signature, the predicate fields, and the SHA-256 digest of the RFC 8785 canonical JSON bytes.
+Trestle verify checks a JSON file against a detached DSSE envelope and a PEM public key. Verification checks the DSSE signature, the predicate fields, and the digest of the RFC 8785 canonical JSON bytes using the algorithm recorded in the authenticated predicate.
 
 ```bash
 trestle verify \
@@ -665,6 +682,8 @@ trestle verify \
 ```
 
 If signing used `--subject-name`, pass the same value during verification.
+
+No digest option is required for verification. Use `--digest-algorithm` only to restrict the accepted algorithm. See [Digest algorithms](#digest-algorithms).
 
 ## `trestle generate-manifest`
 
@@ -697,7 +716,7 @@ Automatic discovery accepts at most 1,000 artifacts, 64 dependency levels, 50 Mi
 
 ## `trestle sign-manifest`
 
-Trestle sign-manifest writes a detached DSSE envelope for a JSON package manifest. The manifest lists related JSON artifacts. Trestle canonicalizes each artifact using RFC 8785, records each SHA-256 digest in an in-toto Statement, and signs the package Statement with a PEM private key.
+Trestle sign-manifest writes a detached DSSE envelope for a JSON package manifest. The manifest lists related JSON artifacts. Trestle canonicalizes each artifact using RFC 8785, records each digest (SHA-256 by default) in an in-toto Statement, and signs the package Statement with a PEM private key.
 
 Enable the package manifest beta feature before use:
 
@@ -749,6 +768,17 @@ For an encrypted private key, use `--key-password-env` as with `trestle sign`.
 
 The signed package Statement uses the [OSCAL package predicate](../predicates/oscal-package/v1.md).
 
+Use `--digest-algorithm` to select the same digest algorithm for every artifact in the package:
+
+```bash
+trestle sign-manifest --manifest package.json --private-key private.pem \
+  --digest-algorithm SHA3-256 -o package.sha3.dsse
+trestle verify-manifest --manifest package.json --signature package.sha3.dsse \
+  --public-key public.pem
+```
+
+The package manifest schema is unchanged. `generate-manifest` discovers files rather than computing their signing digests, so it does not need this option. The URL hash used to name downloaded files is independent of the selected artifact digest.
+
 ## `trestle verify-manifest`
 
 Trestle verify-manifest checks a JSON package manifest against a detached DSSE envelope and a PEM public key. Verification checks the package DSSE signature, requires the manifest metadata and artifact set to match the signed package Statement, and confirms that each current JSON artifact digest matches its signed digest.
@@ -759,6 +789,8 @@ trestle verify-manifest \
   --signature package.dsse \
   --public-key public.pem
 ```
+
+After authenticating the package Statement, verification detects the algorithm from its subjects. Automatic detection requires exactly one digest per subject and the same supported algorithm across all subjects. Use `--digest-algorithm` to require a specific algorithm for every artifact; this also permits selecting one algorithm when subjects contain multiple digests. There is no fallback to another algorithm if the required digest is missing or incorrect. See [Digest algorithms](#digest-algorithms).
 
 This first manifest signing flow verifies package digests only. Per-document signature requirements are expected to be added in a later workflow.
 

--- a/tests/trestle/core/canonicalization_test.py
+++ b/tests/trestle/core/canonicalization_test.py
@@ -15,7 +15,9 @@
 # limitations under the License.
 """Tests for canonical JSON helpers."""
 
+import hashlib
 import pathlib
+from typing import Any, Callable
 
 import pytest
 
@@ -25,9 +27,55 @@ from trestle.common.err import TrestleError
 from trestle.core.canonicalization import (
     canonicalize_json_object,
     canonicalize_json_text,
+    digest_algorithm_name,
+    digest_hex,
     load_canonical_json_file,
+    parse_digest_algorithm,
     sha256_digest_hex,
 )
+from trestle.oscal.common import Algorithm
+
+
+@pytest.mark.parametrize(
+    'algorithm, constructor',
+    [
+        (Algorithm.SHA_224, hashlib.sha224),
+        (Algorithm.SHA_256, hashlib.sha256),
+        (Algorithm.SHA_384, hashlib.sha384),
+        (Algorithm.SHA_512, hashlib.sha512),
+        (Algorithm.SHA3_224, hashlib.sha3_224),
+        (Algorithm.SHA3_256, hashlib.sha3_256),
+        (Algorithm.SHA3_384, hashlib.sha3_384),
+        (Algorithm.SHA3_512, hashlib.sha3_512),
+    ],
+)
+def test_digest_algorithms(algorithm: Algorithm, constructor: Callable[[bytes], Any]) -> None:
+    """Each OSCAL algorithm should map to the correct hash and in-toto name."""
+    expected = constructor(b'abc')
+    assert digest_algorithm_name(algorithm) == expected.name
+    assert digest_hex(b'abc', algorithm) == expected.hexdigest()
+    assert parse_digest_algorithm(expected.name) == algorithm
+
+
+def test_digest_algorithm_preserves_sha256() -> None:
+    """The generic helper and compatibility wrapper should preserve SHA-256 output."""
+    expected = 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad'
+    assert digest_hex(b'abc', Algorithm.SHA_256) == expected
+    assert sha256_digest_hex(b'abc') == expected
+
+
+@pytest.mark.parametrize('algorithm', ['md5', 'sha1', 'SHA-256', None, []])
+def test_digest_rejects_unsupported_algorithms(algorithm: Any) -> None:
+    """Programmatic callers must select an approved OSCAL Algorithm enum member."""
+    with pytest.raises(TrestleError, match='Unsupported digest algorithm'):
+        digest_hex(b'abc', algorithm)
+
+
+@pytest.mark.parametrize('name', ['md5', 'sha1', 'SHA-256', '', None, [], {}])
+def test_parse_digest_algorithm_rejects_unsupported_names(name: Any) -> None:
+    """Signed algorithm metadata must identify a supported in-toto digest name."""
+    with pytest.raises(TrestleError, match='Unsupported digest algorithm'):
+        parse_digest_algorithm(name)
 
 
 def test_canonicalization_is_stable_for_equivalent_json() -> None:

--- a/tests/trestle/core/commands/sign_manifest_verify_manifest_test.py
+++ b/tests/trestle/core/commands/sign_manifest_verify_manifest_test.py
@@ -19,7 +19,7 @@ import base64
 import json
 import pathlib
 import sys
-from typing import Tuple
+from typing import Optional, Tuple
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
@@ -31,6 +31,7 @@ from trestle.common.err import TrestleError
 from trestle.cli import Trestle
 from trestle.core.commands.common.return_codes import CmdReturnCodes
 from trestle.core.commands.sign_manifest import SignManifestCmd
+from trestle.oscal.common import Algorithm
 
 
 def write_ed25519_key_pair(
@@ -176,8 +177,12 @@ def test_sign_manifest_and_verify_manifest_accept_one_time_beta_flag(
     assert not (tmp_path / 'xdg-config').exists()
 
 
-def test_sign_manifest_and_verify_manifest_round_trip(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
-    """Sign-manifest should write a DSSE envelope that verify-manifest accepts."""
+@pytest.mark.parametrize('algorithm', [None] + [algorithm.value for algorithm in Algorithm])
+def test_sign_manifest_and_verify_manifest_round_trip(
+    tmp_path: pathlib.Path, monkeypatch: MonkeyPatch, algorithm: Optional[str]
+) -> None:
+    """Package commands should support the default and every explicit digest algorithm."""
+    algorithm_args = ['--digest-algorithm', algorithm] if algorithm else []
     private_key_path, public_key_path = write_ed25519_key_pair(tmp_path)
     manifest_path = write_package_manifest(tmp_path)
     envelope_path = tmp_path / 'package.dsse'
@@ -194,7 +199,8 @@ def test_sign_manifest_and_verify_manifest_round_trip(tmp_path: pathlib.Path, mo
             str(private_key_path),
             '-o',
             str(envelope_path),
-        ],
+        ]
+        + algorithm_args,
     )
     assert Trestle().run() == CmdReturnCodes.SUCCESS.value
     assert envelope_path.exists()
@@ -222,6 +228,33 @@ def test_sign_manifest_and_verify_manifest_round_trip(tmp_path: pathlib.Path, mo
         ],
     )
     assert Trestle().run() == CmdReturnCodes.SUCCESS.value
+
+    monkeypatch.setattr(sys, 'argv', sys.argv + algorithm_args)
+    assert Trestle().run() == CmdReturnCodes.SUCCESS.value
+
+    other_algorithm = 'SHA-512' if algorithm in (None, 'SHA-256') else 'SHA-256'
+    monkeypatch.setattr(sys, 'argv', sys.argv + ['--digest-algorithm', other_algorithm])
+    assert Trestle().run() == CmdReturnCodes.COMMAND_ERROR.value
+
+
+@pytest.mark.parametrize('command', ['sign-manifest', 'verify-manifest'])
+@pytest.mark.parametrize('algorithm', ['MD5', 'SHA-1', 'unknown'])
+def test_manifest_commands_reject_unsupported_digest_algorithms(
+    monkeypatch: MonkeyPatch, capsys: pytest.CaptureFixture[str], command: str, algorithm: str
+) -> None:
+    """Unsupported digest names should fail argument parsing, before accessing files."""
+    command_args = (
+        ['--private-key', 'private.pem', '-o', 'package.dsse']
+        if command == 'sign-manifest'
+        else ['--public-key', 'public.pem', '--signature', 'package.dsse']
+    )
+    monkeypatch.setattr(
+        sys, 'argv', ['trestle', command, '--manifest', 'package.json', '--digest-algorithm', algorithm] + command_args
+    )
+    with pytest.raises(SystemExit) as error:
+        Trestle().run()
+    assert error.value.code == 2
+    assert 'invalid choice' in capsys.readouterr().err
 
 
 def test_sign_manifest_supports_encrypted_private_key(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:

--- a/tests/trestle/core/commands/sign_verify_test.py
+++ b/tests/trestle/core/commands/sign_verify_test.py
@@ -18,7 +18,7 @@
 import json
 import pathlib
 import sys
-from typing import Tuple
+from typing import Optional, Tuple
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
@@ -30,6 +30,7 @@ from tests import test_utils
 import trestle.common.const as const
 from trestle.cli import Trestle
 from trestle.core.commands.common.return_codes import CmdReturnCodes
+from trestle.oscal.common import Algorithm
 
 
 def write_ed25519_key_pair(
@@ -129,8 +130,10 @@ def test_sign_and_verify_accept_one_time_beta_flag(tmp_path: pathlib.Path, monke
     assert not (tmp_path / 'xdg-config').exists()
 
 
-def test_sign_and_verify_round_trip(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
-    """Sign should write a DSSE sidecar that verify accepts."""
+@pytest.mark.parametrize('algorithm', [None] + [algorithm.value for algorithm in Algorithm])
+def test_sign_and_verify_round_trip(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch, algorithm: Optional[str]) -> None:
+    """Sign and verify should support the default and every explicit digest algorithm."""
+    algorithm_args = ['--digest-algorithm', algorithm] if algorithm else []
     private_key_path, public_key_path = write_ed25519_key_pair(tmp_path)
     input_path = tmp_path / 'catalog.json'
     envelope_path = tmp_path / 'catalog.json.dsse'
@@ -139,7 +142,8 @@ def test_sign_and_verify_round_trip(tmp_path: pathlib.Path, monkeypatch: MonkeyP
     monkeypatch.setattr(
         sys,
         'argv',
-        ['trestle', 'sign', '-f', str(input_path), '--private-key', str(private_key_path), '-o', str(envelope_path)],
+        ['trestle', 'sign', '-f', str(input_path), '--private-key', str(private_key_path), '-o', str(envelope_path)]
+        + algorithm_args,
     )
     assert Trestle().run() == CmdReturnCodes.SUCCESS.value
     assert input_path.read_text(encoding=const.FILE_ENCODING) == '{"b":2,"a":1}'
@@ -162,6 +166,33 @@ def test_sign_and_verify_round_trip(tmp_path: pathlib.Path, monkeypatch: MonkeyP
         ],
     )
     assert Trestle().run() == CmdReturnCodes.SUCCESS.value
+
+    monkeypatch.setattr(sys, 'argv', sys.argv + algorithm_args)
+    assert Trestle().run() == CmdReturnCodes.SUCCESS.value
+
+    other_algorithm = 'SHA-512' if algorithm in (None, 'SHA-256') else 'SHA-256'
+    monkeypatch.setattr(sys, 'argv', sys.argv + ['--digest-algorithm', other_algorithm])
+    assert Trestle().run() == CmdReturnCodes.COMMAND_ERROR.value
+
+
+@pytest.mark.parametrize('command', ['sign', 'verify'])
+@pytest.mark.parametrize('algorithm', ['MD5', 'SHA-1', 'unknown'])
+def test_signing_commands_reject_unsupported_digest_algorithms(
+    monkeypatch: MonkeyPatch, capsys: pytest.CaptureFixture[str], command: str, algorithm: str
+) -> None:
+    """Unsupported digest names should fail argument parsing, before accessing files."""
+    command_args = (
+        ['--private-key', 'private.pem', '-o', 'file.dsse']
+        if command == 'sign'
+        else ['--public-key', 'public.pem', '--signature', 'file.dsse']
+    )
+    monkeypatch.setattr(
+        sys, 'argv', ['trestle', command, '-f', 'file.json', '--digest-algorithm', algorithm] + command_args
+    )
+    with pytest.raises(SystemExit) as error:
+        Trestle().run()
+    assert error.value.code == 2
+    assert 'invalid choice' in capsys.readouterr().err
 
 
 def test_sign_and_verify_real_nist_800_53_catalog(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:

--- a/tests/trestle/core/signing_manifest_test.py
+++ b/tests/trestle/core/signing_manifest_test.py
@@ -26,13 +26,14 @@ from cryptography.hazmat.primitives.asymmetric import ed25519
 
 import trestle.common.const as const
 from trestle.common.err import TrestleError
+from trestle.core.canonicalization import digest_algorithm_name, digest_hex, load_canonical_json_file
 from trestle.core.signing import (
-    DIGEST_ALGORITHM,
     IN_TOTO_STATEMENT_TYPE,
     load_pem_private_key_signer,
     load_pem_public_key,
     sign_in_toto_statement,
 )
+from trestle.oscal.common import Algorithm
 from trestle.core.signing_manifest import (
     MANIFEST_VERSION,
     PACKAGE_PREDICATE_TYPE,
@@ -111,10 +112,102 @@ def test_create_manifest_envelope_contains_package_statement(tmp_path: pathlib.P
         ],
     }
     assert {subject['name'] for subject in statement['subject']} == {'ssp.json', 'profile.json', 'catalog.json'}
-    assert all(DIGEST_ALGORITHM in subject['digest'] for subject in statement['subject'])
+    assert all('sha256' in subject['digest'] for subject in statement['subject'])
 
     public_key = load_pem_public_key(public_key_path)
     verify_manifest_envelope(manifest, envelope, public_key)
+
+
+@pytest.mark.parametrize('algorithm', list(Algorithm))
+@pytest.mark.parametrize('require_algorithm', [False, True])
+def test_manifest_digest_algorithms(tmp_path: pathlib.Path, algorithm: Algorithm, require_algorithm: bool) -> None:
+    """All package subjects must use the selected digest, including during verification."""
+    private_key_path, public_key_path = write_ed25519_key_pair(tmp_path)
+    signer = load_pem_private_key_signer(private_key_path)
+    public_key = load_pem_public_key(public_key_path)
+    manifest = load_signing_manifest(write_package_manifest(tmp_path))
+    envelope = create_manifest_envelope(manifest, signer, algorithm)
+    required_algorithm = algorithm if require_algorithm else None
+    statement = verify_manifest_envelope(manifest, envelope, public_key, required_algorithm)
+    for subject, artifact in zip(statement['subject'], manifest.artifacts, strict=True):
+        _, canonical_bytes = load_canonical_json_file(artifact.path)
+        assert subject['digest'] == {digest_algorithm_name(algorithm): digest_hex(canonical_bytes, algorithm)}
+
+    other_algorithm = Algorithm.SHA_512 if algorithm == Algorithm.SHA_256 else Algorithm.SHA_256
+    with pytest.raises(TrestleError, match='does not contain a .* digest'):
+        verify_manifest_envelope(manifest, envelope, public_key, other_algorithm)
+
+    statement['subject'][0]['digest'] = {digest_algorithm_name(other_algorithm): '0' * 64}
+    expected_error = 'does not contain a .* digest' if require_algorithm else 'same digest algorithm'
+    with pytest.raises(TrestleError, match=expected_error):
+        verify_manifest_envelope(manifest, sign_in_toto_statement(statement, signer), public_key, required_algorithm)
+
+    manifest.artifacts[-1].path.write_text('{"changed":true}', encoding=const.FILE_ENCODING)
+    with pytest.raises(TrestleError, match='digest does not match artifact'):
+        verify_manifest_envelope(manifest, envelope, public_key, required_algorithm)
+
+
+@pytest.mark.parametrize(
+    'digest, expected_error',
+    [
+        (None, 'exactly one digest'),
+        ([], 'exactly one digest'),
+        ({}, 'exactly one digest'),
+        ({'md5': 'bad-digest'}, 'Unsupported digest algorithm'),
+        ({'sha1': 'bad-digest'}, 'Unsupported digest algorithm'),
+        ({'sha256': None}, 'does not contain a SHA-256 digest'),
+        ({'sha256': 'bad-digest', 'sha512': 'bad-digest'}, 'exactly one digest'),
+    ],
+)
+@pytest.mark.parametrize('subject_index', [0, 1])
+def test_manifest_rejects_invalid_digest_detection(
+    tmp_path: pathlib.Path, digest: Any, expected_error: str, subject_index: int
+) -> None:
+    """Every subject must provide an unambiguous supported algorithm for automatic detection."""
+    private_key_path, public_key_path = write_ed25519_key_pair(tmp_path)
+    manifest = load_signing_manifest(write_package_manifest(tmp_path))
+    statement = build_manifest_statement(manifest)
+    statement['subject'][subject_index]['digest'] = digest
+    envelope = sign_in_toto_statement(statement, load_pem_private_key_signer(private_key_path))
+    with pytest.raises(TrestleError, match=expected_error):
+        verify_manifest_envelope(manifest, envelope, load_pem_public_key(public_key_path))
+
+
+def test_manifest_explicit_algorithm_selects_from_multiple_digests(tmp_path: pathlib.Path) -> None:
+    """An explicit restriction can select one algorithm from an authenticated digest set."""
+    private_key_path, public_key_path = write_ed25519_key_pair(tmp_path)
+    manifest = load_signing_manifest(write_package_manifest(tmp_path))
+    statement = build_manifest_statement(manifest)
+    for subject, artifact in zip(statement['subject'], manifest.artifacts, strict=True):
+        _, canonical_bytes = load_canonical_json_file(artifact.path)
+        subject['digest']['sha512'] = digest_hex(canonical_bytes, Algorithm.SHA_512)
+    envelope = sign_in_toto_statement(statement, load_pem_private_key_signer(private_key_path))
+    public_key = load_pem_public_key(public_key_path)
+    for algorithm in (Algorithm.SHA_256, Algorithm.SHA_512):
+        verify_manifest_envelope(manifest, envelope, public_key, algorithm)
+
+
+def test_manifest_authenticates_before_detecting_digest_algorithm(tmp_path: pathlib.Path) -> None:
+    """Tampered subjects must fail signature verification before detection or artifact reads."""
+    private_key_path, public_key_path = write_ed25519_key_pair(tmp_path)
+    manifest = load_signing_manifest(write_package_manifest(tmp_path))
+    statement = build_manifest_statement(manifest)
+    envelope = sign_in_toto_statement(statement, load_pem_private_key_signer(private_key_path))
+    statement['subject'][0]['digest'] = {'md5': 'bad-digest'}
+    envelope['payload'] = base64.b64encode(json.dumps(statement).encode(const.FILE_ENCODING)).decode('ascii')
+    manifest.artifacts[0].path.unlink()
+    with pytest.raises(TrestleError, match='signature could not be verified'):
+        verify_manifest_envelope(manifest, envelope, load_pem_public_key(public_key_path))
+
+
+def test_explicit_sha256_preserves_default_manifest_envelope(tmp_path: pathlib.Path) -> None:
+    """Selecting SHA-256 should preserve the existing package payload and signature."""
+    private_key_path, public_key_path = write_ed25519_key_pair(tmp_path)
+    signer = load_pem_private_key_signer(private_key_path)
+    manifest = load_signing_manifest(write_package_manifest(tmp_path))
+    envelope = create_manifest_envelope(manifest, signer)
+    assert create_manifest_envelope(manifest, signer, Algorithm.SHA_256) == envelope
+    verify_manifest_envelope(manifest, envelope, load_pem_public_key(public_key_path))
 
 
 def test_build_manifest_statement_matches_create_manifest_payload(tmp_path: pathlib.Path) -> None:
@@ -207,9 +300,10 @@ def test_verify_manifest_rejects_changed_manifest(tmp_path: pathlib.Path) -> Non
         (lambda statement: statement['subject'].append(statement['subject'][0]), 'duplicate subject'),
         (
             lambda statement: statement['subject'][0].update({'digest': {'sha512': 'missing-sha256'}}),
-            'does not contain a SHA-256 digest',
+            'same digest algorithm',
         ),
         (lambda statement: statement['subject'].pop(), 'subjects do not match'),
+        (lambda statement: statement.update({'subject': []}), 'subjects do not match'),
     ],
 )
 def test_verify_manifest_rejects_malformed_package_statements(

--- a/tests/trestle/core/signing_test.py
+++ b/tests/trestle/core/signing_test.py
@@ -27,10 +27,9 @@ from cryptography.hazmat.primitives.asymmetric import ed25519
 
 import trestle.common.const as const
 from trestle.common.err import TrestleError
-from trestle.core.canonicalization import sha256_digest_hex
+from trestle.core.canonicalization import digest_algorithm_name, digest_hex, sha256_digest_hex
 from trestle.core.signing import (
     CANONICALIZATION_ALGORITHM,
-    DIGEST_ALGORITHM,
     DSSE_PAYLOAD_TYPE,
     IN_TOTO_STATEMENT_TYPE,
     MAX_SIGNATURES,
@@ -46,6 +45,7 @@ from trestle.core.signing import (
     verify_oscal_provenance_envelope,
     write_dsse_envelope,
 )
+from trestle.oscal.common import Algorithm
 
 
 def write_ed25519_key_pair(tmp_path: pathlib.Path, password: bytes = b'') -> Tuple[pathlib.Path, pathlib.Path]:
@@ -113,12 +113,91 @@ def test_create_oscal_provenance_envelope_contains_in_toto_statement(tmp_path: p
     assert statement['_type'] == IN_TOTO_STATEMENT_TYPE
     assert statement['predicateType'] == OSCAL_PREDICATE_TYPE
     assert statement['predicate']['canonicalization'] == CANONICALIZATION_ALGORITHM
-    assert statement['predicate']['digestAlgorithm'] == DIGEST_ALGORITHM
+    assert statement['predicate']['digestAlgorithm'] == 'sha256'
     assert statement['subject'][0]['name'] == 'catalog.json'
     assert statement['subject'][0]['digest']['sha256'] == sha256_digest_hex(b'{"a":1,"b":2}')
 
     public_key = load_pem_public_key(public_key_path)
     verify_oscal_provenance_envelope(input_path, envelope, public_key)
+
+
+@pytest.mark.parametrize('algorithm', list(Algorithm))
+@pytest.mark.parametrize('require_algorithm', [False, True])
+def test_sign_and_verify_digest_algorithms(
+    tmp_path: pathlib.Path, algorithm: Algorithm, require_algorithm: bool
+) -> None:
+    """Every supported digest should round-trip and reject a mismatch or changed artifact."""
+    input_path, signer, public_key, _, _ = signing_context(tmp_path)
+    envelope = create_oscal_provenance_envelope(input_path, signer, digest_algorithm=algorithm)
+    required_algorithm = algorithm if require_algorithm else None
+    statement = verify_oscal_provenance_envelope(input_path, envelope, public_key, digest_algorithm=required_algorithm)
+    algorithm_name = digest_algorithm_name(algorithm)
+    assert statement['predicate']['digestAlgorithm'] == algorithm_name
+    assert statement['subject'][0]['digest'] == {algorithm_name: digest_hex(b'{"a":1}', algorithm)}
+
+    other_algorithm = Algorithm.SHA_512 if algorithm == Algorithm.SHA_256 else Algorithm.SHA_256
+    with pytest.raises(TrestleError, match='does not describe a .* digest'):
+        verify_oscal_provenance_envelope(input_path, envelope, public_key, digest_algorithm=other_algorithm)
+
+    input_path.write_text('{"a":2}', encoding=const.FILE_ENCODING)
+    with pytest.raises(TrestleError, match='digest does not match'):
+        verify_oscal_provenance_envelope(input_path, envelope, public_key, digest_algorithm=required_algorithm)
+
+
+def test_explicit_sha256_preserves_default_envelope(tmp_path: pathlib.Path) -> None:
+    """Explicit SHA-256 should produce the same Statement and signature as the existing default."""
+    input_path, signer, public_key, envelope, _ = signing_context(tmp_path)
+    assert create_oscal_provenance_envelope(input_path, signer, digest_algorithm=Algorithm.SHA_256) == envelope
+    verify_oscal_provenance_envelope(input_path, envelope, public_key, digest_algorithm=Algorithm.SHA_256)
+
+
+@pytest.mark.parametrize(
+    'digest', [{}, {'sha256': None}, {'sha256': 123}, {'sha256': True}, {'sha256': []}, {'sha256': {}}]
+)
+@pytest.mark.parametrize('require_algorithm', [False, True])
+def test_verify_rejects_missing_or_non_string_digest(
+    tmp_path: pathlib.Path, digest: Dict[str, Any], require_algorithm: bool
+) -> None:
+    """Reject malformed signed digests before reading the artifact in either verification mode."""
+    input_path, signer, public_key, _, statement = signing_context(tmp_path)
+    statement['subject'][0]['digest'] = digest
+    envelope = sign_in_toto_statement(statement, signer)
+    input_path.unlink()
+    with pytest.raises(TrestleError, match='subject does not contain a SHA-256 digest: catalog.json'):
+        verify_oscal_provenance_envelope(
+            input_path, envelope, public_key, digest_algorithm=Algorithm.SHA_256 if require_algorithm else None
+        )
+
+
+@pytest.mark.parametrize('require_algorithm', [False, True])
+def test_verify_rejects_inconsistent_digest_algorithm(tmp_path: pathlib.Path, require_algorithm: bool) -> None:
+    """A valid signature must not allow the predicate and subject algorithm to disagree."""
+    input_path, signer, public_key, _, statement = signing_context(tmp_path)
+    statement['predicate']['digestAlgorithm'] = 'sha3_256'
+    envelope = sign_in_toto_statement(statement, signer)
+    with pytest.raises(TrestleError, match='subject does not contain a SHA3-256 digest: catalog.json'):
+        verify_oscal_provenance_envelope(
+            input_path, envelope, public_key, digest_algorithm=Algorithm.SHA3_256 if require_algorithm else None
+        )
+
+
+@pytest.mark.parametrize('name', ['md5', 'sha1', 'SHA-256', '', None, [], {}])
+def test_verify_rejects_unsupported_signed_digest_algorithm(tmp_path: pathlib.Path, name: Any) -> None:
+    """A valid signature does not make unsupported algorithm metadata acceptable."""
+    input_path, signer, public_key, _, statement = signing_context(tmp_path)
+    statement['predicate']['digestAlgorithm'] = name
+    with pytest.raises(TrestleError, match='Unsupported digest algorithm'):
+        verify_oscal_provenance_envelope(input_path, sign_in_toto_statement(statement, signer), public_key)
+
+
+def test_verify_authenticates_before_detecting_digest_algorithm(tmp_path: pathlib.Path) -> None:
+    """Tampered metadata must fail signature verification before detection or artifact reads."""
+    input_path, _, public_key, envelope, statement = signing_context(tmp_path)
+    statement['predicate']['digestAlgorithm'] = 'md5'
+    envelope['payload'] = base64.b64encode(json.dumps(statement).encode(const.FILE_ENCODING)).decode('ascii')
+    input_path.unlink()
+    with pytest.raises(TrestleError, match='signature could not be verified'):
+        verify_oscal_provenance_envelope(input_path, envelope, public_key)
 
 
 def test_key_loaders_reject_invalid_pem(tmp_path: pathlib.Path) -> None:

--- a/trestle/core/canonicalization.py
+++ b/trestle/core/canonicalization.py
@@ -20,12 +20,15 @@ from __future__ import annotations
 import hashlib
 import json
 import pathlib
-from typing import Any, Dict, List, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Tuple
 
 import rfc8785
 
 from trestle.common import const
 from trestle.common.err import TrestleError
+
+if TYPE_CHECKING:
+    from trestle.oscal.common import Algorithm
 
 
 def load_canonical_json_file(path: pathlib.Path) -> Tuple[Any, bytes]:
@@ -56,9 +59,36 @@ def canonicalize_json_object(json_obj: Any) -> bytes:
         raise TrestleError(f'Unable to canonicalize JSON object according to RFC 8785: {error}')
 
 
+def digest_algorithm_name(algorithm: Algorithm) -> str:
+    """Return the hashlib and in-toto name for a supported OSCAL digest algorithm."""
+    # OSCAL's base model imports canonicalization, so defer this import to avoid a cycle.
+    from trestle.oscal.common import Algorithm
+
+    if not isinstance(algorithm, Algorithm):
+        raise TrestleError(f'Unsupported digest algorithm: {algorithm}')
+    return algorithm.value.lower().replace('sha-', 'sha').replace('-', '_')
+
+
+def digest_hex(data: bytes, algorithm: Algorithm) -> str:
+    """Return a hexadecimal digest using the selected OSCAL algorithm."""
+    return hashlib.new(digest_algorithm_name(algorithm), data).hexdigest()
+
+
+def parse_digest_algorithm(name: Any) -> Algorithm:
+    """Resolve an in-toto digest name to a supported OSCAL algorithm."""
+    from trestle.oscal.common import Algorithm
+
+    for algorithm in Algorithm:
+        if digest_algorithm_name(algorithm) == name:
+            return algorithm
+    raise TrestleError(f'Unsupported digest algorithm: {name}')
+
+
 def sha256_digest_hex(data: bytes) -> str:
-    """Return a SHA-256 digest for canonical bytes."""
-    return hashlib.sha256(data).hexdigest()
+    """Return a SHA-256 digest for compatibility with existing callers."""
+    from trestle.oscal.common import Algorithm
+
+    return digest_hex(data, Algorithm.SHA_256)
 
 
 def _object_pairs_without_duplicates(pairs: List[Tuple[str, Any]]) -> Dict[str, Any]:

--- a/trestle/core/commands/sign.py
+++ b/trestle/core/commands/sign.py
@@ -26,7 +26,13 @@ from trestle.common.err import TrestleError, handle_generic_command_exception
 from trestle.core.beta_features import beta_feature
 from trestle.core.commands.command_docs import CommandBase
 from trestle.core.commands.common.return_codes import CmdReturnCodes
-from trestle.core.signing import create_oscal_provenance_envelope, load_pem_private_key_signer, write_dsse_envelope
+from trestle.core.signing import (
+    DEFAULT_DIGEST_ALGORITHM,
+    create_oscal_provenance_envelope,
+    load_pem_private_key_signer,
+    write_dsse_envelope,
+)
+from trestle.oscal.common import Algorithm
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +41,7 @@ class SignCmd(CommandBase):
     """Sign a JSON file as a detached DSSE provenance envelope.
 
     This command does not modify the input JSON file. It reads the JSON
-    bytes, canonicalizes them using RFC 8785, computes a SHA-256 digest over
+    bytes, canonicalizes them using RFC 8785, computes the selected digest over
     the canonical JSON, and records that digest in an in-toto Statement. The
     Statement is then signed as a DSSE payload using the provided PEM private
     key and written as a detached sidecar envelope.
@@ -64,6 +70,12 @@ class SignCmd(CommandBase):
         self.add_argument('-o', '--output', help='Output DSSE envelope file.', required=True, type=pathlib.Path)
         self.add_argument('--overwrite', help='Replace an existing DSSE envelope.', action='store_true')
         self.add_argument(
+            '--digest-algorithm',
+            choices=[algorithm.value for algorithm in Algorithm],
+            default=DEFAULT_DIGEST_ALGORITHM.value,
+            help='Artifact digest algorithm (default: SHA-256).',
+        )
+        self.add_argument(
             '--subject-name',
             help='Subject name to record in the in-toto Statement. Defaults to the input file name.',
             default=None,
@@ -74,7 +86,15 @@ class SignCmd(CommandBase):
         """Sign a JSON file."""
         try:
             log.set_log_level_from_args(args)
-            self.sign(args.file, args.key, args.output, args.subject_name, args.key_password_env, args.overwrite)
+            self.sign(
+                args.file,
+                args.key,
+                args.output,
+                args.subject_name,
+                args.key_password_env,
+                args.overwrite,
+                digest_algorithm=Algorithm(args.digest_algorithm),
+            )
             return CmdReturnCodes.SUCCESS.value
         except Exception as e:  # pragma: no cover
             return handle_generic_command_exception(e, logger, 'Error while signing JSON')
@@ -88,6 +108,7 @@ class SignCmd(CommandBase):
         subject_name: Optional[str] = None,
         key_password_env: Optional[str] = None,
         overwrite: bool = False,
+        digest_algorithm: Algorithm = DEFAULT_DIGEST_ALGORITHM,
     ) -> None:
         """Write a detached DSSE provenance envelope for a JSON file."""
         input_path = input_path.resolve()
@@ -105,5 +126,5 @@ class SignCmd(CommandBase):
             key_password = os.environ[key_password_env]
 
         signer = load_pem_private_key_signer(key_path, key_password)
-        envelope = create_oscal_provenance_envelope(input_path, signer, subject_name)
+        envelope = create_oscal_provenance_envelope(input_path, signer, subject_name, digest_algorithm)
         write_dsse_envelope(envelope, output_path, overwrite)

--- a/trestle/core/commands/sign_manifest.py
+++ b/trestle/core/commands/sign_manifest.py
@@ -26,8 +26,9 @@ from trestle.common.err import TrestleError, handle_generic_command_exception
 from trestle.core.beta_features import beta_feature
 from trestle.core.commands.command_docs import CommandBase
 from trestle.core.commands.common.return_codes import CmdReturnCodes
-from trestle.core.signing import load_pem_private_key_signer, write_dsse_envelope
+from trestle.core.signing import DEFAULT_DIGEST_ALGORITHM, load_pem_private_key_signer, write_dsse_envelope
 from trestle.core.signing_manifest import create_manifest_envelope, load_signing_manifest
+from trestle.oscal.common import Algorithm
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +38,7 @@ class SignManifestCmd(CommandBase):
 
     The manifest lists local JSON artifacts that belong to a package. This
     command canonicalizes each listed JSON artifact with RFC 8785, records each
-    SHA-256 digest in an in-toto Statement, signs the Statement using the
+    selected digest in an in-toto Statement, signs the Statement using the
     provided PEM private key, and writes the detached package envelope.
     """
 
@@ -61,13 +62,26 @@ class SignManifestCmd(CommandBase):
         )
         self.add_argument('-o', '--output', help='Output DSSE package envelope file.', required=True, type=pathlib.Path)
         self.add_argument('--overwrite', help='Replace an existing DSSE package envelope.', action='store_true')
+        self.add_argument(
+            '--digest-algorithm',
+            choices=[algorithm.value for algorithm in Algorithm],
+            default=DEFAULT_DIGEST_ALGORITHM.value,
+            help='Artifact digest algorithm (default: SHA-256).',
+        )
 
     @beta_feature('json-manifest-signing')
     def _run(self, args: argparse.Namespace) -> int:
         """Sign a JSON package manifest."""
         try:
             log.set_log_level_from_args(args)
-            self.sign_manifest(args.manifest, args.key, args.output, args.key_password_env, args.overwrite)
+            self.sign_manifest(
+                args.manifest,
+                args.key,
+                args.output,
+                args.key_password_env,
+                args.overwrite,
+                digest_algorithm=Algorithm(args.digest_algorithm),
+            )
             return CmdReturnCodes.SUCCESS.value
         except Exception as e:  # pragma: no cover
             return handle_generic_command_exception(e, logger, 'Error while signing package manifest')
@@ -80,6 +94,7 @@ class SignManifestCmd(CommandBase):
         output_path: pathlib.Path,
         key_password_env: Optional[str] = None,
         overwrite: bool = False,
+        digest_algorithm: Algorithm = DEFAULT_DIGEST_ALGORITHM,
     ) -> None:
         """Write a detached DSSE envelope for a JSON package manifest."""
         manifest_path = manifest_path.resolve()
@@ -98,5 +113,5 @@ class SignManifestCmd(CommandBase):
 
         signer = load_pem_private_key_signer(key_path, key_password)
         manifest = load_signing_manifest(manifest_path)
-        envelope = create_manifest_envelope(manifest, signer)
+        envelope = create_manifest_envelope(manifest, signer, digest_algorithm)
         write_dsse_envelope(envelope, output_path, overwrite)

--- a/trestle/core/commands/verify.py
+++ b/trestle/core/commands/verify.py
@@ -26,6 +26,7 @@ from trestle.core.beta_features import beta_feature
 from trestle.core.commands.command_docs import CommandBase
 from trestle.core.commands.common.return_codes import CmdReturnCodes
 from trestle.core.signing import load_dsse_envelope, load_pem_public_key, verify_oscal_provenance_envelope
+from trestle.oscal.common import Algorithm
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +37,7 @@ class VerifyCmd(CommandBase):
     Verification performs two checks. First, it verifies the DSSE signature
     over the DSSE pre-authentication encoding for the in-toto Statement payload
     using the provided PEM public key. Second, it canonicalizes the input JSON
-    using RFC 8785, computes its SHA-256 digest, and confirms that the
+    using RFC 8785, computes its digest with the signed algorithm, and confirms that the
     digest matches the subject digest recorded in the signed Statement.
 
     Both checks are required: the digest proves the file matches the signed
@@ -54,6 +55,11 @@ class VerifyCmd(CommandBase):
             '--public-key', help='Path to the PEM public key for verification.', required=True, type=pathlib.Path
         )
         self.add_argument(
+            '--digest-algorithm',
+            choices=[algorithm.value for algorithm in Algorithm],
+            help='Require this artifact digest algorithm. By default, detect it from the signed Statement.',
+        )
+        self.add_argument(
             '--subject-name',
             help='Subject name expected in the in-toto Statement. Defaults to the input file name.',
             default=None,
@@ -64,7 +70,13 @@ class VerifyCmd(CommandBase):
         """Verify a JSON file."""
         try:
             log.set_log_level_from_args(args)
-            self.verify(args.file, args.signature, args.public_key, args.subject_name)
+            self.verify(
+                args.file,
+                args.signature,
+                args.public_key,
+                args.subject_name,
+                digest_algorithm=Algorithm(args.digest_algorithm) if args.digest_algorithm else None,
+            )
             return CmdReturnCodes.SUCCESS.value
         except Exception as e:  # pragma: no cover
             return handle_generic_command_exception(e, logger, 'Error while verifying JSON signature')
@@ -76,8 +88,9 @@ class VerifyCmd(CommandBase):
         signature_path: pathlib.Path,
         public_key_path: pathlib.Path,
         subject_name: Optional[str] = None,
+        digest_algorithm: Optional[Algorithm] = None,
     ) -> None:
         """Verify a detached DSSE provenance envelope for a JSON file."""
         public_key = load_pem_public_key(public_key_path.resolve())
         envelope = load_dsse_envelope(signature_path.resolve())
-        verify_oscal_provenance_envelope(input_path.resolve(), envelope, public_key, subject_name)
+        verify_oscal_provenance_envelope(input_path.resolve(), envelope, public_key, subject_name, digest_algorithm)

--- a/trestle/core/commands/verify_manifest.py
+++ b/trestle/core/commands/verify_manifest.py
@@ -18,6 +18,7 @@
 import argparse
 import logging
 import pathlib
+from typing import Optional
 
 from trestle.common import log
 from trestle.common.err import handle_generic_command_exception
@@ -26,6 +27,7 @@ from trestle.core.commands.command_docs import CommandBase
 from trestle.core.commands.common.return_codes import CmdReturnCodes
 from trestle.core.signing import load_dsse_envelope, load_pem_public_key
 from trestle.core.signing_manifest import load_signing_manifest, verify_manifest_envelope
+from trestle.oscal.common import Algorithm
 
 logger = logging.getLogger(__name__)
 
@@ -50,23 +52,37 @@ class VerifyManifestCmd(CommandBase):
         self.add_argument(
             '--public-key', help='Path to the PEM public key for verification.', required=True, type=pathlib.Path
         )
+        self.add_argument(
+            '--digest-algorithm',
+            choices=[algorithm.value for algorithm in Algorithm],
+            help='Require this artifact digest algorithm. By default, detect it from the signed Statement.',
+        )
 
     @beta_feature('json-manifest-signing')
     def _run(self, args: argparse.Namespace) -> int:
         """Verify a JSON package manifest."""
         try:
             log.set_log_level_from_args(args)
-            self.verify_manifest(args.manifest, args.signature, args.public_key)
+            self.verify_manifest(
+                args.manifest,
+                args.signature,
+                args.public_key,
+                digest_algorithm=Algorithm(args.digest_algorithm) if args.digest_algorithm else None,
+            )
             return CmdReturnCodes.SUCCESS.value
         except Exception as e:  # pragma: no cover
             return handle_generic_command_exception(e, logger, 'Error while verifying package manifest signature')
 
     @classmethod
     def verify_manifest(
-        cls, manifest_path: pathlib.Path, signature_path: pathlib.Path, public_key_path: pathlib.Path
+        cls,
+        manifest_path: pathlib.Path,
+        signature_path: pathlib.Path,
+        public_key_path: pathlib.Path,
+        digest_algorithm: Optional[Algorithm] = None,
     ) -> None:
         """Verify a detached DSSE envelope for a JSON package manifest."""
         manifest = load_signing_manifest(manifest_path.resolve())
         public_key = load_pem_public_key(public_key_path.resolve())
         envelope = load_dsse_envelope(signature_path.resolve())
-        verify_manifest_envelope(manifest, envelope, public_key)
+        verify_manifest_envelope(manifest, envelope, public_key, digest_algorithm)

--- a/trestle/core/signing.py
+++ b/trestle/core/signing.py
@@ -30,13 +30,20 @@ from securesystemslib.signer import CryptoSigner, Key, SSlibKey, Signature, Sign
 
 from trestle.common import const
 from trestle.common.err import TrestleError
-from trestle.core.canonicalization import canonicalize_json_text, load_canonical_json_file, sha256_digest_hex
+from trestle.core.canonicalization import (
+    canonicalize_json_text,
+    digest_algorithm_name,
+    digest_hex,
+    load_canonical_json_file,
+    parse_digest_algorithm,
+)
+from trestle.oscal.common import Algorithm
 
 DSSE_PAYLOAD_TYPE = 'application/vnd.in-toto+json'
 IN_TOTO_STATEMENT_TYPE = 'https://in-toto.io/Statement/v1'
 OSCAL_PREDICATE_TYPE = 'https://oscal-compass.github.io/compliance-trestle/predicates/oscal-signing/v1'
 CANONICALIZATION_ALGORITHM = 'RFC8785'
-DIGEST_ALGORITHM = 'sha256'
+DEFAULT_DIGEST_ALGORITHM = Algorithm.SHA_256
 DIGEST_SOURCE = 'canonical-json'
 MAX_SIGNATURES = 16
 
@@ -65,15 +72,18 @@ def load_pem_public_key(path: pathlib.Path) -> Key:
         raise TrestleError(f'Unable to load public key for verification: {path}') from error
 
 
-def build_in_toto_statement(subject_name: str, digest: str) -> Dict[str, Any]:
+def build_in_toto_statement(
+    subject_name: str, digest: str, digest_algorithm: Algorithm = DEFAULT_DIGEST_ALGORITHM
+) -> Dict[str, Any]:
     """Build the in-toto Statement payload for a JSON artifact digest."""
+    algorithm_name = digest_algorithm_name(digest_algorithm)
     return {
         '_type': IN_TOTO_STATEMENT_TYPE,
-        'subject': [{'name': subject_name, 'digest': {DIGEST_ALGORITHM: digest}}],
+        'subject': [{'name': subject_name, 'digest': {algorithm_name: digest}}],
         'predicateType': OSCAL_PREDICATE_TYPE,
         'predicate': {
             'canonicalization': CANONICALIZATION_ALGORITHM,
-            'digestAlgorithm': DIGEST_ALGORITHM,
+            'digestAlgorithm': algorithm_name,
             'digestSource': DIGEST_SOURCE,
             'tool': 'compliance-trestle',
         },
@@ -95,13 +105,16 @@ def dsse_pae(payload_type: str, payload: bytes) -> bytes:
 
 
 def create_oscal_provenance_envelope(
-    input_path: pathlib.Path, signer: Signer, subject_name: Optional[str] = None
+    input_path: pathlib.Path,
+    signer: Signer,
+    subject_name: Optional[str] = None,
+    digest_algorithm: Algorithm = DEFAULT_DIGEST_ALGORITHM,
 ) -> Dict[str, Any]:
     """Create a DSSE envelope whose payload is an in-toto Statement for a JSON file."""
     _validate_json_path(input_path)
     _, canonical_bytes = load_canonical_json_file(input_path)
-    digest = sha256_digest_hex(canonical_bytes)
-    statement = build_in_toto_statement(subject_name or input_path.name, digest)
+    digest = digest_hex(canonical_bytes, digest_algorithm)
+    statement = build_in_toto_statement(subject_name or input_path.name, digest, digest_algorithm)
     return sign_in_toto_statement(statement, signer)
 
 
@@ -157,15 +170,17 @@ def load_dsse_envelope(envelope_path: pathlib.Path) -> Dict[str, Any]:
 
 
 def verify_oscal_provenance_envelope(
-    input_path: pathlib.Path, envelope: Dict[str, Any], public_key: Key, subject_name: Optional[str] = None
+    input_path: pathlib.Path,
+    envelope: Dict[str, Any],
+    public_key: Key,
+    subject_name: Optional[str] = None,
+    digest_algorithm: Optional[Algorithm] = None,
 ) -> Dict[str, Any]:
-    """Verify a DSSE in-toto Statement envelope against a JSON file."""
+    """Verify a JSON file, detecting the signed digest algorithm unless one is required."""
     _validate_json_path(input_path)
-    _, canonical_bytes = load_canonical_json_file(input_path)
-    expected_digest = sha256_digest_hex(canonical_bytes)
     payload = _verified_payload(envelope, public_key)
     statement = _load_statement(payload)
-    _validate_statement(statement, subject_name or input_path.name, expected_digest)
+    _validate_statement(statement, subject_name or input_path.name, input_path, digest_algorithm)
     return statement
 
 
@@ -215,7 +230,9 @@ def _load_statement(payload: bytes) -> Dict[str, Any]:
     return statement
 
 
-def _validate_statement(statement: Dict[str, Any], subject_name: str, expected_digest: str) -> None:
+def _validate_statement(
+    statement: Dict[str, Any], subject_name: str, input_path: pathlib.Path, digest_algorithm: Optional[Algorithm]
+) -> None:
     if statement.get('_type') != IN_TOTO_STATEMENT_TYPE:
         raise TrestleError('DSSE payload is not an in-toto Statement v1.')
     if statement.get('predicateType') != OSCAL_PREDICATE_TYPE:
@@ -226,8 +243,10 @@ def _validate_statement(statement: Dict[str, Any], subject_name: str, expected_d
         raise TrestleError('in-toto Statement predicate must be a JSON object.')
     if predicate.get('canonicalization') != CANONICALIZATION_ALGORITHM:
         raise TrestleError('in-toto Statement does not describe RFC 8785 canonicalization.')
-    if predicate.get('digestAlgorithm') != DIGEST_ALGORITHM:
-        raise TrestleError('in-toto Statement does not describe a SHA-256 digest.')
+    signed_algorithm = parse_digest_algorithm(predicate.get('digestAlgorithm'))
+    algorithm_name = digest_algorithm_name(signed_algorithm)
+    if digest_algorithm is not None and digest_algorithm_name(digest_algorithm) != algorithm_name:
+        raise TrestleError(f'in-toto Statement does not describe a {digest_algorithm.value} digest.')
     if predicate.get('digestSource') != DIGEST_SOURCE:
         raise TrestleError('in-toto Statement does not describe a canonical JSON digest source.')
 
@@ -254,7 +273,14 @@ def _validate_statement(statement: Dict[str, Any], subject_name: str, expected_d
     digest = subject.get('digest')
     if not isinstance(digest, dict):
         raise TrestleError(f'in-toto Statement subject does not contain a digest for: {subject_name}')
-    if hmac.compare_digest(str(digest.get(DIGEST_ALGORITHM)), expected_digest):
+    actual_digest = digest.get(algorithm_name)
+    if not isinstance(actual_digest, str):
+        raise TrestleError(
+            f'in-toto Statement subject does not contain a {signed_algorithm.value} digest: {subject_name}'
+        )
+    _, canonical_bytes = load_canonical_json_file(input_path)
+    expected_digest = digest_hex(canonical_bytes, signed_algorithm)
+    if hmac.compare_digest(actual_digest, expected_digest):
         return
 
     raise TrestleError(f'in-toto Statement digest does not match JSON file: {subject_name}')

--- a/trestle/core/signing_manifest.py
+++ b/trestle/core/signing_manifest.py
@@ -20,20 +20,26 @@ from __future__ import annotations
 import hmac
 import pathlib
 from dataclasses import dataclass
-from typing import Any, Dict, List, Set
+from typing import Any, Dict, List, Optional, Set
 from urllib.parse import urlparse
 
 from securesystemslib.signer import Key, Signer
 
 from trestle.common.err import TrestleError
-from trestle.core.canonicalization import load_canonical_json_file, sha256_digest_hex
+from trestle.core.canonicalization import (
+    digest_algorithm_name,
+    digest_hex,
+    load_canonical_json_file,
+    parse_digest_algorithm,
+)
 from trestle.core.signing import (
-    DIGEST_ALGORITHM,
+    DEFAULT_DIGEST_ALGORITHM,
     IN_TOTO_STATEMENT_TYPE,
     load_in_toto_statement,
     sign_in_toto_statement,
     verify_dsse_payload,
 )
+from trestle.oscal.common import Algorithm
 
 PACKAGE_PREDICATE_TYPE = 'https://oscal-compass.github.io/compliance-trestle/predicates/oscal-package/v1'
 MANIFEST_VERSION = 'v1'
@@ -113,16 +119,20 @@ def load_signing_manifest(manifest_path: pathlib.Path) -> SigningManifest:
     return SigningManifest(manifest_path, primary_artifact, artifacts)
 
 
-def create_manifest_envelope(manifest: SigningManifest, signer: Signer) -> Dict[str, Any]:
+def create_manifest_envelope(
+    manifest: SigningManifest, signer: Signer, digest_algorithm: Algorithm = DEFAULT_DIGEST_ALGORITHM
+) -> Dict[str, Any]:
     """Create a DSSE envelope for a validated signing manifest."""
-    return sign_in_toto_statement(build_manifest_statement(manifest), signer)
+    return sign_in_toto_statement(build_manifest_statement(manifest, digest_algorithm), signer)
 
 
-def build_manifest_statement(manifest: SigningManifest) -> Dict[str, Any]:
+def build_manifest_statement(
+    manifest: SigningManifest, digest_algorithm: Algorithm = DEFAULT_DIGEST_ALGORITHM
+) -> Dict[str, Any]:
     """Build the in-toto Statement payload for a signing manifest."""
     return {
         '_type': IN_TOTO_STATEMENT_TYPE,
-        'subject': _manifest_subjects(manifest),
+        'subject': _manifest_subjects(manifest, digest_algorithm),
         'predicateType': PACKAGE_PREDICATE_TYPE,
         'predicate': {
             'tool': PACKAGE_TOOL,
@@ -133,15 +143,19 @@ def build_manifest_statement(manifest: SigningManifest) -> Dict[str, Any]:
     }
 
 
-def verify_manifest_envelope(manifest: SigningManifest, envelope: Dict[str, Any], public_key: Key) -> Dict[str, Any]:
-    """Verify a DSSE package Statement envelope against a signing manifest."""
+def verify_manifest_envelope(
+    manifest: SigningManifest, envelope: Dict[str, Any], public_key: Key, digest_algorithm: Optional[Algorithm] = None
+) -> Dict[str, Any]:
+    """Verify a package, detecting its signed digest algorithm unless one is required."""
     payload = verify_dsse_payload(envelope, public_key)
     statement = load_in_toto_statement(payload)
-    _validate_manifest_statement(statement, manifest)
+    _validate_manifest_statement(statement, manifest, digest_algorithm)
     return statement
 
 
-def _validate_manifest_statement(statement: Dict[str, Any], manifest: SigningManifest) -> None:
+def _validate_manifest_statement(
+    statement: Dict[str, Any], manifest: SigningManifest, digest_algorithm: Optional[Algorithm]
+) -> None:
     if statement.get('_type') != IN_TOTO_STATEMENT_TYPE:
         raise TrestleError('DSSE payload is not an in-toto Statement v1.')
     if statement.get('predicateType') != PACKAGE_PREDICATE_TYPE:
@@ -159,16 +173,16 @@ def _validate_manifest_statement(statement: Dict[str, Any], manifest: SigningMan
     if predicate != expected_predicate:
         raise TrestleError('in-toto package Statement predicate does not match the signing manifest.')
 
-    _validate_manifest_subjects(statement.get('subject'), manifest)
+    _validate_manifest_subjects(statement.get('subject'), manifest, digest_algorithm)
 
 
-def _validate_manifest_subjects(subjects: Any, manifest: SigningManifest) -> None:
+def _validate_manifest_subjects(
+    subjects: Any, manifest: SigningManifest, digest_algorithm: Optional[Algorithm]
+) -> None:
     if not isinstance(subjects, list):
         raise TrestleError('in-toto package Statement subject must be an array.')
 
-    expected_subjects = {
-        subject['name']: subject['digest'][DIGEST_ALGORITHM] for subject in _manifest_subjects(manifest)
-    }
+    selected_algorithm = digest_algorithm
     actual_subjects: Dict[str, str] = {}
     for subject in subjects:
         if not isinstance(subject, dict):
@@ -179,28 +193,49 @@ def _validate_manifest_subjects(subjects: Any, manifest: SigningManifest) -> Non
         if name in actual_subjects:
             raise TrestleError(f'in-toto package Statement contains a duplicate subject: {name}')
         digest = subject.get('digest')
-        if not isinstance(digest, dict) or not isinstance(digest.get(DIGEST_ALGORITHM), str):
-            raise TrestleError(f'in-toto package Statement subject does not contain a SHA-256 digest: {name}')
-        actual_subjects[name] = digest[DIGEST_ALGORITHM]
+        if digest_algorithm is None:
+            if not isinstance(digest, dict) or len(digest) != 1:
+                raise TrestleError(
+                    f'in-toto package Statement subject must contain exactly one digest for automatic detection: {name}'
+                )
+            subject_algorithm = parse_digest_algorithm(next(iter(digest)))
+        else:
+            subject_algorithm = digest_algorithm
+        if selected_algorithm is None:
+            selected_algorithm = subject_algorithm
+        elif selected_algorithm != subject_algorithm:
+            raise TrestleError('in-toto package Statement subjects must use the same digest algorithm.')
+        algorithm_name = digest_algorithm_name(subject_algorithm)
+        if not isinstance(digest, dict) or not isinstance(digest.get(algorithm_name), str):
+            raise TrestleError(
+                f'in-toto package Statement subject does not contain a {subject_algorithm.value} digest: {name}'
+            )
+        actual_subjects[name] = digest[algorithm_name]
 
-    if set(actual_subjects) != set(expected_subjects):
+    if selected_algorithm is None or set(actual_subjects) != {artifact.name for artifact in manifest.artifacts}:
         raise TrestleError('in-toto package Statement subjects do not match the signing manifest artifacts.')
 
+    algorithm_name = digest_algorithm_name(selected_algorithm)
+    expected_subjects = {
+        subject['name']: subject['digest'][algorithm_name]
+        for subject in _manifest_subjects(manifest, selected_algorithm)
+    }
     for name, expected_digest in expected_subjects.items():
         if not hmac.compare_digest(actual_subjects[name], expected_digest):
             raise TrestleError(f'in-toto package Statement digest does not match artifact: {name}')
 
 
-def _manifest_subjects(manifest: SigningManifest) -> List[Dict[str, Any]]:
+def _manifest_subjects(manifest: SigningManifest, digest_algorithm: Algorithm) -> List[Dict[str, Any]]:
+    algorithm_name = digest_algorithm_name(digest_algorithm)
     return [
-        {'name': artifact.name, 'digest': {DIGEST_ALGORITHM: _artifact_digest(artifact.path)}}
+        {'name': artifact.name, 'digest': {algorithm_name: _artifact_digest(artifact.path, digest_algorithm)}}
         for artifact in manifest.artifacts
     ]
 
 
-def _artifact_digest(path: pathlib.Path) -> str:
+def _artifact_digest(path: pathlib.Path, digest_algorithm: Algorithm) -> str:
     _, canonical_bytes = load_canonical_json_file(path)
-    return sha256_digest_hex(canonical_bytes)
+    return digest_hex(canonical_bytes, digest_algorithm)
 
 
 def _required_string(data: Dict[str, Any], key: str, context: str) -> str:


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

<!--- Uncomment below if changes are for GitHub Actions -->

<!--
### How To Test

If using [act](https://github.com/nektos/act), fill in below:

**act version**  

**act command**
```bash
```
-->

## Summary
Can now choose the hash algorithm when signing files or packages. SHA-256 is the default. Verification checks the signature, then uses the recorded algorithm unless the user requires a specific one. 
## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)
- Closes #2358

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
